### PR TITLE
fix(editor): add missing useTranslation import in SensorControlPanel

### DIFF
--- a/frontend/src/components/simulator/SensorControlPanel.tsx
+++ b/frontend/src/components/simulator/SensorControlPanel.tsx
@@ -7,6 +7,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   SENSOR_CONTROLS,
   type SensorControl,


### PR DESCRIPTION
Block 9 added `const { t } = useTranslation()` at line 50 but forgot the matching `import { useTranslation } from 'react-i18next'`. The component then crashes the moment a user clicks a sensor on the canvas with `Uncaught ReferenceError: useTranslation is not defined`, taking the whole simulator render tree down.