### PR TITLE
fix(espidf): bump ninja timeout 300s → 600s for cold first builds

### DIFF
--- a/backend/app/services/espidf_compiler.py
+++ b/backend/app/services/espidf_compiler.py
@@ -986,6 +986,13 @@ class ESPIDFCompiler:
             ninja_cmd = ['ninja']
             logger.info('[espidf] Building with ninja...')
 
+            # Cold ESP-IDF builds with external Arduino libraries (e.g. Adafruit
+            # BMP280 + BusIO + Unified Sensor → ~1480 build steps) regularly take
+            # 5-7 minutes on modest hardware. 300s used to cut them off at 98%;
+            # bump to 600s so first-run cold compiles complete. Subsequent
+            # builds reuse ninja's cache and finish in seconds.
+            NINJA_TIMEOUT_S = 600
+
             def _run_ninja():
                 return subprocess.run(
                     ninja_cmd,
@@ -993,7 +1000,7 @@ class ESPIDFCompiler:
                     capture_output=True,
                     text=True,
                     env=env,
-                    timeout=300,
+                    timeout=NINJA_TIMEOUT_S,
                 )
 
             try:
@@ -1001,7 +1008,7 @@ class ESPIDFCompiler:
             except subprocess.TimeoutExpired:
                 return {
                     'success': False,
-                    'error': 'ESP-IDF build timed out (300s)',
+                    'error': f'ESP-IDF build timed out ({NINJA_TIMEOUT_S}s)',
                     'stdout': '',
                     'stderr': '',
                 }


### PR DESCRIPTION
The ESP32 BMP280 example compile was timing out at 98% (1473/1483 build steps), failing with the unhelpful "ESP-IDF build timed out (300s)" message even though every individual step was healthy.

Cold ESP-IDF builds that pull in external Arduino libraries — Adafruit BMP280 + Adafruit BusIO + Adafruit Unified Sensor on top of the base arduino-esp32 component tree — routinely produce ~1480 build objects. On modest VPS hardware this takes 5-7 minutes the first time. Ninja's incremental cache makes subsequent compiles seconds, but the first one needs more headroom.

Constant lifted to NINJA_TIMEOUT_S so the value used in the timeout matches the value reported in the error message — the previous code hard-coded "300s" in two places that were free to drift apart.

Repro before: open the example "ESP32 — BMP280 Barometric Pressure" on velxio.dev/editor on a clean container, click compile → fails after 5 minutes with timeout. After: completes in ~6 minutes on the first run, ~5 seconds on subsequent runs.