### PR TITLE
fix(docs): RISC-V emulation goes through QEMU, not a TypeScript brows…

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ ESP32 simulation with an HC-SR04 ultrasonic distance sensor — real Xtensa emul
 | **ESP32-CAM** | Xtensa LX6 @ 240 MHz | QEMU lcgamboa (backend) | C++ (Arduino) |
 | **Seeed XIAO ESP32-S3** | Xtensa LX7 @ 240 MHz | QEMU lcgamboa (backend) | C++ (Arduino) |
 | **Arduino Nano ESP32** | Xtensa LX6 @ 240 MHz | QEMU lcgamboa (backend) | C++ (Arduino) |
-| **ESP32-C3 DevKit** | RISC-V RV32IMC @ 160 MHz | RiscVCore.ts (browser) | C++ (Arduino) |
-| **Seeed XIAO ESP32-C3** | RISC-V RV32IMC @ 160 MHz | RiscVCore.ts (browser) | C++ (Arduino) |
-| **ESP32-C3 SuperMini** | RISC-V RV32IMC @ 160 MHz | RiscVCore.ts (browser) | C++ (Arduino) |
-| **CH32V003** | RISC-V RV32EC @ 48 MHz | RiscVCore.ts (browser) | C++ (Arduino) |
+| **ESP32-C3 DevKit** | RISC-V RV32IMC @ 160 MHz | QEMU lcgamboa (backend) | C++ (Arduino) |
+| **Seeed XIAO ESP32-C3** | RISC-V RV32IMC @ 160 MHz | QEMU lcgamboa (backend) | C++ (Arduino) |
+| **ESP32-C3 SuperMini** | RISC-V RV32IMC @ 160 MHz | QEMU lcgamboa (backend) | C++ (Arduino) |
+| **CH32V003** | RISC-V RV32EC @ 48 MHz | QEMU lcgamboa (backend) | C++ (Arduino) |
 | **Raspberry Pi 3B** | ARM Cortex-A53 @ 1.2 GHz | QEMU raspi3b (backend) | Python |
 
 ---
@@ -176,14 +176,13 @@ See [docs/RP2040_EMULATION.md](docs/RP2040_EMULATION.md) for full technical deta
 
 See [docs/ESP32_EMULATION.md](docs/ESP32_EMULATION.md) for setup and full technical details.
 
-#### ESP32-C3 / XIAO-C3 / SuperMini / CH32V003 (RISC-V, in-browser)
+#### ESP32-C3 / XIAO-C3 / SuperMini / CH32V003 (RISC-V via QEMU)
 
-- **RV32IMC emulation** in TypeScript — no backend, no QEMU, no WebSocket
+- **RV32IMC emulation** through QEMU lcgamboa with `libqemu-riscv32` and the `esp32c3-picsimlab` machine — same backend pattern as Xtensa ESP32, different libqemu binary
 - **GPIO 0–21** via W1TS/W1TC MMIO registers (ESP32-C3); PB0–PB5 (CH32V003)
 - **UART0** serial output in Serial Monitor
 - **CH32V003** — RV32EC core at 48 MHz, 16 KB flash, DIP-8 / SOP package — ultra-compact
-- **Instant startup** — zero latency, works offline
-- **CI-testable** — same TypeScript runs in Vitest
+- **TypeScript ISA layer** (`RiscVCore.ts`, `Esp32C3Simulator.ts`) is kept as Vitest-only unit-test infrastructure — it cannot handle the 150+ ROM functions ESP-IDF needs and is not the production emulation path
 
 See [docs/RISCV_EMULATION.md](docs/RISCV_EMULATION.md) for full technical details.
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -126,7 +126,7 @@
           "@id": "https://velxio.dev/#app",
           "name": "Velxio",
           "alternateName": ["Velxio Circuit Simulator", "Velxio Arduino Simulator", "Velxio SPICE Simulator", "Velxio Online Electronics Simulator", "Velxio Multi-Board Emulator"],
