### PR TITLE
fix(micropython): write LittleFS files with UTF-8 byte length

### DIFF
--- a/frontend/src/simulation/MicroPythonLoader.ts
+++ b/frontend/src/simulation/MicroPythonLoader.ts
@@ -157,7 +157,13 @@ export async function loadUserFiles(
   for (const file of files) {
     const fileName = file.name;
     const content = file.content;
-    writeFile(lfsInstance, fileName, content, content.length);
+    // cwrap marshals `content` to the WASM heap as UTF-8, so the byte count we
+    // pass must be the UTF-8 length, NOT content.length (UTF-16 code units).
+    // A multi-byte char (e.g. an em-dash in a comment) makes UTF-8 longer, and
+    // passing the shorter content.length truncates the tail of the file —
+    // corrupting the final statement into a SyntaxError at EOF.
+    const byteLength = new TextEncoder().encode(content).length;
+    writeFile(lfsInstance, fileName, content, byteLength);
   }
 
   // Unmount and free


### PR DESCRIPTION
loadUserFiles passed content.length (UTF-16 code units) as the byte count to lfs_write_file, but cwrap marshals the content to the heap as UTF-8. A file with multi-byte chars (e.g. an em-dash in a comment) is then written short by the multi-byte overhead, truncating the tail. The async-LED Wi-Fi example (2 em-dashes) lost its last 4 bytes, turning the final 'asyncio.run(main())' into 'asyncio.run(main' -> SyntaxError at EOF. Use the UTF-8 byte length so the whole file lands; ASCII files are unaffected.