### PR TITLE
fix(hooks): annotate get_current_user_id(request: Request)

### DIFF
--- a/backend/app/core/hooks.py
+++ b/backend/app/core/hooks.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Awaitable, Callable, Optional
 
+from fastapi import Request
+
 logger = logging.getLogger(__name__)
 
 
@@ -91,7 +93,7 @@ def register_get_current_user_id(hook: GetCurrentUserIdHook) -> None:
     _get_current_user_id_hook = hook
 
 
-async def get_current_user_id(request) -> Optional[str]:  # FastAPI dependency
+async def get_current_user_id(request: Request) -> Optional[str]:  # FastAPI dependency
     if _get_current_user_id_hook is None:
         return None
     try:


### PR DESCRIPTION
Without the type annotation, FastAPI treats `request` as a Query parameter and bubbles it up to every endpoint that uses `Depends(get_current_user_id)`. Result: POST /api/compile/start and POST /api/compile/ both returned 422
{"loc":["query","request"],"msg":"Field required"} on every call the frontend made — compile was fully broken in production.

The frontend then caught the 422 axios error and surfaced response.data as a CompileResult, which had no success/stdout/ stderr/error fields, so the editor's CompilationConsole rendered only the fallback "✕ Compilation failed" line with no detail.

Annotating `request: Request` is the standard FastAPI pattern; the framework injects the raw HTTPRequest and no longer treats it as a query parameter.