-          "description": "Free, open-source online circuit and microcontroller simulator running entirely in the browser. Real-time SPICE analog co-simulation via ngspice-WASM (resistors, capacitors, op-amps, transistors, diodes, voltage regulators) wired to 19 boards across 5 CPU architectures: ATmega328p/2560/ATtiny85 (AVR8 via avr8js), RP2040 ARM Cortex-M0+ (rp2040js), ESP32-C3/CH32V003 RISC-V RV32IMC (browser), ESP32/ESP32-S3 Xtensa LX6/LX7 (QEMU), and Raspberry Pi 3B ARM Cortex-A53 (QEMU Linux). Build custom chips in C/Rust/AssemblyScript via the Wokwi Custom Chips API. Includes live oscilloscope, voltmeter, ammeter, signal generator, 100+ interactive electronic components, Monaco Editor, Serial Monitor, arduino-cli compilation, and Library Manager.",
+          "description": "Free, open-source online circuit and microcontroller simulator. Real-time SPICE analog co-simulation via ngspice-WASM (resistors, capacitors, op-amps, transistors, diodes, voltage regulators) wired to 19 boards across 5 CPU architectures: ATmega328p/2560/ATtiny85 (AVR8 via avr8js), RP2040 ARM Cortex-M0+ (rp2040js, browser), ESP32-C3/CH32V003 RISC-V RV32IMC (QEMU lcgamboa libqemu-riscv32), ESP32/ESP32-S3 Xtensa LX6/LX7 (QEMU lcgamboa libqemu-xtensa), and Raspberry Pi 3B ARM Cortex-A53 (QEMU Linux). Build custom chips in C/Rust/AssemblyScript via the Wokwi Custom Chips API. Includes live oscilloscope, voltmeter, ammeter, signal generator, 100+ interactive electronic components, Monaco Editor, Serial Monitor, arduino-cli compilation, and Library Manager.",
           "url": "https://velxio.dev/",
           "applicationCategory": "DeveloperApplication",
           "applicationSubCategory": "Electronics Simulator",
@@ -147,7 +147,7 @@
             "Custom chips in C, Rust, and AssemblyScript (Wokwi Custom Chips API + WASI shim) — define your own ICs and reuse them across projects",
             "Real AVR8 emulation: Arduino Uno (ATmega328p), Nano, Mega 2560 (ATmega2560), ATtiny85, Leonardo (ATmega32u4), Pro Mini at 16 MHz",
             "RP2040 emulation: Raspberry Pi Pico and Pico W (ARM Cortex-M0+ at 133 MHz via rp2040js)",
-            "RISC-V emulation: ESP32-C3 DevKit, XIAO ESP32-C3, ESP32-C3 SuperMini, CH32V003 (RV32IMC/RV32EC browser-native)",
+            "RISC-V emulation: ESP32-C3 DevKit, XIAO ESP32-C3, ESP32-C3 SuperMini, CH32V003 (RV32IMC/RV32EC via QEMU lcgamboa libqemu-riscv32)",
             "ESP32 / ESP32-S3 / ESP32-CAM / Nano ESP32 emulation (Xtensa LX6/LX7 via QEMU)",
             "Raspberry Pi 3B emulation: full ARM Cortex-A53 Linux (Raspberry Pi OS via QEMU raspi3b)",
             "Live instruments: oscilloscope (multi-channel), voltmeter, ammeter, signal generator (sine/square/DC)",
@@ -252,7 +252,7 @@
         <ul>
           <li>Real AVR8 emulation: Arduino Uno (ATmega328p), Nano, Mega 2560, ATtiny85, Leonardo, Pro Mini at 16 MHz via avr8js</li>
           <li>Raspberry Pi Pico &amp; Pico W (RP2040, ARM Cortex-M0+ at 133 MHz) via rp2040js</li>
