### PR TITLE
fix(nginx): add ipv6 listen property to nginx service conf

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,5 +1,6 @@
 server {
     listen 80;
+    listen [::]:80;
     server_name localhost velxio.dev www.velxio.dev;
     root /usr/share/nginx/html;
     index index.html;

--- a/deploy/nginx.prod.conf
+++ b/deploy/nginx.prod.conf
@@ -1,5 +1,6 @@
 server {
     listen 80;
+    listen [::]:80;
     server_name velxio.dev www.velxio.dev;
     root /usr/share/nginx/html;
     index index.html;


### PR DESCRIPTION
- hotfix for issues #108 and #89 where standalone dockerimage does not provide velxio UI

Hello there, first, thank you for this project.

I had a little issue searching for the issue because I ran the docker-compose and the standalone image, docker-compose works, but not the other.

But docker-compose does not change anything about nginx, so why? Then, I remember, I had issues related to the network configuration between Docker/Docker Compose and Podman/Podman Compose. So instead of setting up some Docker/Podman configuration, I tried inside the compose standalone containers (both from the same image) `curl --ipv4 localhost` and `curl --ipv6 localhost`.

I don't know exactly why it is handling the request internally as ipv6 when I'm requesting from outside the container using ipv4, but it seems it depends on the Docker/Compose networks. You can check it out with `docker inspect container`, the default network settings are different.

If you know the exact reason for this behavior, please let me know. (I checked both networks and they are setup as ipv4)