### PR TITLE
test(metadata): drill into components array for BMP280 lookup

### DIFF
--- a/frontend/src/__tests__/component-metadata-bmp280.test.ts
+++ b/frontend/src/__tests__/component-metadata-bmp280.test.ts
@@ -1,11 +1,18 @@
 import { describe, it, expect } from 'vitest';
 import metadata from '../../public/components-metadata.json';
 
+interface ComponentMetadataEntry {
+  id: string;
+  tagName: string;
+  category: string;
+  pinCount: number;
+  [key: string]: unknown;
+}
+
 describe('component metadata — BMP280 entry', () => {
   it('is registered with id "bmp280" and tagName "velxio-bmp280"', () => {
-    const entry = (metadata as Array<Record<string, unknown>>).find(
-      (c) => c.id === 'bmp280',
-    );
+    const components = (metadata as { components: ComponentMetadataEntry[] }).components;
+    const entry = components.find((c) => c.id === 'bmp280');
     expect(entry, 'BMP280 missing from components-metadata.json').toBeDefined();
     expect(entry!.tagName).toBe('velxio-bmp280');
     expect(entry!.category).toBe('sensor');


### PR DESCRIPTION
components-metadata.json is shaped { version, components: [...] }, not a flat array. The previous test assumed the latter and crashed on default.find at module load on master, breaking CI for every PR.