### PR TITLE
fix(tests): update mocks + assertions for PinManager API changes

### DIFF
--- a/frontend/src/__tests__/esp32-integration.test.ts
+++ b/frontend/src/__tests__/esp32-integration.test.ts
@@ -46,6 +46,7 @@ vi.mock('../simulation/PinManager', () => ({
     this.updatePort = vi.fn();
     this.onPinChange = vi.fn().mockReturnValue(() => {});
     this.getListenersCount = vi.fn().mockReturnValue(0);
+    this.resetPinStates = vi.fn();
   }),
 }));
 

--- a/frontend/src/__tests__/esp32c3-blink.test.ts
+++ b/frontend/src/__tests__/esp32c3-blink.test.ts
@@ -158,9 +158,11 @@ describe('ESP32-C3 bare-metal blink (compiled with riscv32-esp-elf-gcc)', () => 
     sim.loadBin(binData);
     runSteps(sim, 2000);
 
-    // PinManager must have received GPIO 8 state changes
-    expect(pm.setPinState).toHaveBeenCalledWith(8, true);
-    expect(pm.setPinState).toHaveBeenCalledWith(8, false);
+    // PinManager must have received GPIO 8 state changes. Production code
+    // passes the optional `source` argument ('mcu') since PinManager added
+    // the input/output classification field.
+    expect(pm.setPinState).toHaveBeenCalledWith(8, true, 'mcu');
+    expect(pm.setPinState).toHaveBeenCalledWith(8, false, 'mcu');
   });
 
   it('timestamps increase monotonically across blink events', () => {

--- a/frontend/src/__tests__/esp32c3-simulation.test.ts
+++ b/frontend/src/__tests__/esp32c3-simulation.test.ts
@@ -480,7 +480,7 @@ describe('Esp32C3Simulator — GPIO pin toggling', () => {
     core.reset(0x42000000);
     runSteps(core, 3);
 
-    expect(pm.setPinState).toHaveBeenCalledWith(0, true);
+    expect(pm.setPinState).toHaveBeenCalledWith(0, true, 'mcu');
     s.stop();
   });
 });

--- a/frontend/src/__tests__/multi-board-integration.test.ts
+++ b/frontend/src/__tests__/multi-board-integration.test.ts
@@ -48,6 +48,7 @@ vi.mock('../simulation/PinManager', () => ({
     this.updatePort = vi.fn();
     this.onPinChange = vi.fn().mockReturnValue(() => {});
     this.getListenersCount = vi.fn().mockReturnValue(0);
+    this.resetPinStates = vi.fn();
   }),
 }));
 


### PR DESCRIPTION
PR #192 (spice-led-pipeline) added two PinManager changes that were not reflected in the test mocks / assertions:

- `setPinState(pin, state)` gained an optional `source: 'mcu' | 'external'` third arg. Production ESP32-C3 / RISC-V simulators now pass `'mcu'` to mark the call as an MCU output (so the SPICE collector emits a V-source). The esp32c3-blink and esp32c3-simulation tests asserted on the old 2-arg shape.
- `resetPinStates()` is a new public method on PinManager called by `stopBoard` / `resetBoard` to clear cached pin states. The mocks in esp32-integration.test.ts and multi-board-integration.test.ts did not add it, so any test that ran stopBoard hit `TypeError: getBoardPinManager(...)?.resetPinStates is not a function`.

This commit:
- Adds `'mcu'` to the two ESP32-C3 setPinState assertions.
- Adds `this.resetPinStates = vi.fn()` to both integration mocks.

These are pure test fixups — no production code touched. The `circuit-simulation-service.test.ts > handleMcuEdge` failure (`expected 1 to be 2`) is a separate regression in production code introduced by PR #192 and is NOT fixed here.