-          <li>ESP32-C3 / XIAO ESP32-C3 / SuperMini / CH32V003 (RISC-V RV32IMC/EC) &mdash; browser-native, no backend needed</li>
+          <li>ESP32-C3 / XIAO ESP32-C3 / SuperMini / CH32V003 (RISC-V RV32IMC/EC) &mdash; via QEMU lcgamboa (libqemu-riscv32)</li>
           <li>ESP32 / ESP32-S3 / ESP32-CAM / Arduino Nano ESP32 (Xtensa LX6/LX7 at 240 MHz) via QEMU lcgamboa</li>
           <li>Raspberry Pi 3B (ARM Cortex-A53, full Linux) via QEMU raspi3b &mdash; runs Python scripts with RPi.GPIO</li>
           <li><strong>Custom Chips</strong> — author your own integrated circuits in C, Rust, or AssemblyScript using the Wokwi Custom Chips API; reuse them across projects</li>
@@ -277,8 +277,8 @@
           <li>Arduino Pro Mini (ATmega328P) &mdash; 3.3 V / 5 V variants</li>
           <li>Raspberry Pi Pico (RP2040) &mdash; ARM Cortex-M0+ at 133 MHz</li>
           <li>Raspberry Pi Pico W (RP2040) &mdash; ARM Cortex-M0+ + WiFi</li>
-          <li>ESP32-C3 DevKit (RISC-V RV32IMC) &mdash; 160 MHz, browser-native</li>
-          <li>Seeed XIAO ESP32-C3 (RISC-V RV32IMC) &mdash; compact, browser-native</li>
+          <li>ESP32-C3 DevKit (RISC-V RV32IMC) &mdash; 160 MHz, QEMU libqemu-riscv32</li>
+          <li>Seeed XIAO ESP32-C3 (RISC-V RV32IMC) &mdash; compact, QEMU libqemu-riscv32</li>
           <li>ESP32-C3 SuperMini (RISC-V RV32IMC) &mdash; mini form factor</li>
           <li>CH32V003 (RISC-V RV32EC) &mdash; 48 MHz, ultra-compact DIP-8</li>
           <li>ESP32 DevKit V1 / C V4 (Xtensa LX6) &mdash; 240 MHz, WiFi, QEMU</li>
@@ -313,7 +313,7 @@
           <dt>Is Velxio free?</dt>
           <dd>Yes. Velxio is free and open-source under the GNU AGPLv3 license. A commercial license is available for proprietary integrations.</dd>
           <dt>Does Velxio work offline?</dt>
-          <dd>The simulation engine — including the SPICE analog solver and all browser-side CPU emulators (AVR8, RP2040, RISC-V) — runs entirely in the browser. Compilation requires the local arduino-cli backend. Self-hosted deployments work fully offline once running.</dd>
+          <dd>The SPICE analog solver and the browser-side CPU emulators (AVR8 via avr8js, RP2040 via rp2040js) run entirely in the browser. Xtensa and RISC-V boards (ESP32 / ESP32-S3 / ESP32-C3 / CH32V003) and Raspberry Pi 3 Linux run through QEMU lcgamboa, which is bundled in the self-hosted Docker image. Compilation requires the local arduino-cli backend. Self-hosted deployments work fully offline once running.</dd>
           <dt>Can Velxio simulate analog circuits like SPICE?</dt>
           <dd>Yes. Velxio 2.5 includes real-time SPICE analog simulation via ngspice compiled to WebAssembly. It runs full Modified Nodal Analysis on every tick — non-linear devices (diodes, BJTs, MOSFETs, op-amps with saturation) behave like real silicon, not idealised models.</dd>
           <dt>Can I co-simulate Arduino code with an analog circuit?</dt>
@@ -399,7 +399,7 @@
             <li>Hardware timers (Timer0/1/2) with PWM, CTC, and overflow interrupts</li>
             <li>10-bit ADC, full USART0 (TX/RX), SPI, I2C</li>
             <li>RP2040 dual-core ARM Cortex-M0+ via rp2040js</li>
-            <li>RISC-V RV32IMC (ESP32-C3) emulation in browser</li>
+            <li>RISC-V RV32IMC (ESP32-C3) emulation via QEMU lcgamboa</li>
           </ul>
         </section>
 

