### PR TITLE
fix(esp32): bundle mkspiffs so uploaded SPIFFS files are actually fla…

### DIFF
--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -117,6 +117,20 @@ RUN git clone --branch 2.0.17 --depth=1 --recursive --shallow-submodules \
     https://github.com/espressif/arduino-esp32.git /opt/arduino-esp32 \
  && rm -rf /opt/arduino-esp32/.git
 
+# mkspiffs (arduino-esp32 0.2.3 flavor) — bakes uploaded files into the SPIFFS
+# data-partition image at compile time. Without it espidf_compiler._build_spiffs_image
+# silently returns None and ships a blank SPIFFS region, so SPIFFS.begin() fails and
+# auto-formats and user-uploaded files never appear (GH #162). Installed at the exact
+# path the runtime locates via IDF_TOOLS_PATH (tools/mkspiffs/*/mkspiffs/mkspiffs).
+RUN mkdir -p /root/.espressif/tools/mkspiffs/0.2.3/mkspiffs \
+ && wget -qO /tmp/mkspiffs.tgz \
+      https://github.com/igrr/mkspiffs/releases/download/0.2.3/mkspiffs-0.2.3-arduino-esp32-linux64.tar.gz \
+ && tar -xzf /tmp/mkspiffs.tgz -C /tmp \
+ && cp /tmp/mkspiffs-0.2.3-arduino-esp32-linux64/mkspiffs \
+       /root/.espressif/tools/mkspiffs/0.2.3/mkspiffs/mkspiffs \
+ && chmod +x /root/.espressif/tools/mkspiffs/0.2.3/mkspiffs/mkspiffs \
+ && rm -rf /tmp/mkspiffs.tgz /tmp/mkspiffs-0.2.3-arduino-esp32-linux64
+
 
 # ---- Stage 1: Build frontend and third-party ----
 FROM node:20 AS frontend-builder


### PR DESCRIPTION
…shed

The SPIFFS upload feature (GH #162) is wired end-to-end — Board Options uploads -> spiffs_files -> espidf_compiler._build_spiffs_image() -> _merge_flash_image() at the partition offset — but the mkspiffs binary it shells out to was never bundled in the image. _locate_mkspiffs() returns None, _build_spiffs_image() logs "mkspiffs not found ... files will be ignored" and returns None, and the merged flash ships with a blank SPIFFS region. The firmware's SPIFFS.begin() then fails to mount, auto-formats, and the uploaded files never appear.

Install the arduino-esp32 0.2.3 flavor of mkspiffs (the exact build referenced by the arduino-esp32 2.0.17 package index, matching the SPIFFS on-disk format SPIFFS.begin() expects) into the espidf-builder stage at the path the runtime already searches (IDF_TOOLS_PATH/tools/mkspiffs/*/mkspiffs/). No code change needed — _build_spiffs_image() works once the binary exists.

LittleFS is a separate follow-up (arduino-esp32 2.0.17's index does not ship mklittlefs; needs sourcing the matching tool + FS-type selection in the compiler).