### PR TITLE
fix(espidf): one compile per build variant, and heal a corrupted managed component

### DIFF
--- a/backend/app/services/espidf_compiler.py
+++ b/backend/app/services/espidf_compiler.py
@@ -244,6 +244,55 @@ def _run_with_streaming(
 _MAX_BUILD_VARIANTS = 6
 
 
+# One compile at a time per build variant. The build queue bounds how many
+# compiles run at once, not WHERE they run: two requests that hash to the same
+# variant (the deploy gate's smoke fired the S3 OLED example twice, 13 s
+# apart) shared one project dir, and the second configure walked into the
+# first one's half-copied managed component. The component manager then
+# reported it "corrupted" on every later attempt, and that variant was dead
+# until someone deleted it by hand (2026-09-03).
+_VARIANT_LOCKS: dict[str, asyncio.Lock] = {}
+_VARIANT_LOCKS_GUARD = threading.Lock()
+
+
+def _variant_lock(key: str) -> asyncio.Lock:
+    """The lock that serialises compiles inside one persistent build variant."""
+    with _VARIANT_LOCKS_GUARD:
+        lock = _VARIANT_LOCKS.get(key)
+        if lock is None:
+            lock = _VARIANT_LOCKS[key] = asyncio.Lock()
+        return lock
+
+
+_CORRUPT_COMPONENT_RE = re.compile(
+    r'The downloaded component "([^"]+)"\s+is\s+corrupted', re.IGNORECASE
+)
+
+
+def _corrupt_managed_component(stderr: str | None) -> str | None:
+    """Name of the managed component the IDF component manager refused as
+    corrupted (its message wraps across lines), or None for any other cmake
+    failure."""
+    m = _CORRUPT_COMPONENT_RE.search(stderr or '')
+    return m.group(1) if m else None
+
+
+def _heal_corrupt_managed_components(project_dir: Path, build_dir: Path) -> bool:
+    """Drop the variant's managed_components/ (the component manager copies
+    them back from its own intact cache on the next configure) and the cmake
+    cache that recorded them. Returns True when there was something to drop."""
+    removed = False
+    managed = project_dir / 'managed_components'
+    if managed.exists():
+        shutil.rmtree(managed, ignore_errors=True)
+        removed = True
+    cache = build_dir / 'CMakeCache.txt'
+    if cache.exists():
+        cache.unlink(missing_ok=True)
+        removed = True
+    return removed
+
+
 def _evict_cold_variants(target_dir: Path, keep: int) -> None:
     """LRU-evict variant dirs (``v_*``) beyond ``keep``, coldest mtime first."""
     try:
@@ -4307,17 +4356,21 @@ class ESPIDFCompiler:
             ).hexdigest()[:12]
             try:
                 if _USE_PERSISTENT_DIR:
-                    project_dir = _prepare_persistent_project_dir(idf_target, eff_hash)
-                    logger.info(f'[espidf] Using persistent build dir: {project_dir}')
-                    return await self._compile_in_dir(
-                        project_dir, files, idf_target,
-                        progress_callback, normalized_opts, spiffs_files,
-                        allowed_libraries=allowed, libraries_dir=scope_dir,
-                        arduino_mode=arduino_mode, use_idf5=use_idf5,
-                        pure_idf=pure_idf, board_fqbn=board_fqbn,
-                        custom_wifi_ssids=custom_wifi_ssids,
-                        denied_libraries=denied, speculative_out=speculative,
-                    )
+                    # Prepare AND build under the variant lock: prepare wipes main/ and
+                    # user_libs, and the configure populates managed_components/ - neither
+                    # survives a second compile landing in the same dir mid-way.
+                    async with _variant_lock(f'{idf_target}/{eff_hash}'):
+                        project_dir = _prepare_persistent_project_dir(idf_target, eff_hash)
+                        logger.info(f'[espidf] Using persistent build dir: {project_dir}')
+                        return await self._compile_in_dir(
+                            project_dir, files, idf_target,
+                            progress_callback, normalized_opts, spiffs_files,
+                            allowed_libraries=allowed, libraries_dir=scope_dir,
+                            arduino_mode=arduino_mode, use_idf5=use_idf5,
+                            pure_idf=pure_idf, board_fqbn=board_fqbn,
+                            custom_wifi_ssids=custom_wifi_ssids,
+                            denied_libraries=denied, speculative_out=speculative,
+                        )
                 with tempfile.TemporaryDirectory(prefix='espidf_') as temp_dir:
                     project_dir = Path(temp_dir) / 'project'
                     shutil.copytree(_TEMPLATE_DIR, project_dir)
@@ -4942,6 +4995,28 @@ class ESPIDFCompiler:
                 'stderr': '',
             }
 
