### PR TITLE
fix(nginx): use relative redirects so trailing-slash 301s preserve HTTPS

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -5,6 +5,14 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Use relative redirects (e.g. `/examples/` instead of
+    # `http://velxio.dev/examples/`) so trailing-slash and other internal
+    # redirects don't downgrade HTTPS clients to HTTP. We sit behind a TLS
+    # terminator (host nginx → Cloudflare); without this nginx generates
+    # absolute Location headers using the listening protocol (http) and the
+    # browser blocks the redirect as mixed-content.
+    absolute_redirect off;
+
     # Security headers
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;


### PR DESCRIPTION
Browsers were reporting:
    Unsafe attempt to load URL http://velxio.dev/examples/
    from frame with URL https://velxio.dev/examples.

Repro:
    curl -I https://velxio.dev/examples
    → 301  Location: http://velxio.dev/examples/   ← protocol downgraded

Why: docker/nginx.conf has the container listening on `:80` only — TLS is terminated by the host nginx in front of it (which then proxies to http://127.0.0.1:3080). When nginx generates a trailing-slash 301 it uses the listening protocol (http) for the absolute Location header, not the X-Forwarded-Proto. The browser correctly blocks the redirect.

Fix: `absolute_redirect off;` makes nginx emit relative Location headers (`Location: /examples/`), so the browser resolves them against the original request URL and HTTPS is preserved end-to-end.

After fix:
    curl -I https://velxio.dev/examples
    → 301  Location: /examples/

Goes in the same branch as the BMP280 ninja-timeout fix because both are deploy-blocking and small.