### PR TITLE
fix(ccache): set max-size + compression via ENV (image-build config w…

### DIFF
--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -191,10 +191,17 @@ ENV IDF_CCACHE_ENABLE=1
 # ccache hit across compiles even though some flags (-I, -fmacro-prefix-map)
 # embed absolute paths into the command line.
 ENV CCACHE_BASEDIR=/var/lib/velxio-build
-RUN mkdir -p /var/cache/ccache \
-    && ccache --max-size=8G \
-    && ccache --set-config=compression=true \
-    && ccache --set-config=compression_level=6
+# Cache cap, compression. These are set as env vars (rather than written
+# to /var/cache/ccache/ccache.conf via `ccache --set-config` at image-build
+# time) because $CCACHE_DIR is a named volume — anything we write into it
+# during build is masked at runtime by the volume mount, so config in the
+# image gets shadowed by whatever's already in the volume. ccache reads
+# CCACHE_MAXSIZE / CCACHE_COMPRESS / CCACHE_COMPRESSLEVEL at runtime,
+# overriding any conf-file value.
+ENV CCACHE_MAXSIZE=8G
+ENV CCACHE_COMPRESS=1
+ENV CCACHE_COMPRESSLEVEL=6
+RUN mkdir -p /var/cache/ccache
 
 # Install ESP-IDF Python dependencies using the final image's Python
 # The requirements.txt has version constraints required by ESP-IDF 4.4.x


### PR DESCRIPTION
…as shadowed)

The previous bump to 8G (PR #153) didn't take effect on prod. Verified post-deploy:

    Cache size (GB):  2.0 / 2.0 (99.95%)

Cause: $CCACHE_DIR (/var/cache/ccache) is a named docker volume. Any config we wrote into it via `ccache --set-config max_size 8G` during the RUN step gets masked at runtime by the mount of the existing volume — which still contained the original 2 GB config from when the cache was first populated.

Fix: set CCACHE_MAXSIZE / CCACHE_COMPRESS / CCACHE_COMPRESSLEVEL as ENV in the Dockerfile. ccache reads those at runtime and they override any conf-file value, including whatever stale config is sitting in the volume.

After this lands and the submodule bumps, `ccache -s` should report the new 8 GB max immediately on container start without needing to wipe or re-init the cache volume.