### PR TITLE
build(esp32): ship ESP-IDF 5.5.4 + arduino-esp32 3.3.10 in the standalone image

### DIFF
--- a/Dockerfile.espidf-toolchain
+++ b/Dockerfile.espidf-toolchain
@@ -9,20 +9,32 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libusb-1.0-0 ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Install ESP-IDF 4.4.7 (matches Arduino ESP32 core 2.0.17 / lcgamboa QEMU ROM)
-RUN git clone -b v4.4.7 --recursive --depth=1 --shallow-submodules \
-    https://github.com/espressif/esp-idf.git /opt/esp-idf
+# ESP-IDF v5.5.4 + arduino-esp32 3.3.10 — the same pair velxio.dev builds
+# with. espidf_compiler discovers them at /opt/esp-idf-v5 and
+# /opt/arduino-esp32-3 (overridable via IDF5_PATH / ARDUINO_ESP32_5_PATH) and
+# routes every ESP32-family Arduino build through them (_use_idf5).
+#
+# History: until 2026-08 this stage pinned IDF 4.4.7 + core 2.0.17 because
+# the original qemu-8.1.3 WiFi shim crashed on IDF 5.x cache handling. The
+# current libqemu builds run IDF 5.x firmware, and velxio.dev moved to the
+# 3.x core; shipping 2.0.17 here meant sketches written on velxio.dev
+# (ledcAttach, esp_now_recv_info_t, the esp_task_wdt config API, ...) did
+# not compile on a self-hosted image.
+RUN git clone -b v5.5.4 --recursive --depth=1 --shallow-submodules \
+    https://github.com/espressif/esp-idf.git /opt/esp-idf-v5
 
-WORKDIR /opt/esp-idf
+WORKDIR /opt/esp-idf-v5
 
-# Install toolchains for esp32 (Xtensa) and esp32c3 (RISC-V) only
-RUN ./install.sh esp32,esp32c3
+# Every family toolchain. Classic-ESP32 builds need the v5.5 xtensa toolchain
+# too: with only the RISC-V targets installed they silently pick whatever GCC
+# is on PATH and die mid-build on newlib header mismatches.
+RUN ./install.sh esp32,esp32s3,esp32c3,esp32c6
 
 # Clean up large unnecessary files to reduce image size
 RUN rm -rf .git docs examples \
     && find /root/.espressif -name '*.tar.*' -delete 2>/dev/null || true
 
-# Install Arduino-as-component for full Arduino API support in ESP-IDF builds
-RUN git clone --branch 2.0.17 --depth=1 --recursive --shallow-submodules \
-    https://github.com/espressif/arduino-esp32.git /opt/arduino-esp32 \
- && rm -rf /opt/arduino-esp32/.git
+# Arduino-as-component (3.x core, IDF 5.5 based) for full Arduino API support
+RUN git clone --branch 3.3.10 --depth=1 --recursive --shallow-submodules \
+    https://github.com/espressif/arduino-esp32.git /opt/arduino-esp32-3 \
+ && rm -rf /opt/arduino-esp32-3/.git

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -99,23 +99,35 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libusb-1.0-0 ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Install ESP-IDF 4.4.7 (matches Arduino ESP32 core 2.0.17 / lcgamboa QEMU ROM)
-RUN git clone -b v4.4.7 --recursive --depth=1 --shallow-submodules \
-    https://github.com/espressif/esp-idf.git /opt/esp-idf
+# ESP-IDF v5.5.4 + arduino-esp32 3.3.10 — the same pair velxio.dev builds
+# with. espidf_compiler discovers them at /opt/esp-idf-v5 and
+# /opt/arduino-esp32-3 (overridable via IDF5_PATH / ARDUINO_ESP32_5_PATH) and
+# routes every ESP32-family Arduino build through them (_use_idf5).
+#
+# History: until 2026-08 this stage pinned IDF 4.4.7 + core 2.0.17 because
+# the original qemu-8.1.3 WiFi shim crashed on IDF 5.x cache handling. The
+# current libqemu builds run IDF 5.x firmware, and velxio.dev moved to the
+# 3.x core; shipping 2.0.17 here meant sketches written on velxio.dev
+# (ledcAttach, esp_now_recv_info_t, the esp_task_wdt config API, ...) did
+# not compile on a self-hosted image.
+RUN git clone -b v5.5.4 --recursive --depth=1 --shallow-submodules \
+    https://github.com/espressif/esp-idf.git /opt/esp-idf-v5
 
