### PR TITLE
fix(ci): auto-increment release version on each Discord announce (baseline 3.0.0)

### DIFF
--- a/.github/workflows/discord-release-notify.yml
+++ b/.github/workflows/discord-release-notify.yml
@@ -72,12 +72,26 @@ jobs:
             }
 
             // ── Version ──────────────────────────────────────────────────────
-            let version = '2.0.1';
+            // The version to announce comes from frontend/package.json on the
+            // release branch. After announcing we bump the PATCH and commit it
+            // back to release, so EACH merge announces a fresh version
+            // (3.0.0 -> 3.0.1 -> 3.0.2 ...) instead of repeating the same one.
+            // To jump the major/minor, edit frontend/package.json on the
+            // release branch (e.g. set "version": "3.1.0") and the next merge
+            // continues from there.
+            let version = '3.0.0';
             try {
               const pkg = JSON.parse(fs.readFileSync('frontend/package.json', 'utf8'));
-              version = pkg.version ?? '2.0.1';
+              version = pkg.version ?? '3.0.0';
             } catch {}
-            console.log(`Version: v${version}`);
+
+            function bumpPatch(v) {
+              const m = String(v).match(/^(\d+)\.(\d+)\.(\d+)/);
+              if (!m) return v;            // leave non-semver strings untouched
+              return `${m[1]}.${m[2]}.${Number(m[3]) + 1}`;
+            }
+            const nextVersion = bumpPatch(version);
+            console.log(`Version: v${version}  ->  next: v${nextVersion}`);
 
             // ── Rango exacto del PR mergeado ──────────────────────────────────
             // base.sha = tip de release ANTES del merge
@@ -178,15 +192,32 @@ jobs:
             fs.writeFileSync(changelogPath, changelogContent, 'utf8');
             console.log('CHANGELOG.md updated');
 
-            // ── Commit y push del CHANGELOG ───────────────────────────────────
+            // ── Bump frontend/package.json to the next patch ──────────────────
+            // This is the fix for the "same version announced every time" bug:
+            // nothing ever advanced the counter. Text-replace so the file's
+            // existing formatting is preserved.
             try {
-              execSync('git add CHANGELOG.md', { stdio: 'inherit' });
+              const pkgPath = 'frontend/package.json';
+              const pkgRaw = fs.readFileSync(pkgPath, 'utf8');
+              const bumped = pkgRaw.replace(
+                /("version"\s*:\s*")[^"]+(")/,
+                `$1${nextVersion}$2`
+              );
+              fs.writeFileSync(pkgPath, bumped, 'utf8');
+              console.log(`Bumped frontend/package.json: ${version} -> ${nextVersion}`);
+            } catch (e) {
+              console.log('package.json bump failed:', e.message);
+            }
+
+            // ── Commit y push del CHANGELOG + version bump ────────────────────
+            try {
+              execSync('git add CHANGELOG.md frontend/package.json', { stdio: 'inherit' });
               execSync(
-                `git commit -m "docs: update CHANGELOG for v${version} [skip ci]"`,
+                `git commit -m "chore: release v${version}, bump to v${nextVersion} [skip ci]"`,
                 { stdio: 'inherit' }
               );
               execSync('git push origin release', { stdio: 'inherit' });
-              console.log('CHANGELOG.md committed and pushed');
+              console.log(`CHANGELOG + version bump committed and pushed (next: v${nextVersion})`);
             } catch (e) {
               console.log('Nothing to commit or push failed:', e.message);
             }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "velxio",
   "homepage": "https://velxio.dev",
   "private": true,
-  "version": "2.0.1",
+  "version": "3.0.0",
   "type": "module",
   "scripts": {
     "generate:metadata": "cd .. && npx tsx scripts/generate-component-metadata.ts",


### PR DESCRIPTION
## Problem

The Discord release-notify workflow read the announced version from
`frontend/package.json` but never wrote it back. Nothing advanced the
counter, so every merge to `release` announced the SAME version -- the
CHANGELOG ended up with two `## [2.0.1]` entries.

## Fix

After generating the CHANGELOG and before announcing, the workflow now bumps
the PATCH in `frontend/package.json` and commits it (with the CHANGELOG) to
`release`. Each merge advances the counter: 3.0.0 -> 3.0.1 -> 3.0.2 ...

Baseline set to **3.0.0** so the next release is announced as v3.0.0.

To jump the major/minor later, edit `frontend/package.json` on the `release`
branch (e.g. `"version": "3.1.0"`) and the next merge continues from there.

## Note on rollout

The workflow that runs for a `master -> release` merge is the one **on the
base branch (`release`)**, not the PR head. So this same fix has already been
pushed directly to `release` (a plain push does not trigger the announce
workflow). This PR keeps `master` -- the source of truth -- in sync.