+        if cmake_result.returncode != 0:
+            # A managed component left half-copied by an interrupted or
+            # concurrent configure makes the component manager refuse the
+            # whole variant for good ("is corrupted"). The copy in its own
+            # cache is intact, so drop the variant's copies and configure
+            # once more instead of failing every compile of this variant
+            # until the dir is deleted by hand.
+            corrupt = _corrupt_managed_component(cmake_result.stderr)
+            if corrupt and _heal_corrupt_managed_components(project_dir, build_dir):
+                logger.warning(
+                    f'[espidf] managed component "{corrupt}" corrupted in '
+                    f'{project_dir}; dropped managed_components/ and reconfiguring'
+                )
+                try:
+                    cmake_result = await asyncio.to_thread(_run_cmake)
+                except subprocess.TimeoutExpired:
+                    return {
+                        'success': False,
+                        'error': f'ESP-IDF cmake reconfigure timed out ({cmake_timeout}s)',
+                        'stdout': '',
+                        'stderr': '',
+                    }
         if cmake_result.returncode != 0:
             logger.error(f'[espidf] cmake failed:\n{cmake_result.stderr}')
             return {

--- a/test/backend/unit/test_espidf_variant_lock.py
+++ b/test/backend/unit/test_espidf_variant_lock.py
@@ -1,0 +1,98 @@
+"""Persistent build variants are single-writer, and a variant whose managed
+component got truncated heals itself.
+
+Real failure (deploy gate, 2026-09-03): the engine smoke fired the ESP32-S3
+OLED example twice, 13 s apart. Both compiles hashed to the same variant and
+ran in the same project dir; the second configure found the first one's
+half-copied ``espressif/esp-serial-flasher`` and the component manager
+declared it corrupted. From then on every compile of that variant failed with
+"ESP-IDF cmake configure failed" until the directory was deleted by hand.
+"""
+
+import asyncio
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / 'backend'))
+
+from app.services.espidf_compiler import (  # noqa: E402
+    _corrupt_managed_component,
+    _heal_corrupt_managed_components,
+    _variant_lock,
+)
+
+
+_CMAKE_STDERR = '''CMake Error at /opt/esp-idf-v5/tools/cmake/build.cmake:631 (message):
+  ERROR: The downloaded component "espressif/esp-serial-flasher" is
+  corrupted.
+
+  Please try running the command again.
+
+  File "CMakeLists.txt" is missing in the component in
+
+
+  "/var/lib/velxio-build/esp32s3/v_38f59ea9c73c/project/managed_components/espressif__esp-serial-flasher"
+'''
+
+
+class VariantLockTests(unittest.TestCase):
+    def test_same_variant_shares_one_lock(self):
+        a = _variant_lock('esp32s3/v_38f59ea9c73c')
+        b = _variant_lock('esp32s3/v_38f59ea9c73c')
+        self.assertIs(a, b)
+        self.assertIsInstance(a, asyncio.Lock)
+
+    def test_different_variants_do_not_block_each_other(self):
+        self.assertIsNot(_variant_lock('esp32s3/v_a'), _variant_lock('esp32s3/v_b'))
+        self.assertIsNot(_variant_lock('esp32/v_a'), _variant_lock('esp32s3/v_a'))
+
+    def test_the_lock_serialises_two_compiles_of_one_variant(self):
+        order: list[str] = []
+
+        async def compile_once(tag: str, hold: float):
+            async with _variant_lock('esp32c3/v_serial'):
+                order.append(f'{tag}:in')
+                await asyncio.sleep(hold)
+                order.append(f'{tag}:out')
+
+        async def run():
+            await asyncio.gather(compile_once('first', 0.05), compile_once('second', 0))
+
+        asyncio.run(run())
+        self.assertEqual(order, ['first:in', 'first:out', 'second:in', 'second:out'])
+
+
+class CorruptComponentTests(unittest.TestCase):
+    def test_the_wrapped_message_names_the_component(self):
+        self.assertEqual(_corrupt_managed_component(_CMAKE_STDERR), 'espressif/esp-serial-flasher')
+
+    def test_other_cmake_failures_are_not_healed(self):
+        self.assertIsNone(_corrupt_managed_component('CMake Error: sdkconfig has changed'))
+        self.assertIsNone(_corrupt_managed_component(''))
+        self.assertIsNone(_corrupt_managed_component(None))  # type: ignore[arg-type]
+
+    def test_heal_drops_the_variant_copies_and_the_cmake_cache(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp) / 'project'
+            build = project / 'build'
+            comp = project / 'managed_components' / 'espressif__esp-serial-flasher'
+            comp.mkdir(parents=True)
+            (comp / 'README.md').write_text('half copied', encoding='utf-8')
+            build.mkdir()
+            (build / 'CMakeCache.txt').write_text('stale', encoding='utf-8')
+            (build / 'build.ninja').write_text('keep', encoding='utf-8')
+
+            self.assertTrue(_heal_corrupt_managed_components(project, build))
+            self.assertFalse((project / 'managed_components').exists())
+            self.assertFalse((build / 'CMakeCache.txt').exists())
+            # The rest of build/ (ninja state, objects) is left for ccache/ninja.
+            self.assertTrue((build / 'build.ninja').exists())
+            # Nothing left to heal: say so, so the caller does not reconfigure twice.
+            self.assertFalse(_heal_corrupt_managed_components(project, build))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

- A per-variant `asyncio.Lock` around prepare + cmake configure + ninja in `ESPIDFCompiler.compile`, so two compiles that hash to the same persistent build variant run one after the other instead of in the same directory at the same time.
- When cmake configure fails with `The downloaded component "<name>" is corrupted`, drop the variant's `managed_components/` and `CMakeCache.txt` and configure once more. The component manager's own cache is intact, so the second configure repopulates them.

## Why

Production deploy gate, 2026-09-03: the engine smoke fired the ESP32-S3 OLED example twice, 13 s apart. Both landed in `/var/lib/velxio-build/esp32s3/v_38f59ea9c73c/project`; the second configure found the first one's half-copied `espressif__esp-serial-flasher` (7 of 14 files, no `CMakeLists.txt`) and every later compile of that variant failed with `ESP-IDF cmake configure failed` until the directory was deleted by hand. The build queue bounds how many compiles run, not where.

## Tests

`test/backend/unit/test_espidf_variant_lock.py`: same variant shares one lock, different variants do not, two compiles of one variant serialise; the wrapped cmake message is parsed; the heal drops `managed_components/` and the cmake cache and leaves the ninja state alone. All `test_espidf_*` suites pass (74 passed, 14 skipped).