-WORKDIR /opt/esp-idf
+WORKDIR /opt/esp-idf-v5
 
-# Install toolchains for esp32 (Xtensa) and esp32c3 (RISC-V) only
-RUN ./install.sh esp32,esp32c3
+# Every family toolchain. Classic-ESP32 builds need the v5.5 xtensa toolchain
+# too: with only the RISC-V targets installed they silently pick whatever GCC
+# is on PATH and die mid-build on newlib header mismatches.
+RUN ./install.sh esp32,esp32s3,esp32c3,esp32c6
 
 # Clean up large unnecessary files to reduce image size
 RUN rm -rf .git docs examples \
     && find /root/.espressif -name '*.tar.*' -delete 2>/dev/null || true
 
-# Install Arduino-as-component for full Arduino API support in ESP-IDF builds
-RUN git clone --branch 2.0.17 --depth=1 --recursive --shallow-submodules \
-    https://github.com/espressif/arduino-esp32.git /opt/arduino-esp32 \
- && rm -rf /opt/arduino-esp32/.git
+# Arduino-as-component (3.x core, IDF 5.5 based) for full Arduino API support
+RUN git clone --branch 3.3.10 --depth=1 --recursive --shallow-submodules \
+    https://github.com/espressif/arduino-esp32.git /opt/arduino-esp32-3 \
+ && rm -rf /opt/arduino-esp32-3/.git
 
 # mkspiffs (arduino-esp32 0.2.3 flavor) — bakes uploaded files into the SPIFFS
 # data-partition image at compile time. Without it espidf_compiler._build_spiffs_image
@@ -252,10 +264,17 @@ ENV QEMU_RISCV32_LIB=/app/lib/libqemu-riscv32.so
 
 # ── ESP-IDF toolchain for ESP32 compilation ──────────────────────────────────
 # Copied from espidf-builder stage: IDF framework + cross-compiler toolchains
-COPY --from=espidf-builder /opt/esp-idf /opt/esp-idf
+COPY --from=espidf-builder /opt/esp-idf-v5 /opt/esp-idf-v5
 COPY --from=espidf-builder /root/.espressif /root/.espressif
+COPY --from=espidf-builder /opt/arduino-esp32-3 /opt/arduino-esp32-3
 
-COPY --from=espidf-builder /opt/arduino-esp32 /opt/arduino-esp32
+# Legacy-path symlinks: espidf_compiler hardcodes /opt/esp-idf (version
+# signature, IDF_PATH default) and /opt/arduino-esp32, and the entrypoint
+# sources /opt/esp-idf/export.sh. Pointing both at the v5 trees keeps every
+# read site working; the compiler still discovers the v5 install through
+# /opt/esp-idf-v5 and /opt/arduino-esp32-3.
+RUN ln -sn /opt/esp-idf-v5 /opt/esp-idf \
+ && ln -sn /opt/arduino-esp32-3 /opt/arduino-esp32
 
 # Memoize ldgen. It re-parses every component's linker.lf with pyparsing on
 # EVERY build - measured at 15.2 s here, 41% of a whole ESP-IDF compile of a
@@ -331,10 +350,31 @@ RUN mkdir -p /var/cache/ccache /var/lib/velxio-build /root/Arduino
 # /var/lib/velxio-build — persistent ESP-IDF build dir (one subdir per target)
 VOLUME ["/app/data", "/root/.arduino15", "/root/Arduino", "/var/cache/ccache", "/var/lib/velxio-build"]
 
