### PR TITLE
fix(ci): pass VELXIO_LICENSE_KEY to publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,6 +59,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             ESPIDF_IMAGE=ghcr.io/davidmonterocrespo24/velxio-espidf-toolchain:latest
+            VELXIO_LICENSE_KEY=${{ secrets.VELXIO_BUILD_LICENSE_KEY }}
           cache-from: type=gha
           # mode=min only stores the layers used in the final image. mode=max
           # also stores all intermediate layers, which doubles or triples the


### PR DESCRIPTION
After the Dockerfile.standalone refactor (PR #182), the qemu-provider stage requires VELXIO_LICENSE_KEY to fetch libqemu .so + ESP32 ROM blobs from velxio.dev's gated download endpoint. The Publish Docker Image workflow was missing the build-arg, so it failed on every push to master and the GHCR / Docker Hub :master image went stale.

Plumbs the existing repo secret VELXIO_BUILD_LICENSE_KEY into docker/build-push-action@v6's build-args list. Same secret the backend-e2e-tests workflow already consumes — single source of truth.