### PR TITLE
feat(header): add Pricing link to top nav + landing footer

### DIFF
--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -143,6 +143,9 @@ export const AppHeader: React.FC<AppHeaderProps> = ({ autoSave }) => {
             <Link to={localize('/about')} className={'header-nav-link' + isActive('/about')}>
               {t('header.nav.about')}
             </Link>
+            <Link to={localize('/pricing')} className={'header-nav-link' + isActive('/pricing')}>
+              {t('header.nav.pricing')}
+            </Link>
             <a
               href={blogUrlFor(currentLocale)}
               className="header-nav-link"

--- a/frontend/src/i18n/locales/de/common.json
+++ b/frontend/src/i18n/locales/de/common.json
@@ -9,6 +9,7 @@
       "examples": "Beispiele",
       "editor": "Editor",
       "about": "Über uns",
+      "pricing": "Preise",
       "blog": "Blog",
       "github": "GitHub",
       "discord": "Discord"

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -9,6 +9,7 @@
       "examples": "Examples",
       "editor": "Editor",
       "about": "About",
+      "pricing": "Pricing",
       "blog": "Blog",
       "github": "GitHub",
       "discord": "Discord"

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -9,6 +9,7 @@
       "examples": "Ejemplos",
       "editor": "Editor",
       "about": "Acerca de",
+      "pricing": "Precios",
       "blog": "Blog",
       "github": "GitHub",
       "discord": "Discord"

--- a/frontend/src/i18n/locales/fr/common.json
+++ b/frontend/src/i18n/locales/fr/common.json
@@ -9,6 +9,7 @@
       "examples": "Exemples",
       "editor": "Éditeur",
       "about": "À propos",
+      "pricing": "Tarifs",
       "blog": "Blog",
       "github": "GitHub",
       "discord": "Discord"

--- a/frontend/src/i18n/locales/it/common.json
+++ b/frontend/src/i18n/locales/it/common.json
@@ -9,6 +9,7 @@
       "examples": "Esempi",
       "editor": "Editor",
       "about": "Informazioni",
+      "pricing": "Prezzi",
       "blog": "Blog",
       "github": "GitHub",
       "discord": "Discord"

--- a/frontend/src/i18n/locales/ja/common.json
+++ b/frontend/src/i18n/locales/ja/common.json
@@ -9,6 +9,7 @@
       "examples": "例",
       "editor": "エディター",
       "about": "概要",
+      "pricing": "料金",
       "blog": "ブログ",
       "github": "GitHub",
       "discord": "Discord"

--- a/frontend/src/i18n/locales/pt-br/common.json
+++ b/frontend/src/i18n/locales/pt-br/common.json
@@ -9,6 +9,7 @@
       "examples": "Exemplos",
       "editor": "Editor",
       "about": "Sobre",
+      "pricing": "Preços",
       "blog": "Blog",
       "github": "GitHub",
       "discord": "Discord"

--- a/frontend/src/i18n/locales/ru/common.json
+++ b/frontend/src/i18n/locales/ru/common.json
@@ -9,6 +9,7 @@
       "examples": "Примеры",
       "editor": "Редактор",
       "about": "О проекте",
+      "pricing": "Цены",
       "blog": "Блог",
       "github": "GitHub",
       "discord": "Discord"

--- a/frontend/src/i18n/locales/zh-cn/common.json
+++ b/frontend/src/i18n/locales/zh-cn/common.json
@@ -9,6 +9,7 @@
       "examples": "示例",
       "editor": "编辑器",
       "about": "关于",
+      "pricing": "价格",
       "blog": "博客",
       "github": "GitHub",
       "discord": "Discord"

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1349,6 +1349,7 @@ export const LandingPage: React.FC = () => {
           <Link to={localize('/docs')}>{t('header.nav.documentation')}</Link>
           <Link to={localize('/examples')}>{t('header.nav.examples')}</Link>
           <Link to={localize('/editor')}>{t('header.nav.editor')}</Link>
+          <Link to={localize('/pricing')}>{t('header.nav.pricing')}</Link>
           <Link to={localize('/about')}>{t('header.nav.about')}</Link>
         </div>
         <p className="footer-copy">{t('footer.about')}</p>


### PR DESCRIPTION
The /pricing page exists (PricingPlaceholder upstream, real PricingPage portal-mounted by the private overlay) but had no entry in the top nav. Adds 'pricing' to header.nav in all 9 locales (de, en, es, fr, it, ja, pt-br, ru, zh-cn), wires the Link in AppHeader between About and Blog, and mirrors the link in the landing-page footer.