-# Install ESP-IDF Python dependencies using the final image's Python
-# The requirements.txt has version constraints required by ESP-IDF 4.4.x
-RUN grep -v 'esp-windows-curses' /opt/esp-idf/requirements.txt \
-    | pip install --no-cache-dir -r /dev/stdin
+# Recreate the IDF v5.5 Python env with THIS stage's python. The
+# espidf-builder created it with its own python (3.10) and a venv's
+# site-packages are version-scoped, so the copied env cannot even import
+# `packaging` here; IDF's cmake also derives the env dir name from the
+# RUNNING python (idf5.5_py3.12_env) and fails with "python doesn't exist"
+# when it is missing. Every ESP32-family compile routes through the v5
+# tree, so a broken v5 env means no ESP32 compiles at all.
+RUN rm -rf /root/.espressif/python_env/idf5.5_* \
+ && rm -f /root/.espressif/espidf.constraints.v5.5.txt \
+ && cd /opt/esp-idf-v5 \
+ && ./tools/idf_tools.py install-python-env \
+ # The v5.5.4 snapshot is internally inconsistent: its cmake hardcodes
+ # component-manager interface_version 4 (project.cmake:64) while its
+ # requirements pin idf-component-manager~=2.2, whose CLI tops out at
+ # interface 3. Interface 4 lives in the 3.x line — install it and relax
+ # both pins so the cmake python dependency check accepts the pairing.
+ && /root/.espressif/python_env/idf5.5_*/bin/pip install "idf-component-manager>=3.1,<4" \
+ && sed -i 's/^idf-component-manager.*/idf-component-manager>=2.2,<4/' \
+      /root/.espressif/espidf.constraints.v5.5.txt \
+      /opt/esp-idf-v5/tools/requirements/requirements.core.txt \
+ && find /root/.espressif -name '*.tar.*' -delete 2>/dev/null || true
+
+# System-python IDF deps. IDF 5.x has no root requirements.txt (the 4.4
+# tree did); its equivalent is tools/requirements/requirements.core.txt.
+RUN pip install --no-cache-dir -r /opt/esp-idf-v5/tools/requirements/requirements.core.txt
 
 EXPOSE 80
 

