### PR TITLE
fix(desktop): the editor toolbar vanished from the desktop app (0.4.7)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -552,6 +552,14 @@ body {
 .app-header--with-toolbar .header-left {
   gap: 6px;
 }
+/* Tauri desktop: the header is the toolbar strip and nothing else — the
+   brand and the menus live in the native title bar / menubar. */
+.app-header--desktop .header-left {
+  display: none;
+}
+.app-header--desktop .header-editor-toolbar {
+  margin-left: 0;
+}
 
 .app-header--with-toolbar .header-content {
   align-items: stretch;

--- a/frontend/src/components/layout/AppHeader.tsx
+++ b/frontend/src/components/layout/AppHeader.tsx
@@ -93,16 +93,31 @@ export const AppHeader: React.FC<AppHeaderProps> = ({ editorMenu, editorToolbar 
     };
   }, [hasStrip]);
 
-  // Tauri desktop: skip the header entirely. The marketing nav was
-  // already hidden, but the strip itself was still painting an empty
-  // black bar over the editor. Brand/auto-save/share/auth-slot all
-  // live elsewhere in desktop: title bar shows "Velxio Desktop", the
-  // native menubar has File/Edit/View/Help, auto-save is a Pro cloud
-  // feature (desktop saves to .vlx), share generates a velxio.dev URL
-  // that doesn't apply to a desktop session, and the license flow
-  // owns its own DesktopWelcomePage.
+  // Tauri desktop: no brand row. Brand/auto-save/share/auth-slot all live
+  // elsewhere in desktop: the title bar shows "Velxio Desktop", the native
+  // menubar has File/Edit/View/Help, auto-save is a Pro cloud feature
+  // (desktop saves to .vlx), share generates a velxio.dev URL that doesn't
+  // apply to a desktop session, and the license flow owns its own
+  // DesktopWelcomePage.
+  //
+  // This used to `return null` outright, back when the strip below the
+  // header was empty in desktop and painted a black bar. Since the editor
+  // toolbar strip (Compile / Run / Libraries, board + canvas controls)
+  // moved INSIDE this header (`editorToolbar`, 2026-08), that early return
+  // dropped the whole strip from the desktop app: 0.4.7 shipped with no
+  // Compile, Run or Libraries button. Render the strip alone, in the same
+  // .header-content > .header-editor-toolbar structure headerStripFit.ts
+  // measures, with an empty .header-left so the whole row is toolbar.
   if (import.meta.env.VITE_DESKTOP) {
-    return null;
+    if (!editorToolbar) return null;
+    return (
+      <header ref={headerRef} className="app-header app-header--with-toolbar app-header--desktop">
+        <div className="header-content">
+          <div className="header-left" />
+          <div className="header-editor-toolbar">{editorToolbar}</div>
+        </div>
+      </header>
+    );
   }
 
   // Compare with the trailing slash ignored: /editor is served (and


### PR DESCRIPTION
## Symptom

A desktop user upgrading 0.4.2 -> 0.4.7 reported that the Compile, Run and Libraries buttons are gone. They are: the whole editor toolbar strip (Code/Both/Circuit, compile, run, stop, Libraries, serial, theme switch) is missing in the desktop app, only the canvas controls that `SimulatorCanvas` paints on its own remain.

## Cause

On 2026-08-18 the editor toolbar strip moved inside `AppHeader` (`editorToolbar` prop, one 44px row). `AppHeader` has had `if (import.meta.env.VITE_DESKTOP) return null;` since May, from when the strip below the header was empty in desktop and painted a black bar. After the move that early return drops the entire toolbar in the Tauri build. 0.4.2 predates the move; 0.4.7 (built 2026-08-23) includes it, and so does current master, so a new desktop release from master without this fix would ship the same bug.

## Fix

Under `VITE_DESKTOP` the header renders the strip alone, in the same `.header-content > .header-editor-toolbar` structure `headerStripFit.ts` measures, with an empty hidden `.header-left` (brand and menus keep living in the native title bar and menubar). Without an `editorToolbar` (non-editor routes) it still renders nothing. Two small CSS rules under `.app-header--desktop`.

## Verification

Two `VITE_DESKTOP=true` builds of the OSS frontend served in a headless browser at `/editor`:

- master: no `header.app-header`, no `.unified-toolbar`, no compile/run/libraries buttons (matches the report).
- this branch: a 45px `header.app-header.app-header--with-toolbar.app-header--desktop` row with Code/Both/Circuit, compile, run, stop, Libraries, serial and the theme switch, next to the canvas controls; `tsc --noEmit` clean.

Not exercised: the real Tauri shell (needs a desktop build); the strip-fit measurement runs unchanged, with `.header-left` at 0px.

Needs a desktop release (0.4.8) to reach users; the web build is unaffected.
