### PR TITLE
fix(microsd): style the SD Card upload panel for the dark property dialog

### DIFF
--- a/frontend/src/components/simulator/ComponentPropertyDialog.css
+++ b/frontend/src/components/simulator/ComponentPropertyDialog.css
@@ -331,7 +331,7 @@
 
 /* ── microSD "SD Card" upload panel ─────────────────────────────────────── */
 .sd-card-section {
-  border-top: 1px solid var(--border-color, #e2e2e2);
+  border-top: 1px solid #444;
   padding: 8px 10px;
   display: flex;
   flex-direction: column;
@@ -356,7 +356,7 @@
 }
 .sd-card-hint {
   font-size: 11px;
-  color: var(--text-secondary, #777);
+  color: #aaa;
   line-height: 1.3;
 }
 .sd-card-file {
@@ -373,7 +373,7 @@
 }
 .sd-card-file-size {
   flex: 0 0 auto;
-  color: var(--text-secondary, #777);
+  color: #aaa;
   font-variant-numeric: tabular-nums;
 }
 .sd-card-file-remove {
@@ -399,17 +399,22 @@
 }
 .sd-card-add {
   font-size: 12px;
-  padding: 4px 10px;
-  border: 1px solid var(--border-color, #ccc);
+  font-weight: 500;
+  padding: 5px 12px;
+  border: none;
   border-radius: 4px;
-  background: var(--surface, #f6f6f6);
+  background-color: #007acc;
+  color: #fff;
   cursor: pointer;
+  transition: all 0.2s;
 }
 .sd-card-add:hover {
-  background: var(--surface-hover, #ececec);
+  background-color: #005a9e;
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 122, 204, 0.3);
 }
 .sd-card-total {
   font-size: 11px;
-  color: var(--text-secondary, #777);
+  color: #aaa;
   font-variant-numeric: tabular-nums;
 }


### PR DESCRIPTION
## Problem

In the microSD component's property dialog, the "SD Card" upload panel was
styled with light-theme CSS-var fallbacks. The dialog itself is dark
(`#2d2d2d`, white text), so:

- The "+ Add files" button (`var(--surface, #f6f6f6)` + light border) rendered
  as a washed-out light-gray box that looked broken/disabled.
- The section divider (`#e2e2e2`) and secondary text (`#777`) didn't match the
  dialog's dark palette.

## Fix

- Style "+ Add files" as a primary action, matching `.rotate-button`
  (solid `#007acc`, white text, hover lift).
- Use the dialog's dark values for the divider (`#444`) and secondary text
  (`#aaa`).

Cosmetic only; no behaviour change. The upload gate (paid) is unchanged.