--- a/README.md
+++ b/README.md
@@ -364,10 +364,11 @@ arduino-cli config add board_manager.additional_urls \
 arduino-cli core install ATTinyCore:avr
 ```
 
-> ESP32 (Xtensa) compilation in manual install requires the ESP-IDF 4.4.7
-> toolchain installed locally. The Docker image bundles this — for manual
-> installs see [docs/ESP32_EMULATION.md](docs/ESP32_EMULATION.md). If you
-> only need AVR / RP2040 boards you can skip ESP-IDF entirely.
+> ESP32 (Xtensa / RISC-V) compilation in a manual install requires ESP-IDF
+> v5.5.4 plus the arduino-esp32 3.3.10 core installed locally, the same pair
+> velxio.dev builds with. The Docker image bundles both — for manual installs
+> see [docs/ESP32_EMULATION.md](docs/ESP32_EMULATION.md). If you only need
+> AVR / RP2040 boards you can skip ESP-IDF entirely.
 
 ---
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -54,7 +54,8 @@ if [ -d /opt/arduino15-seed ]; then
 fi
 
 # Install missing cores.
-# ESP32 core MUST be 2.0.17 (IDF 4.4.x) — newer 3.x is incompatible with QEMU ROM bins.
+# ESP32 builds use ESP-IDF 5.5.4 + arduino-esp32 3.3.10 (the velxio.dev pair);
+# the arduino-cli 3.x core below is only the fallback when ESP-IDF is absent.
 arduino-cli core update-index 2>/dev/null || true
 arduino-cli core install arduino:avr 2>/dev/null || true
 arduino-cli core install rp2040:rp2040 2>/dev/null || true
@@ -70,13 +71,17 @@ if [ -f /opt/esp-idf/export.sh ]; then
     echo "✅ ESP-IDF $(cat /opt/esp-idf/version.txt 2>/dev/null || echo 'unknown') ready"
 else
     echo "⚠️  ESP-IDF not found — falling back to arduino-cli for ESP32"
+    # 3.x core (IDF 5.5 based), matching the arduino-esp32 3.3.10 the image
+    # builds with under ESP-IDF; 3.3.9 is the newest 3.3.x the board manager
+    # index carries. Sketches written on velxio.dev use 3.x-only APIs.
+    ESP32_CORE_VERSION=3.3.9
     ESP32_VER=$(arduino-cli core list 2>/dev/null | grep esp32:esp32 | awk '{print $2}')
     if [ -z "$ESP32_VER" ]; then
-        echo "📦 Installing ESP32 core 2.0.17..."
-        arduino-cli core install esp32:esp32@2.0.17
-    elif [[ "$ESP32_VER" != 2.0.17 ]]; then
-        echo "⚠️  ESP32 core is $ESP32_VER, need 2.0.17 — reinstalling..."
-        arduino-cli core install esp32:esp32@2.0.17
+        echo "Installing ESP32 core ${ESP32_CORE_VERSION}..."
+        arduino-cli core install esp32:esp32@${ESP32_CORE_VERSION}
+    elif [[ "$ESP32_VER" != ${ESP32_CORE_VERSION} ]]; then
+        echo "ESP32 core is $ESP32_VER, need ${ESP32_CORE_VERSION} - reinstalling..."
+        arduino-cli core install esp32:esp32@${ESP32_CORE_VERSION}
     fi
 fi
 

--- a/docs/ESP32C3_WIFI_BLUETOOTH.md
+++ b/docs/ESP32C3_WIFI_BLUETOOTH.md
@@ -280,8 +280,8 @@ python -m pytest tests/test_esp32c3_wifi.py -v
 
 ### La compilación falla para ESP32-C3
 
-- **ESP-IDF (producción)**: Los sketches ESP32-C3 se compilan con ESP-IDF 4.4.7 (`IDF_TARGET=esp32c3`). El backend traduce Arduino WiFi/WebServer a ESP-IDF C nativo.
-- **Fallback arduino-cli**: `arduino-cli core install esp32:esp32@2.0.17` (incluye soporte C3).
+- **ESP-IDF (producción)**: Los sketches ESP32-C3 se compilan con ESP-IDF 5.5.4 y el core arduino-esp32 3.3.10 (`IDF_TARGET=esp32c3`). El backend traduce Arduino WiFi/WebServer a ESP-IDF C nativo.
+- **Fallback arduino-cli**: `arduino-cli core install esp32:esp32@3.3.9` (incluye soporte C3).
 
 ### WiFi no se activa
 - Verifica que tu sketch incluya `#include <WiFi.h>`

--- a/docs/ESP32_EMULATION.md
+++ b/docs/ESP32_EMULATION.md
@@ -1,7 +1,7 @@
 # ESP32 Emulation (Xtensa) — Technical Documentation
 
 > Status: **Functional** · Backend complete · Frontend complete
-> Engine: **lcgamboa/qemu-8.1.3** · Platform: **arduino-esp32 2.0.17 (IDF 4.4.x)**
+> Engine: **libqemu 1.2.x (lcgamboa QEMU fork, 9.2 base)** · Platform: **arduino-esp32 3.3.10 (IDF 5.5.4)**
 > Available on: **Windows** (`.dll`) · **Linux / Docker** (`.so`, included in the official image)
 > Applies to: **ESP32, ESP32-S3** (Xtensa LX6/LX7 architecture)
 
@@ -83,26 +83,45 @@ pacman -S \
   git diffutils
 ```
 
-### 1.3 Install arduino-cli and the ESP32 2.0.17 Core
+### 1.3 Install the ESP32 toolchain (ESP-IDF 5.5.4 + arduino-esp32 3.3.10)
+
+The backend compiles ESP32-family sketches with ESP-IDF and the arduino-esp32
+core as a component. This is what the Docker image and velxio.dev use, so a
+sketch that builds on velxio.dev builds identically here.
 
 ```bash
-# Install arduino-cli (if not already installed)
-winget install ArduinoSA.arduino-cli
+# ESP-IDF v5.5.4 with every family toolchain
+git clone -b v5.5.4 --recursive --depth=1 --shallow-submodules \
+    https://github.com/espressif/esp-idf.git /opt/esp-idf-v5
+cd /opt/esp-idf-v5 && ./install.sh esp32,esp32s3,esp32c3,esp32c6
 