--- a/frontend/src/data/examples.ts
+++ b/frontend/src/data/examples.ts
@@ -3626,18 +3626,18 @@ void loop() {
     ],
   },
 
-  // ─── ESP32-C3 (RISC-V browser emulator) Examples ──────────────────────────
+  // ─── ESP32-C3 (RISC-V via QEMU lcgamboa) Examples ─────────────────────────
   {
     id: 'c3-blink',
     title: 'ESP32-C3: Blink LED',
     description:
-      'Blink an LED on GPIO 8 of the ESP32-C3. Runs entirely in the browser via the RISC-V emulator — no backend needed.',
+      'Blink an LED on GPIO 8 of the ESP32-C3. Runs through the QEMU lcgamboa backend (libqemu-riscv32) at 160 MHz.',
     category: 'basics',
     difficulty: 'beginner',
     boardType: 'esp32-c3',
     boardFilter: 'esp32-c3',
     code: `// ESP32-C3 — Blink LED on GPIO 8
-// Runs in-browser via RV32IMC emulator (Esp32C3Simulator)
+// Runs via QEMU libqemu-riscv32 (esp32c3-picsimlab machine)
 
 #define LED_PIN 8
 
@@ -3696,7 +3696,7 @@ void setup() {
   Serial.begin(115200);
   delay(200);
   Serial.println("=== ESP32-C3 Serial Demo ===");
-  Serial.println("RV32IMC @ 160 MHz — browser emulator");
+  Serial.println("RV32IMC @ 160 MHz — QEMU libqemu-riscv32");
   Serial.println();
 }
 

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -155,10 +155,10 @@ export const AboutPage: React.FC = () => {
                   <polyline points="8 6 2 12 8 18" />
                 </svg>
               </div>
-              <h3>RISC-V In-Browser</h3>
+              <h3>RISC-V via QEMU</h3>
               <p>
-                ESP32-C3 and CH32V003 run on a custom RV32IMC core written in TypeScript — entirely
-                client-side, no QEMU.
+                ESP32-C3 (DevKit, XIAO, SuperMini) and CH32V003 are emulated through the QEMU
+                lcgamboa fork with libqemu-riscv32, the same backend pattern as Xtensa ESP32.
               </p>
             </div>
             <div className="about-arch-card">

--- a/frontend/src/pages/ArduinoEmulatorPage.tsx
+++ b/frontend/src/pages/ArduinoEmulatorPage.tsx
@@ -157,8 +157,8 @@ export const ArduinoEmulatorPage: React.FC = () => {
             <div className="seo-card">
               <h3>RISC-V (ESP32-C3)</h3>
               <p>
-                Browser-native RV32IMC emulation for ESP32-C3 — no backend server required, compiled
-                to WebAssembly, runs at 160 MHz.
+                RV32IMC emulation for ESP32-C3 at 160 MHz via the QEMU lcgamboa fork
+                (libqemu-riscv32, esp32c3-picsimlab machine).
               </p>
             </div>
           </div>
@@ -184,9 +184,10 @@ export const ArduinoEmulatorPage: React.FC = () => {
               <p>Raspberry Pi Pico, Raspberry Pi Pico W — dual ARM Cortex-M0+ at 133 MHz.</p>
             </div>
             <div className="seo-card">
-              <h3>RISC-V — Browser</h3>
+              <h3>RISC-V — QEMU</h3>
               <p>
-                ESP32-C3 DevKit, XIAO ESP32-C3, ESP32-C3 SuperMini, CH32V003 — RV32IMC at 160 MHz.
+                ESP32-C3 DevKit, XIAO ESP32-C3, ESP32-C3 SuperMini, CH32V003 — RV32IMC at 160 MHz
+                via libqemu-riscv32.
               </p>
             </div>
             <div className="seo-card">

--- a/frontend/src/pages/DocsPage.tsx
+++ b/frontend/src/pages/DocsPage.tsx
@@ -1812,9 +1812,11 @@ const RiscVEmulationSection: React.FC = () => (
     <span className="docs-label">// risc-v</span>
     <h1>RISC-V Emulation (ESP32-C3)</h1>
     <p>
-      ESP32-C3, XIAO ESP32-C3, and C3 SuperMini boards use a <strong>RISC-V RV32IMC</strong> core
-      running at 160 MHz. Velxio emulates them entirely in the browser, no backend, no QEMU, no
-      WebAssembly pipeline. The emulator is written in pure TypeScript and runs at real-time speeds.
+      ESP32-C3, XIAO ESP32-C3, and C3 SuperMini boards run on the <strong>RISC-V RV32IMC</strong>
+      architecture at 160 MHz. Velxio emulates them through the same QEMU-based backend as the
+      Xtensa ESP32 family, using <code>libqemu-riscv32</code> with the <code>esp32c3-picsimlab</code>
+      machine target. A separate TypeScript ISA implementation lives in the repo for unit-testing
+      RV32IMC instruction decoding, but it is not the production emulation path.
     </p>
 
     <h2>Supported Boards</h2>
@@ -2088,10 +2090,10 @@ const Esp32EmulationSection: React.FC = () => (
     </p>
 
     <div className="docs-callout">
-      <strong>Note:</strong> This section applies only to <strong>ESP32</strong> and{' '}
-      <strong>ESP32-S3</strong> (Xtensa). For ESP32-C3, XIAO ESP32-C3, and C3 SuperMini (RISC-V),
-      see <strong>RISC-V Emulation (ESP32-C3)</strong> in the sidebar, those boards run entirely in
-      the browser.
+      <strong>Note:</strong> This section applies to <strong>ESP32</strong>,{' '}
+      <strong>ESP32-S3</strong> (Xtensa) and <strong>ESP32-C3</strong> (RISC-V) — they all share
+      the same QEMU lcgamboa pipeline, just with different libqemu binaries and machine targets.
+      See <strong>RISC-V Emulation (ESP32-C3)</strong> for the C3-specific differences.
     </div>
 
     <h2>How It Works</h2>

--- a/frontend/src/pages/ElectronicsSimulatorPage.tsx
+++ b/frontend/src/pages/ElectronicsSimulatorPage.tsx
@@ -25,7 +25,7 @@ const FAQ_ITEMS = [
   },
   {
     q: 'Do I need to install anything?',
-    a: 'No. Open velxio.dev in any modern browser and start. Compilation of Arduino sketches uses the cloud arduino-cli backend, but the SPICE solver and AVR / RP2040 / RISC-V emulators all run locally in your browser.',
+    a: 'No. Open velxio.dev in any modern browser and start. The SPICE solver and the AVR / RP2040 emulators run locally in your browser; Xtensa and RISC-V boards (ESP32, ESP32-C3, CH32V003) plus Raspberry Pi 3 Linux run through QEMU lcgamboa, bundled in the Docker image. Compilation of Arduino sketches uses the cloud arduino-cli backend.',
   },
   {
     q: 'Is it good for teaching electronics?',

--- a/frontend/src/pages/Esp32C3SimulatorPage.tsx
+++ b/frontend/src/pages/Esp32C3SimulatorPage.tsx
@@ -45,7 +45,7 @@ const JSON_LD: object[] = [
     applicationCategory: 'DeveloperApplication',
     operatingSystem: 'Any (browser-based)',
     description:
-      'Free online ESP32-C3 RISC-V simulator. Browser-native RV32IMC emulation at 160 MHz — no backend, no install. Simulate ESP32-C3 DevKit, XIAO ESP32-C3, SuperMini, and CH32V003.',
+      'Free online ESP32-C3 RISC-V simulator. RV32IMC emulation at 160 MHz via the QEMU lcgamboa backend (libqemu-riscv32). Simulate ESP32-C3 DevKit, XIAO ESP32-C3, SuperMini, and CH32V003.',
     url: 'https://velxio.dev/esp32-c3-simulator',
     offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
     author: { '@type': 'Person', name: 'David Montero Crespo' },
@@ -90,11 +90,12 @@ export const Esp32C3SimulatorPage: React.FC = () => {
           <h1>
             Free ESP32-C3 Simulator
             <br />
-            <span className="accent">RISC-V Emulation — Runs in Your Browser</span>
+            <span className="accent">RISC-V Emulation via QEMU</span>
           </h1>
           <p className="subtitle">
-            Simulate ESP32-C3 and CH32V003 RISC-V code directly in your browser — no QEMU backend,
-            no install. RV32IMC at 160 MHz with 48+ interactive components.
+            Simulate ESP32-C3 and CH32V003 RISC-V code via the QEMU lcgamboa backend
+            (libqemu-riscv32, esp32c3-picsimlab machine). RV32IMC at 160 MHz with 48+ interactive
+            components.
           </p>
           <div className="seo-cta-group">
             <Link
@@ -109,15 +110,16 @@ export const Esp32C3SimulatorPage: React.FC = () => {
             </Link>
           </div>
           <p className="seo-trust">
-            Free &amp; open-source · 100% browser-native · No backend required
+            Free &amp; open-source · QEMU lcgamboa backend · libqemu-riscv32
           </p>
         </section>
 
         <section className="seo-section">
           <h2>Supported RISC-V boards</h2>
           <p className="lead">
-            Velxio emulates RISC-V microcontrollers natively in the browser using WebAssembly — the
-            fastest simulation path available, no server round-trip.
+            Velxio emulates RISC-V microcontrollers through the QEMU lcgamboa fork — the same
+            backend pattern used for Xtensa ESP32 / ESP32-S3, with libqemu-riscv32 instead of
+            libqemu-xtensa.
           </p>
           <div className="seo-grid">
             <div className="seo-card">

--- a/frontend/src/pages/Esp32SimulatorPage.tsx
+++ b/frontend/src/pages/Esp32SimulatorPage.tsx
@@ -152,7 +152,8 @@ export const Esp32SimulatorPage: React.FC = () => {
             <div className="seo-card">
               <h3>ESP32-C3 (RISC-V)</h3>
               <p>
-                Single-core RISC-V RV32IMC at 160 MHz. Browser-native emulation — no QEMU needed.{' '}
+                Single-core RISC-V RV32IMC at 160 MHz, emulated via the same QEMU backend as Xtensa
+                ESP32 (libqemu-riscv32, esp32c3-picsimlab machine).{' '}
                 <Link to="/esp32-c3-simulator">Learn more →</Link>
               </p>
             </div>

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -583,7 +583,7 @@ const features = [
   {
     icon: <IcoCpu />,
     title: '5 Emulation Engines',
-    desc: 'AVR8 (ATmega328P, ATmega2560, ATtiny85), RP2040 (ARM Cortex-M0+), RV32IMC (ESP32-C3 in-browser), Xtensa LX6/LX7 (ESP32 via QEMU), and ARM Cortex-A53 (Raspberry Pi 3 Linux).',
+    desc: 'AVR8 (ATmega328P, ATmega2560, ATtiny85), RP2040 (ARM Cortex-M0+), RV32IMC (ESP32-C3, CH32V003 via QEMU), Xtensa LX6/LX7 (ESP32 via QEMU), and ARM Cortex-A53 (Raspberry Pi 3 Linux).',
   },
   {
     icon: <IcoChip />,
@@ -779,7 +779,7 @@ export const LandingPage: React.FC = () => {
           name: 'Does Velxio work offline?',
           acceptedAnswer: {
             '@type': 'Answer',
-            text: 'The SPICE solver and the AVR / RP2040 / RISC-V CPU emulators all run in your browser. Compilation of Arduino sketches requires the arduino-cli backend. Self-hosted Docker deployments work fully offline once running.',
+            text: 'The SPICE solver and the AVR / RP2040 CPU emulators run in your browser. Xtensa and RISC-V boards (ESP32, ESP32-S3, ESP32-C3, CH32V003) and Raspberry Pi 3 Linux run through QEMU lcgamboa, bundled in the Docker image. Compilation of Arduino sketches requires the arduino-cli backend. Self-hosted Docker deployments work fully offline once running.',
           },
         },
         {
@@ -1016,14 +1016,14 @@ export const LandingPage: React.FC = () => {
           </div>
         </div>
 
-        {/* ── RISC-V · RV32IMC · Browser ───────────────────────────── */}
+        {/* ── RISC-V · RV32IMC · QEMU lcgamboa ───────────────────────────── */}
         <div className="board-group">
           <div
             className="board-group-header"
             style={{ '--grp-color': '#4a9e6b' } as React.CSSProperties}
           >
-            <span className="board-group-engine">RV32IMC · Browser</span>
-            <span className="board-group-label">RISC-V · 160 MHz · no backend needed</span>
+            <span className="board-group-engine">QEMU lcgamboa</span>
+            <span className="board-group-label">RISC-V · RV32IMC · 160 MHz · libqemu-riscv32</span>
           </div>
           <div className="boards-row">
             <div className="board-card-sm">

--- a/frontend/src/pages/Velxio2Page.tsx
+++ b/frontend/src/pages/Velxio2Page.tsx
@@ -262,7 +262,7 @@ const CHANGE_SECTIONS = [
     items: [
       'Raspberry Pi 3B — full Linux (ARM Cortex-A53 via QEMU raspi3b)',
       'ESP32 / ESP32-S3 / ESP32-CAM — Xtensa LX6/LX7 via QEMU',
-      'ESP32-C3 / CH32V003 — RISC-V RV32IMC, browser-native',
+      'ESP32-C3 / CH32V003 — RISC-V RV32IMC via QEMU (libqemu-riscv32)',
       'RP2040 — Raspberry Pi Pico / Pico W (ARM Cortex-M0+)',
       'ATtiny85, ATmega2560, Leonardo, Pro Mini — AVR8 via avr8js',
       'Multi-board canvas — mix architectures on the same simulation',
@@ -498,7 +498,7 @@ export const Velxio2Page: React.FC = () => {
           {/* RISC-V */}
           <div className="v2-arch-group">
             <div className="v2-arch-label" style={{ borderColor: '#4a9e6b' }}>
-              <span className="v2-arch-engine">Browser-native</span>
+              <span className="v2-arch-engine">QEMU lcgamboa</span>
               RISC-V -- RV32IMC -- 160 MHz
             </div>
             <div className="v2-boards-row">
@@ -725,8 +725,8 @@ export const Velxio2Page: React.FC = () => {
             <div className="seo-card">
               <h3>More realistic emulation</h3>
               <p>
-                QEMU-based Xtensa and ARM emulation. Browser-native RISC-V. Cycle-accurate AVR8 via
-                avr8js. Real firmware execution, not approximations.
+                QEMU-based Xtensa, RISC-V and ARM emulation. Cycle-accurate AVR8 via avr8js. Real
+                firmware execution, not approximations.
               </p>
             </div>
             <div className="seo-card">

--- a/frontend/src/seoRoutes.ts
+++ b/frontend/src/seoRoutes.ts
@@ -43,7 +43,7 @@ export const SEO_ROUTES: SeoRoute[] = [
       title:
         'Velxio — Free Online Circuit & Arduino Simulator | SPICE · ESP32 · RP2040 · ATtiny85 · Custom Chips',
       description:
-        'Velxio is a free, open-source online circuit simulator. Real-time SPICE analog simulation (ngspice-WASM) wired to 19 boards: Arduino Uno/Mega/ATtiny85 (AVR8), ESP32 (Xtensa QEMU), ESP32-C3/CH32V003 (RISC-V), Raspberry Pi Pico (RP2040), Raspberry Pi 3 (Linux). Build custom chips in C/Rust. 100+ components, oscilloscope, voltmeter, ammeter — no cloud.',
+        'Velxio is a free, open-source online circuit simulator. Real-time SPICE analog simulation (ngspice-WASM) wired to 19 boards: Arduino Uno/Mega/ATtiny85 (AVR8), ESP32 (Xtensa QEMU), ESP32-C3/CH32V003 (RISC-V via QEMU libqemu-riscv32), Raspberry Pi Pico (RP2040), Raspberry Pi 3 (Linux). Build custom chips in C/Rust. 100+ components, oscilloscope, voltmeter, ammeter — no cloud.',
       url: `${DOMAIN}/`,
     },
   },
@@ -343,9 +343,9 @@ export const SEO_ROUTES: SeoRoute[] = [
     priority: 0.85,
     changefreq: 'monthly',
     seoMeta: {
-      title: 'Free ESP32-C3 & RISC-V Simulator — Browser-Native Emulation | Velxio',
+      title: 'Free ESP32-C3 & RISC-V Simulator — QEMU Emulation | Velxio',
       description:
-        'Simulate ESP32-C3 RISC-V code directly in your browser — no backend needed. RV32IMC at 160 MHz, 48+ components, Serial Monitor. Also supports CH32V003. Free and open-source.',
+        'Simulate ESP32-C3 RISC-V code via the QEMU lcgamboa backend (libqemu-riscv32) at 160 MHz. 48+ components, Serial Monitor. Also supports CH32V003. Free and open-source.',
       url: `${DOMAIN}/esp32-c3-simulator`,
     },
   },


### PR DESCRIPTION
…er core

The marketing copy and docs claimed ESP32-C3 / XIAO-C3 / SuperMini / CH32V003 ran on a "browser-native RV32IMC core written in TypeScript", but production runs through QEMU lcgamboa (libqemu-riscv32) with the esp32c3-picsimlab machine — same backend pattern as Xtensa ESP32, just a different libqemu binary. The TypeScript ISA layer (RiscVCore.ts / Esp32C3Simulator.ts / RiscVSimulator.ts) is kept only as Vitest unit-test infrastructure for RV32IMC instruction decoding; it cannot handle the 150+ ROM functions ESP-IDF needs at boot and is not wired into the production emulation path.

Files updated:

Marketing pages
- LandingPage: board-group label, FAQ answer, architecture description no longer claim "browser-native" or "no backend needed" for RISC-V.
- AboutPage: arch card retitled "RISC-V via QEMU", body explains the libqemu-riscv32 / lcgamboa backend.
- Velxio2Page: arch group engine label, multi-board feature item, competitive-comparison card all corrected.
- ArduinoEmulatorPage: two RISC-V cards corrected.
- ESP32SimulatorPage: ESP32-C3 cross-link card corrected.
- ESP32C3SimulatorPage: hero subtitle, trust strip, supported-boards intro, JSON-LD description corrected.
- ElectronicsSimulatorPage: install-needed FAQ corrected.
- examples.ts: c3-blink description and code-comment corrected.

SEO surfaces
- index.html: JSON-LD SoftwareApplication description, OS-fallback FAQ body, supported-boards <ul> bullets, feature list bullets corrected.
- seoRoutes.ts: /esp32-c3-simulator title + description corrected; homepage description corrected.

Docs page
- DocsPage RiscVEmulationSection: intro paragraph rewritten — RISC-V goes through QEMU lcgamboa with libqemu-riscv32 / esp32c3-picsimlab, TypeScript layer is Vitest-only.
- DocsPage Esp32EmulationSection callout: section now applies to all ESP32 family (Xtensa + RISC-V), pointer to RISC-V doc clarified.

README
- "Boards" table: production-engine column for ESP32-C3 family and CH32V003 changed from "RiscVCore.ts (browser)" to "QEMU lcgamboa (backend)".
- "ESP32-C3 / XIAO-C3 / SuperMini / CH32V003" subsection retitled "(RISC-V via QEMU)" — body explains libqemu-riscv32 backend and flags the TypeScript layer as Vitest-only.

The two remaining "browser-native" hits in the codebase (Velxio25Page:176, index.html:348) are about ngspice-WASM SPICE analog simulation, which genuinely is browser-native — left alone.

Build verified: npm run build:docker succeeds, 246 SEO pages prerender.