### PR TITLE
perf(ccache): bump cap 2G → 8G — cache was evicting before hits accum…

### DIFF
--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -192,7 +192,7 @@ ENV IDF_CCACHE_ENABLE=1
 # embed absolute paths into the command line.
 ENV CCACHE_BASEDIR=/var/lib/velxio-build
 RUN mkdir -p /var/cache/ccache \
-    && ccache --max-size=2G \
+    && ccache --max-size=8G \
     && ccache --set-config=compression=true \
     && ccache --set-config=compression_level=6
 


### PR DESCRIPTION
…ulate

Empirical confirmation from a smoke test on prod after PR #152 (persistent build dir + dedup) landed:

    Cache size (GB):  2.0 / 2.0 (99.96%)
    Hits:                1 / 86886 ( 0.00%)
    Misses:          86885 / 86886 (100.0%)

The cap was set to 2G when ccache was first wired in (PR #149) under the assumption that base ESP-IDF would fit. With arduino-esp32 + external Arduino libraries (Adafruit BMP280 + BusIO + Unified_Sensor + GFX + …) the cacheable object set comfortably exceeds that — we observed 86k misses while the cache was permanently at 99.96% full, meaning entries get evicted before subsequent compiles can hit them.

Disk usage on the prod VPS at /var/cache/ccache will rise from ~2 GB to ~6-8 GB. The host has plenty of headroom and the named volume sits on the same partition as the rest of /var. Compression at level 6 is already on, so the disk impact is the on-disk size after compression.

The 13-second warm compile we measured today already proves the bulk of the perf win came from ninja's incremental cache + persistent build dir; this is the cherry on top that lets ccache start contributing across container restarts (when ninja's in-build-dir cache is fresh but ccache should still hit at the C/C++ object level).