-# Verify
-arduino-cli version
-
-# Add ESP32 support
-arduino-cli core update-index
-arduino-cli core install esp32:esp32@2.0.17   # ← IMPORTANT: 2.x, NOT 3.x
-
-# Verify
-arduino-cli core list   # should show esp32:esp32  2.0.17
+# arduino-esp32 3.3.10 (IDF 5.5 based) as a component
+git clone --branch 3.3.10 --depth=1 --recursive --shallow-submodules \
+    https://github.com/espressif/arduino-esp32.git /opt/arduino-esp32-3
 ```
 
-> **Why 2.0.17 and not 3.x?** The lcgamboa emulated WiFi periodically disables the SPI flash cache.
-> In IDF 5.x (arduino-esp32 3.x) this causes a cache crash when core 0 interrupts
-> try to execute code from IROM. IDF 4.4.x has different, compatible cache behavior.
+`espidf_compiler` discovers both at those paths. Elsewhere, point it there
+with `IDF5_PATH` and `ARDUINO_ESP32_5_PATH` (and set `IDF_PATH` /
+`ARDUINO_ESP32_PATH` to the same trees for the code paths that read the
+legacy names). `VELXIO_ARDUINO_IDF5=0` forces a 4.4-era tree when one is
+installed alongside; `=1` forces v5.
+
+Without ESP-IDF the backend falls back to arduino-cli. Use the 3.x core
+there too, or velxio.dev sketches will not compile:
+
+```bash
+arduino-cli core update-index
+arduino-cli core install esp32:esp32@3.3.9   # newest 3.3.x in the board manager index
+arduino-cli core list                          # should show esp32:esp32  3.3.9
+```
+
+> **Why 3.x?** Until August 2026 this document pinned 2.0.17 because the
+> original qemu-8.1.3 WiFi shim crashed on IDF 5.x cache handling. The
+> current libqemu builds run IDF 5.x firmware, and velxio.dev moved to the
+> 3.x core. Sketches that still use APIs removed in 3.0 (`ledcSetup` /
+> `ledcAttachPin`, the old `timerBegin` signature, the `esp_now` receive
+> callback with a bare MAC pointer) need the changes from Espressif's
+> [2.x to 3.0 migration guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/migration_guides/2.x_to_3.0.html).
 
 ### 1.4 Install esptool
 
@@ -558,16 +577,21 @@ manager.get_status(client_id)                         # → dict with runtime st
 
 ### 5.1 Required Platform Version
 
-**✅ Use: arduino-esp32 2.x (IDF 4.4.x)**
-**❌ Do not use: arduino-esp32 3.x (IDF 5.x)**
+**Use: arduino-esp32 3.3.10 on ESP-IDF 5.5.4** (the pair velxio.dev builds
+with; see section 1.3). With arduino-cli instead of ESP-IDF, use
+`esp32:esp32@3.3.9`.
 
-```bash
-arduino-cli core install esp32:esp32@2.0.17
-```
+arduino-esp32 2.0.17 (IDF 4.4.7) was the pin until August 2026 and still
+boots on libqemu, but sketches written on velxio.dev use 3.x APIs and do not
+compile against it.
 
-**Why:** The lcgamboa emulated WiFi (core 1) periodically disables the SPI flash cache. In IDF 5.x this causes a crash when core 0 interrupts try to execute code from IROM (flash cache). In IDF 4.4.x the cache behavior is different and compatible.
+**Historical note:** the 2.0.17 pin existed because the original qemu-8.1.3
+WiFi shim (core 1) periodically disabled the SPI flash cache, and IDF 5.x
+firmware crashed when core 0 interrupts executed from IROM. The current
+libqemu builds do not have that problem. If you run an old library you may
+still see it:
 
-**Crash message (IDF 5.x):**
+**Crash message (IDF 5.x on the old qemu-8.1.3 shim):**
 ```
 Guru Meditation Error: Core  / panic'ed (Cache error).
 Cache disabled but cached memory region accessed
@@ -632,7 +656,7 @@ void IRAM_ATTR setup() {
 void IRAM_ATTR loop() { ets_delay_us(1000000); }
 ```
 
-**Normal Arduino sketches** (with `Serial.print`, `delay`, `digitalWrite`) also work correctly with IDF 4.4.x.
+**Normal Arduino sketches** (with `Serial.print`, `delay`, `digitalWrite`) also work correctly with the current toolchain.
 
 ---
 
@@ -1148,7 +1172,7 @@ The connection logic lives in `SimulatorCanvas.tsx`: it detects the tag of the w
 | **No capacitive touch** | `touchRead()` has no callback in picsimlab | Not available |
 | **No DAC** | GPIO25/GPIO26 analog output not exposed by picsimlab | Not available |
 | **Fixed flash at 4MB** | Hardcoded in the esp32-picsimlab machine | Recompile the lib |
-| **arduino-esp32 3.x causes crash** | IDF 5.x handles cache differently from the emulated WiFi | Use 2.x (IDF 4.4.x) |
+| **2.x-era sketches fail to compile** | The toolchain is arduino-esp32 3.3.10; `ledcSetup` / `ledcAttachPin` and other 2.x-only APIs were removed in 3.0 | Follow Espressif's 2.x to 3.0 migration guide |
 | **ADC only on pins defined in `ESP32_ADC_PIN_MAP`** | The GPIO→ADC channel mapping is static in the frontend | Update `ESP32_ADC_PIN_MAP` in `Esp32Element.ts` |
 
 ---

--- a/docs/ESP32_WIFI_BLUETOOTH.md
+++ b/docs/ESP32_WIFI_BLUETOOTH.md
@@ -594,9 +594,9 @@ python -m pytest tests/test_esp32_wifi.py tests/test_esp32c3_wifi.py tests/test_
 - Ejemplo: `http.begin("http://httpbin.org/get")` funciona, `ping google.com` no
 
 ### La compilación falla
-- **ESP-IDF (producción)**: Los sketches ESP32 se compilan ahora con ESP-IDF 4.4.7 en lugar de arduino-cli. El backend traduce automáticamente Arduino WiFi/WebServer a ESP-IDF C nativo. Verifica que `IDF_PATH` esté configurado.
-- **Fallback arduino-cli**: Si ESP-IDF no está disponible, se usa arduino-cli. Instala el core:
+- **ESP-IDF (producción)**: Los sketches ESP32 se compilan con ESP-IDF 5.5.4 y el core arduino-esp32 3.3.10 en lugar de arduino-cli (lo mismo que velxio.dev). El backend traduce automáticamente Arduino WiFi/WebServer a ESP-IDF C nativo. Verifica que `IDF_PATH` esté configurado.
+- **Fallback arduino-cli**: Si ESP-IDF no está disponible, se usa arduino-cli. Instala el core 3.x:
   ```bash
-  arduino-cli core install esp32:esp32@2.0.17
+  arduino-cli core install esp32:esp32@3.3.9
   ```
 - El FQBN correcto es `esp32:esp32:esp32` (no `esp32:esp32:esp32dev`)

--- a/docs/RISCV_EMULATION.md
+++ b/docs/RISCV_EMULATION.md
@@ -505,7 +505,7 @@ The `esp32c3-picsimlab` QEMU machine in the lcgamboa fork emulates the core CPU 
 | Hardware I2C / SPI | Not emulated | Callbacks not registered |
 | Interrupts (`attachInterrupt`) | Not emulated | GPIO interrupt lines not connected |
 | NVS / SPIFFS | Not emulated | Flash writes not persisted |
-| arduino-esp32 3.x (IDF 5.x) | **Unsupported** | Use 2.0.17 (IDF 4.4.x) — same as Xtensa |
+| arduino-esp32 2.x (IDF 4.4.x) | Legacy | Toolchain is 3.3.10 (IDF 5.5.4), same as Xtensa; 2.x-only APIs do not compile |
 
 > The QEMU machine boots the ESP-IDF bootloader and transitions to the Arduino `setup()`/`loop()` correctly for GPIO and UART sketches. Sketches using WiFi, LEDC, or RMT will boot but those peripherals will silently do nothing.
 
@@ -599,7 +599,7 @@ frontend/src/__tests__/fixtures/esp32c3-blink/
 | NeoPixel/RMT | Not emulated | Emulated (RMT decoder in worker) |
 | I2C / SPI | Not emulated | Emulated (synchronous QEMU callbacks) |
 | GPIO32–39 fix | N/A (only 22 GPIOs) | Required (bank 1 register) |
-| Arduino framework | Full (IDF 4.4.x) | Full (IDF 4.4.x) |
+| Arduino framework | Full (IDF 5.5.x) | Full (IDF 5.5.x) |
 | ISA unit tests | Yes (Vitest — RiscVCore.ts) | No (requires native lib) |
 
 ---

--- a/docs/emulator.md
+++ b/docs/emulator.md
@@ -123,7 +123,7 @@ Backed by the **[lcgamboa QEMU fork](https://github.com/lcgamboa/qemu)** running
 | WiFi | SLIRP NAT — connect with `WiFi.begin("PICSimLabWifi", "")` |
 | BLE | Advertising + basic GAP via QEMU's BLE shim |
 
-Toolchain pinned to **arduino-esp32 2.0.17 (IDF 4.4.x)** — only version compatible with the lcgamboa WiFi shim. ESP-IDF projects (`idf.py`) supported via the [espidf_compiler](../backend/app/services/espidf_compiler.py) wrapper.
+Toolchain pinned to **arduino-esp32 3.3.10 (IDF 5.5.4)**, the same pair velxio.dev builds with. ESP-IDF projects (`idf.py`) supported via the [espidf_compiler](../backend/app/services/espidf_compiler.py) wrapper.
 
 See [ESP32 Emulation](./ESP32_EMULATION.md) for setup and architectural details, [ESP32 WiFi/Bluetooth](./ESP32_WIFI_BLUETOOTH.md) for the radio stack.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -109,11 +109,13 @@ arduino-cli config add board_manager.additional_urls \
   http://drazzy.com/package_drazzy.com_index.json
 arduino-cli core install ATTinyCore:avr
 
-# For ESP32 / ESP32-S3 / ESP32-C3 (Arduino core 2.0.17 — the only version
-# compatible with the lcgamboa WiFi shim):
+# For ESP32 / ESP32-S3 / ESP32-C3 the backend prefers ESP-IDF 5.5.4 with the
+# arduino-esp32 3.3.10 core (see docs/ESP32_EMULATION.md, section 1.3). The
+# arduino-cli core is the fallback when ESP-IDF is not installed; use the
+# 3.x line so velxio.dev sketches compile:
 arduino-cli config add board_manager.additional_urls \
   https://espressif.github.io/arduino-esp32/package_esp32_index.json
-arduino-cli core install esp32:esp32@2.0.17
+arduino-cli core install esp32:esp32@3.3.9
 ```
 
 ---
@@ -191,7 +193,7 @@ Click **Examples** in the nav bar, filter by board or category, and click **Load
 | LED doesn't blink | Open the component property dialog and verify the Arduino pin assignment. Check the browser console for port-listener errors. |
 | Serial Monitor is empty | Ensure `Serial.begin()` is called inside `setup()`. |
 | Compilation errors | Open the compilation console at the bottom of the editor for full toolchain output. |
-| ESP32 fails to boot | Use `esp32:esp32@2.0.17` (the only version compatible with the lcgamboa WiFi shim). Check `libqemu-xtensa.{dll,so,dylib}` is present in `backend/app/services/`. |
+| ESP32 fails to boot | Build with the 3.x core (ESP-IDF 5.5.4 + arduino-esp32 3.3.10, or `esp32:esp32@3.3.9` via arduino-cli). Check `libqemu-xtensa.{dll,so,dylib}` is present in `backend/app/services/`. |
 | Pi 3 takes 5+ seconds to start | Expected — QEMU boots a full Raspberry Pi OS. The "booting" status is normal. |
 | Analog probe reads 0 V | Make sure both ends of the wire actually land on a pin (the wire turns blue when valid). Re-check ground connections. |
 | Custom chip won't compile | The custom-chip toolchain ships in the Docker image. For manual setups, see [Custom Chips: Build & Test](./wiki/custom-chips-build-and-test.md). |


### PR DESCRIPTION
## Why

The self-host image (`Dockerfile.standalone`, what GHCR publishes) still pinned ESP-IDF 4.4.7 + arduino-esp32 2.0.17, while velxio.dev moved to ESP-IDF 5.5.4 + arduino-esp32 3.3.10 on 2026-08-07 and dropped the 2.x core. A sketch written on velxio.dev (`ledcAttach`, the `esp_now_recv_info_t` receive callback, the `esp_task_wdt` config API) therefore failed to compile on a self-hosted server; a self-hoster reported exactly that on 2026-09-03.

The backend already routes every ESP32-family Arduino build through the v5 tree + 3.x core when both exist (`espidf_compiler._use_idf5`); only the image was behind.

## What changes

- `Dockerfile.standalone` / `Dockerfile.espidf-toolchain`: clone IDF v5.5.4 with every family toolchain (`esp32,esp32s3,esp32c3,esp32c6`) and arduino-esp32 3.3.10 at `/opt/esp-idf-v5` and `/opt/arduino-esp32-3`; symlink the legacy `/opt/esp-idf` and `/opt/arduino-esp32` paths; recreate the IDF python env with the final stage's python and pin `idf-component-manager` (the same fixes the velxio.dev image carries).
- `docker/entrypoint.sh`: the arduino-cli fallback (only used when ESP-IDF is absent) installs the 3.x core (3.3.9, newest in the board manager index). This path is not exercised by the image and was not tested here.
- Docs: drop the "2.0.17, never 3.x" guidance (it dated from the qemu-8.1.3 WiFi shim, which the current libqemu builds no longer have) and document the 3.x pair plus the `IDF5_PATH` / `ARDUINO_ESP32_5_PATH` / `VELXIO_ARDUINO_IDF5` knobs.

## Compatibility note for self-hosters

This moves the self-host image to the same toolchain as velxio.dev. Sketches that still use APIs removed in arduino-esp32 3.0 (`ledcSetup` / `ledcAttachPin`, the old `timerBegin` signature, the ESP-NOW receive callback with a bare MAC pointer) need the changes from Espressif's 2.x to 3.0 migration guide, exactly as on velxio.dev.

## Verification

Done locally on the prod box (amd64) against this branch, 2026-09-03:

1. `docker build -f Dockerfile.standalone` with the prebuilt libqemu 1.2.7 libs dropped into `prebuilt/qemu/`: exit 0, image 6.81 GB. The python-env step and the `idf-component-manager` pin behave as in the velxio.dev image.
2. Container startup logs the discovery lines: `[espidf] IDF v5.x (esp32c6): /opt/esp-idf-v5` and `[espidf] arduino-esp32 3.x core (IDF5): /opt/arduino-esp32-3`; `/opt/esp-idf` and `/opt/arduino-esp32` resolve through the symlinks; the venv is `idf5.5_py3.12_env`.
3. A sketch that only builds on 3.x (`#error` below `ESP_ARDUINO_VERSION_VAL(3,0,0)`, `ledcAttach`, `esp_now_register_recv_cb` with `esp_now_recv_info_t`, `esp_task_wdt_reconfigure`, WiFi + WebServer) compiled through `POST /api/compile/start` for `esp32:esp32:esp32`: `state=done`, `error=null`, 343 s cold (`velxio-sketch.bin` 0xd00d0 bytes).
4. The same sketch run from the real editor page (workspace draft + Run, headless Chromium) booted on the bundled libqemu: serial shows `VELXIO_IDF5_TEST core=3.3.10`, then `tick N wifi=3` (WL_CONNECTED) for 10+ seconds, no crash, ESP-NOW init and the WebServer running.

Not exercised: the arduino-cli fallback in `docker/entrypoint.sh` (only runs when ESP-IDF is absent) and the linux/arm64 build that CI produces.

Note for anyone building locally without a license key: the classic-ESP32 machine also needs `esp32-v3-rom.bin` / `esp32-v3-rom-app.bin` in `prebuilt/qemu/`; with only the two `.so` files the QEMU worker exits with code 1 at boot. The gated download fetches them automatically.
