### PR TITLE
feat(sim): the line contract - one way to host a single-wire sensor on any board

### DIFF
--- a/frontend/src/__tests__/esp32-dht22-flow.test.ts
+++ b/frontend/src/__tests__/esp32-dht22-flow.test.ts
@@ -5,7 +5,7 @@
  * Verifies:
  *   1. Esp32BridgeShim delegates registerSensor → bridge.sendSensorAttach
  *   2. DHT22 attachEvents detects ESP32 shim and calls registerSensor
- *   3. DHT22 attachEvents falls back to local protocol on AVR (registerSensor → false)
+ *   3. DHT22 attachEvents attaches to a board's own line hub when it hosts the model itself
  *   4. Sensor update flow: updateSensor → bridge.sendSensorUpdate
  *   5. Cleanup: unregisterSensor → bridge.sendSensorDetach
  *   6. Esp32Bridge includes pre-registered sensors in start_esp32 payload
@@ -121,6 +121,8 @@ vi.stubGlobal('sessionStorage', {
 // ── Imports (after mocks) ────────────────────────────────────────────────────
 
 import { Esp32Bridge } from '../simulation/Esp32Bridge';
+import { LineSensorHub } from '../simulation/line/LineSensorHub';
+import type { LineHostPort } from '../simulation/line/LineHost';
 import { PartSimulationRegistry } from '../simulation/parts/PartSimulationRegistry';
 import '../simulation/parts/ProtocolParts';
 
@@ -135,7 +137,7 @@ function makeElement(props: Record<string, unknown> = {}): HTMLElement {
   } as unknown as HTMLElement;
 }
 
-/** Simulator mock that mimics Esp32BridgeShim (registerSensor returns true) */
+/** Simulator mock that mimics Esp32BridgeShim: declares the worker's models as hosted, registerSensor returns true */
 function makeEsp32Shim() {
   const bridge = {
     sendSensorAttach: vi.fn(),
@@ -144,6 +146,7 @@ function makeEsp32Shim() {
   };
   return {
     bridge,
+    lineSupport: () => ({ mode: 'hosted' as const, models: ['dht22', 'hc-sr04'] }),
     pinManager: {
       onPinChange: vi.fn().mockReturnValue(() => {}),
       onPwmChange: vi.fn().mockReturnValue(() => {}),
@@ -252,33 +255,39 @@ describe('dht22 — ESP32 shim detection', () => {
 // 3. DHT22 attachEvents — AVR fallback (local protocol)
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('dht22 — AVR local protocol fallback', () => {
+describe('dht22 — a board that hosts the model itself (AVR / RP2040 shape)', () => {
   const logic = () => PartSimulationRegistry.get('dht22')!;
 
-  it('falls back to local protocol when registerSensor returns false', () => {
-    const sim = makeAVRSim();
+  function makeLocalSim() {
+    const port: LineHostPort = {
+      now: () => 0,
+      clockHz: () => 16e6,
+      scheduleEdge: vi.fn(),
+      onPad: vi.fn().mockReturnValue(() => {}),
+      restPad: vi.fn(),
+    };
+    const hub = new LineSensorHub(port);
+    return { ...makeAVRSim(), port, hub, lineSupport: () => ({ mode: 'local' as const }), lineHub: () => hub };
+  }
+
+  it('attaches the model to the board hub instead of a legacy channel', () => {
+    const sim = makeLocalSim();
     const el = makeElement({ temperature: 25, humidity: 50 });
     logic().attachEvents!(el, sim as any, pinMap({ SDA: 7 }), 'dht22-avr');
-
-    // AVR registerSensor returns false → local protocol path
-    expect(sim.registerSensor).toHaveBeenCalledWith('dht22', 7, { temperature: 25, humidity: 50 });
-
-    // Local protocol: onPinChange registered for start-signal detection
-    expect(sim.pinManager.onPinChange).toHaveBeenCalledWith(7, expect.any(Function));
-    // Local protocol: DATA pin set HIGH (idle)
-    expect(sim.setPinState).toHaveBeenCalledWith(7, true);
+    expect(sim.hub.size).toBe(1);
+    expect(sim.port.onPad).toHaveBeenCalledWith(7, expect.any(Function));
+    expect(sim.port.restPad).toHaveBeenCalledWith(7, true, false);
+    expect(sim.registerSensor).not.toHaveBeenCalled();
   });
 
-  it('local protocol does NOT call registerSensor on bridge methods', () => {
-    const sim = makeAVRSim();
+  it('never touches the legacy sensor channel on a local host', () => {
+    const sim = makeLocalSim();
     const el = makeElement({ temperature: 25, humidity: 50 });
-    logic().attachEvents!(el, sim as any, pinMap({ SDA: 7 }), 'dht22-avr2');
-
-    // AVR path: uses onPinChange, not bridge sensor methods
-    expect(sim.pinManager.onPinChange).toHaveBeenCalledWith(7, expect.any(Function));
-    // updateSensor/unregisterSensor should NOT have been called
+    const cleanup = logic().attachEvents!(el, sim as any, pinMap({ SDA: 7 }), 'dht22-avr2');
     expect(sim.updateSensor).not.toHaveBeenCalled();
     expect(sim.unregisterSensor).not.toHaveBeenCalled();
+    cleanup();
+    expect(sim.hub.size).toBe(0);
   });
 });
 

--- a/frontend/src/__tests__/interactive-parts.test.ts
+++ b/frontend/src/__tests__/interactive-parts.test.ts
@@ -7,6 +7,10 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { PartSimulationRegistry } from '../simulation/parts/PartSimulationRegistry';
+import { LineSensorHub } from '../simulation/line/LineSensorHub';
+import type { LineHostPort } from '../simulation/line/LineHost';
+import { INITIAL_PAD, type PadEvent, type PadState } from '../simulation/line/padEvent';
+import { clearLineGaps, lineGaps } from '../simulation/line/requestLine';
 
 // Side-effect imports — register all parts
 import '../simulation/parts/BasicParts';
@@ -182,39 +186,73 @@ describe('ks2e-m-dc5 — onPinStateChange', () => {
 
 // ─── hc-sr04 ──────────────────────────────────────────────────────────────────
 
-describe('hc-sr04 — attachEvents', () => {
-  it('sets ECHO LOW on init and watches TRIG pin', () => {
-    const logic = PartSimulationRegistry.get('hc-sr04');
-    const el = makeElement();
-    const sim = makeSimulator();
-    logic!.attachEvents!(el, sim as any, pinMap({ TRIG: 2, ECHO: 3 }));
+describe('hc-sr04 — attachEvents (the line contract)', () => {
+  function makeLineSim() {
+    const listeners = new Map<number, Set<(e: PadEvent) => void>>();
+    const port: LineHostPort & { edges: Array<[number, boolean, number]>; rests: Array<[number, boolean, boolean]> } = {
+      edges: [],
+      rests: [],
+      now: () => 5_000,
+      clockHz: () => 16e6,
+      scheduleEdge: (pin, level, at) => port.edges.push([pin, level, at]),
+      onPad: (pin, cb) => {
+        if (!listeners.has(pin)) listeners.set(pin, new Set());
+        listeners.get(pin)!.add(cb);
+        return () => listeners.get(pin)!.delete(cb);
+      },
+      restPad: (pin, level, driven) => port.rests.push([pin, level, driven]),
+    };
+    const hub = new LineSensorHub(port);
+    const sim = {
+      ...makeSimulator(),
+      lineSupport: () => ({ mode: 'local' as const }),
+      lineHub: () => hub,
+      guest(pin: number, drive: PadState['drive'], prevDrive: PadState['drive'] = 'z') {
+        const prev: PadState = { ...INITIAL_PAD, drive: prevDrive };
+        const next: PadState = { drive, pull: 0, level: drive !== 'low', cycle: 5_000 };
+        listeners.get(pin)?.forEach((cb) => cb({ pin, ...next, prev }));
+      },
+    };
+    return { sim, hub, port };
+  }
 
-    expect(sim.setPinState).toHaveBeenCalledWith(3, false); // ECHO initially LOW
-    expect(sim.pinManager.onPinChange).toHaveBeenCalledWith(2, expect.any(Function));
+  it('asks the board to host it, rests ECHO low, and owns ECHO', () => {
+    const logic = PartSimulationRegistry.get('hc-sr04');
+    const { sim, hub, port } = makeLineSim();
+    logic!.attachEvents!(makeElement(), sim as any, pinMap({ TRIG: 2, ECHO: 3 }), 'sr04-1');
+    expect(port.rests).toEqual([[3, false, true]]);
+    expect(hub.ownsPin(3)).toBe(true);
+    expect(hub.ownsPin(2)).toBe(false);
   });
 
-  it('fires ECHO HIGH pulse when TRIG goes HIGH', () => {
+  it('answers a TRIG rise with the two-edge ECHO pulse', () => {
     const logic = PartSimulationRegistry.get('hc-sr04');
-    const el = makeElement();
-    const sim = makeSimulator();
-    logic!.attachEvents!(el, sim as any, pinMap({ TRIG: 2, ECHO: 3 }));
-
-    // Extract the onPinChange callback for TRIG
-    const trigCb = (sim.pinManager.onPinChange as ReturnType<typeof vi.fn>).mock.calls.find(
-      ([pin]: [number]) => pin === 2,
-    )![1] as (_: number, state: boolean) => void;
-
-    trigCb(2, true); // TRIG HIGH
-    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 1);
+    const { sim, port } = makeLineSim();
+    logic!.attachEvents!(makeElement(), sim as any, pinMap({ TRIG: 2, ECHO: 3 }), 'sr04-2');
+    sim.guest(2, 'high', 'low');
+    expect(port.edges).toEqual([
+      [3, true, 5_000 + 16 * 600],
+      [3, false, 5_000 + 16 * 600 + Math.round((10 / 17150) * 16e6)],
+    ]);
   });
 
   it('returns no-op when TRIG or ECHO is not connected', () => {
     const logic = PartSimulationRegistry.get('hc-sr04');
-    const el = makeElement();
-    const sim = makeSimulator();
-    const cleanup = logic!.attachEvents!(el, sim as any, noPins);
-    expect(sim.pinManager.onPinChange).not.toHaveBeenCalled();
+    const { sim, hub } = makeLineSim();
+    const cleanup = logic!.attachEvents!(makeElement(), sim as any, noPins, 'sr04-3');
+    expect(hub.size).toBe(0);
     expect(() => cleanup()).not.toThrow();
+  });
+
+  it('refuses out loud on a board with no line support', () => {
+    clearLineGaps();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const logic = PartSimulationRegistry.get('hc-sr04');
+    const sim = makeSimulator();
+    logic!.attachEvents!(makeElement(), sim as any, pinMap({ TRIG: 2, ECHO: 3 }), 'sr04-4');
+    expect(sim.setPinState).not.toHaveBeenCalled();
+    expect(lineGaps().map((g) => g.sensorType)).toEqual(['hc-sr04']);
+    warn.mockRestore();
   });
 });
 

--- a/frontend/src/__tests__/protocol-parts.test.ts
+++ b/frontend/src/__tests__/protocol-parts.test.ts
@@ -16,6 +16,10 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { PartSimulationRegistry } from '../simulation/parts/PartSimulationRegistry';
+import { LineSensorHub } from '../simulation/line/LineSensorHub';
+import type { LineHostPort } from '../simulation/line/LineHost';
+import { INITIAL_PAD, type PadEvent, type PadState } from '../simulation/line/padEvent';
+import { clearLineGaps, lineGaps } from '../simulation/line/requestLine';
 import { dispatchSensorUpdate } from '../simulation/SensorUpdateRegistry';
 import { useSimulatorStore } from '../store/useSimulatorStore';
 import '../simulation/parts/ProtocolParts';
@@ -344,58 +348,101 @@ describe('mpu6050 — I2C IMU', () => {
 
 // ─── dht22 ───────────────────────────────────────────────────────────────────
 
-describe('dht22 — single-wire sensor', () => {
-  it('sets DATA pin HIGH (idle) on attach', () => {
-    const sim = makePinSim();
+describe('dht22 — single-wire sensor (the line contract)', () => {
+  /** A board that hosts line models itself, over a fake port. */
+  function makeLineSim() {
+    const listeners = new Map<number, Set<(e: PadEvent) => void>>();
+    const port: LineHostPort & { edges: Array<[number, boolean, number]>; rests: Array<[number, boolean, boolean]> } = {
+      edges: [],
+      rests: [],
+      now: () => 10_000,
+      clockHz: () => 16e6,
+      scheduleEdge: (pin, level, at) => port.edges.push([pin, level, at]),
+      onPad: (pin, cb) => {
+        if (!listeners.has(pin)) listeners.set(pin, new Set());
+        listeners.get(pin)!.add(cb);
+        return () => listeners.get(pin)!.delete(cb);
+      },
+      restPad: (pin, level, driven) => port.rests.push([pin, level, driven]),
+    };
+    const hub = new LineSensorHub(port);
+    const sim = {
+      ...makePinSim(),
+      lineSupport: () => ({ mode: 'local' as const }),
+      lineHub: () => hub,
+      /** Emit the guest's drive changes the way a simulator would. */
+      guest(pin: number, drives: Array<PadState['drive']>) {
+        let prev: PadState = INITIAL_PAD;
+        for (const drive of drives) {
+          const next: PadState = { drive, pull: drive === 'z' ? 1 : 0, level: drive !== 'low', cycle: 10_000 };
+          listeners.get(pin)?.forEach((cb) => cb({ pin, ...next, prev }));
+          prev = next;
+        }
+      },
+    };
+    return { sim, hub, port };
+  }
+
+  it('asks the board to host it and rests DATA released on its pull-up', () => {
+    const { sim, hub, port } = makeLineSim();
     const logic = PartSimulationRegistry.get('dht22')!;
-    logic.attachEvents!(makeElement(), sim as any, pinMap({ DATA: 7 }));
-    expect(sim.setPinState).toHaveBeenCalledWith(7, true);
+    logic.attachEvents!(makeElement(), sim as any, pinMap({ DATA: 7 }), 'dht-1');
+    expect(hub.size).toBe(1);
+    expect(hub.ownsPin(7)).toBe(true);
+    expect(port.rests).toEqual([[7, true, false]]);
   });
 
-  it('registers onPinChange for DATA pin', () => {
-    const sim = makePinSim();
+  it('answers the start signal (LOW, then release) with the 84-edge frame', () => {
+    const { sim, port } = makeLineSim();
     const logic = PartSimulationRegistry.get('dht22')!;
-    logic.attachEvents!(makeElement(), sim as any, pinMap({ DATA: 7 }));
-    expect(sim.pinManager.onPinChange).toHaveBeenCalledWith(7, expect.any(Function));
+    logic.attachEvents!(makeElement({ temperature: 25.0, humidity: 50.0 }), sim as any, pinMap({ DATA: 7 }), 'dht-2');
+    sim.guest(7, ['high', 'low', 'z']);
+    expect(port.edges).toHaveLength(84);
+    expect(port.edges[0]).toEqual([7, false, 10_000 + 16 * 20]);
   });
 
-  it('drives DATA in response after LOW → HIGH start sequence', () => {
-    const sim = makePinSim();
+  it('forwards slider changes to the host', () => {
+    const { sim, hub } = makeLineSim();
     const logic = PartSimulationRegistry.get('dht22')!;
-    logic.attachEvents!(
-      makeElement({ temperature: 25.0, humidity: 50.0 }),
-      sim as any,
-      pinMap({ DATA: 7 }),
-    );
-
-    const cb = sim.pinManager.onPinChange.mock.calls[0][1] as (pin: number, state: boolean) => void;
-    sim.setPinState.mockClear();
-
-    cb(7, false); // MCU pulls DATA LOW  (start signal)
-    cb(7, true); // MCU releases DATA HIGH → DHT22 should begin response
-
-    // Response should include at least one LOW pulse
-    const calls = (sim.setPinState as ReturnType<typeof vi.fn>).mock.calls;
-    expect(calls.some(([, s]) => s === false)).toBe(true);
+    const el = makeElement({ temperature: 25.0, humidity: 50.0 }) as any;
+    logic.attachEvents!(el, sim as any, pinMap({ DATA: 7 }), 'dht-3');
+    const spy = vi.spyOn(hub, 'update');
+    dispatchSensorUpdate('dht-3', { temperature: 31 });
+    expect(el.temperature).toBe(31);
+    expect(spy).toHaveBeenCalledWith(7, { temperature: 31, humidity: 50 });
   });
 
   it('no-op if DATA pin not found', () => {
-    const sim = makePinSim();
+    const { sim, hub } = makeLineSim();
     const logic = PartSimulationRegistry.get('dht22')!;
     expect(() => {
-      const c = logic.attachEvents!(makeElement(), sim as any, noPins);
+      const c = logic.attachEvents!(makeElement(), sim as any, noPins, 'dht-4');
       c();
     }).not.toThrow();
-    expect(sim.pinManager.onPinChange).not.toHaveBeenCalled();
+    expect(hub.size).toBe(0);
   });
 
-  it('cleanup drives DATA HIGH', () => {
-    const sim = makePinSim();
+  it('cleanup releases the line', () => {
+    const { sim, hub } = makeLineSim();
     const logic = PartSimulationRegistry.get('dht22')!;
-    const cleanup = logic.attachEvents!(makeElement(), sim as any, pinMap({ DATA: 7 }));
-    sim.setPinState.mockClear();
+    const cleanup = logic.attachEvents!(makeElement(), sim as any, pinMap({ DATA: 7 }), 'dht-5');
     cleanup();
-    expect(sim.setPinState).toHaveBeenCalledWith(7, true);
+    expect(hub.size).toBe(0);
+    expect(hub.ownsPin(7)).toBe(false);
+  });
+
+  it('on a board that cannot host it, refuses out loud and drives nothing', () => {
+    clearLineGaps();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const sim = makePinSim(); // no declaration at all
+    const logic = PartSimulationRegistry.get('dht22')!;
+    const cleanup = logic.attachEvents!(makeElement(), sim as any, pinMap({ DATA: 7 }), 'dht-6');
+    expect(sim.setPinState).not.toHaveBeenCalled();
+    expect(sim.pinManager.onPinChange).not.toHaveBeenCalled();
+    expect(lineGaps()).toContainEqual({ sensorType: 'dht22', pin: 7, why: expect.any(String), componentId: 'dht-6' });
+    expect(warn).toHaveBeenCalled();
+    expect(() => cleanup()).not.toThrow();
+    warn.mockRestore();
   });
 });
 

--- a/frontend/src/components/DynamicComponent.tsx
+++ b/frontend/src/components/DynamicComponent.tsx
@@ -523,6 +523,16 @@ export const DynamicComponent: React.FC<DynamicComponentProps> = ({
             isRunning: () =>
               !!useSimulatorStore.getState().boards.find((b) => b.id === piBoardId)?.running,
             pinManager: getBoardPinManager(piBoardId),
+            // The line contract's declaration. A QEMU-Linux guest reads its
+            // pins over a serial link to the backend (measured: ~120 reads/s,
+            // 8 ms per read) and the bridge carries levels, not timed edges,
+            // so a single-wire sensor's reply has nowhere to land in guest
+            // time. Said here, so the part hears it instead of waiting on a
+            // silent pad.
+            lineSupport: () => ({
+              mode: 'none' as const,
+              why: 'this board runs a Linux guest that reads its pins over a serial link; timed single-wire sensors are not modelled',
+            }),
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
           } as any)
         : null;

--- a/frontend/src/simulation/AVRSimulator.ts
+++ b/frontend/src/simulation/AVRSimulator.ts
@@ -35,6 +35,8 @@ import type { AVRTimerConfig } from 'avr8js/dist/esm/peripherals/timer';
 import type { ADCConfig, ADCMuxConfiguration } from 'avr8js/dist/esm/peripherals/adc';
 import { ADCMuxInputType, ADCReference } from 'avr8js/dist/esm/peripherals/adc';
 import { PinManager } from './PinManager';
+import type { LineCapable, LineHostPort, LineSupport } from './line/LineHost';
+import { LineSensorHub } from './line/LineSensorHub';
 import { hexToUint8Array } from '../utils/hexParser';
 import { I2CBusManager, nullI2CMaster } from './I2CBusManager';
 import type { I2CDevice } from './I2CBusManager';
@@ -294,7 +296,7 @@ const MEGA_PORT_CONFIGS = [
   { name: 'PORTL', config: portLConfig },
 ];
 
-export class AVRSimulator {
+export class AVRSimulator implements LineCapable {
   // Digital input pins are driven from the SPICE solve
   // (connectDigitalInputsToMcu) for nets backed by a real source/element, so
   // `digitalRead()` reflects the real wiring (a pin wired to 5V reads HIGH, a
@@ -340,8 +342,10 @@ export class AVRSimulator {
   /** 'uno' for ATmega328P boards (Uno, Nano); 'mega' for ATmega2560; 'tiny85' for ATtiny85 */
   private boardVariant: 'uno' | 'mega' | 'tiny85';
 
-  /** Cycle-accurate pin change queue — used by timing-sensitive peripherals (e.g. DHT22). */
+  /** Cycle-accurate pin change queue, flushed after every instruction. */
   private scheduledPinChanges: Array<{ cycle: number; pin: number; state: boolean }> = [];
+  /** Line-owning sensor models hosted on this CPU (simulation/line). Built lazily: it closes over the port below. */
+  private lines: LineSensorHub | null = null;
 
   /** Serial output buffer — subscribers receive each byte or line */
   public onSerialData: ((char: string) => void) | null = null;
@@ -356,6 +360,11 @@ export class AVRSimulator {
   private lastPortBValue = 0;
   private lastPortCValue = 0;
   private lastPortDValue = 0;
+  // Last DDR seen per port. avr8js calls a port listener on a DDR change even
+  // when the masked value is unchanged, and the release of a single-wire line
+  // (DDR 1 -> 0 with PORT already what it was) is exactly such a change: it
+  // must reach PinManager.updatePort so the pad's drive state is reported.
+  private lastDdr: Map<string, number> = new Map();
   private lastOcrValues: number[] = [];
   /**
    * Last known TXEN bit value, used to detect 0→1 transitions and seed the
@@ -567,6 +576,7 @@ export class AVRSimulator {
     this.lastPortBValue = 0;
     this.lastPortCValue = 0;
     this.lastPortDValue = 0;
+    this.lastDdr.clear();
     this.lastOcrValues = new Array(this.pwmPins.length).fill(0);
 
     this.setupPinHooks();
@@ -750,10 +760,12 @@ export class AVRSimulator {
       // legacy PORTB offset (8) which would map PB1 → pin 9, etc.
       const TINY85_PIN_MAP = [0, 1, 2, 3, 4, 5, -1, -1];
       this.portB!.addListener((value) => {
-        if (value !== this.lastPortBValue) {
-          this.pinManager.updatePort('PORTB', value, this.lastPortBValue, TINY85_PIN_MAP, readDdr(0x37));
+        const ddr = readDdr(0x37);
+        if (value !== this.lastPortBValue || ddr !== this.lastDdr.get('PORTB')) {
+          this.pinManager.updatePort('PORTB', value, this.lastPortBValue, TINY85_PIN_MAP, ddr, cpu.cycles);
           this.firePinChangeWithTime(value, this.lastPortBValue, null, 0);
           this.lastPortBValue = value;
+          this.lastDdr.set('PORTB', ddr);
         }
       });
     } else if (this.boardVariant === 'mega') {
@@ -769,34 +781,42 @@ export class AVRSimulator {
         this.megaPortValues.set(portName, 0);
         port.addListener((value) => {
           const old = this.megaPortValues.get(portName) ?? 0;
-          if (value !== old) {
-            this.pinManager.updatePort(portName, value, old, pinMap, ddrAddr ? readDdr(ddrAddr) : undefined);
+          const ddr = ddrAddr ? readDdr(ddrAddr) : undefined;
+          if (value !== old || ddr !== this.lastDdr.get(portName)) {
+            this.pinManager.updatePort(portName, value, old, pinMap, ddr, cpu.cycles);
             this.firePinChangeWithTime(value, old, pinMap);
             this.megaPortValues.set(portName, value);
+            if (ddr !== undefined) this.lastDdr.set(portName, ddr);
           }
         });
       }
     } else {
       // Uno / Nano: simple 3-port setup
       this.portB!.addListener((value) => {
-        if (value !== this.lastPortBValue) {
-          this.pinManager.updatePort('PORTB', value, this.lastPortBValue, undefined, readDdr(0x24));
+        const ddr = readDdr(0x24);
+        if (value !== this.lastPortBValue || ddr !== this.lastDdr.get('PORTB')) {
+          this.pinManager.updatePort('PORTB', value, this.lastPortBValue, undefined, ddr, cpu.cycles);
           this.firePinChangeWithTime(value, this.lastPortBValue, null, 8);
           this.lastPortBValue = value;
+          this.lastDdr.set('PORTB', ddr);
         }
       });
       this.portC!.addListener((value) => {
-        if (value !== this.lastPortCValue) {
-          this.pinManager.updatePort('PORTC', value, this.lastPortCValue, undefined, readDdr(0x27));
+        const ddr = readDdr(0x27);
+        if (value !== this.lastPortCValue || ddr !== this.lastDdr.get('PORTC')) {
+          this.pinManager.updatePort('PORTC', value, this.lastPortCValue, undefined, ddr, cpu.cycles);
           this.firePinChangeWithTime(value, this.lastPortCValue, null, 14);
           this.lastPortCValue = value;
+          this.lastDdr.set('PORTC', ddr);
         }
       });
       this.portD!.addListener((value) => {
-        if (value !== this.lastPortDValue) {
-          this.pinManager.updatePort('PORTD', value, this.lastPortDValue, undefined, readDdr(0x2A));
+        const ddr = readDdr(0x2A);
+        if (value !== this.lastPortDValue || ddr !== this.lastDdr.get('PORTD')) {
+          this.pinManager.updatePort('PORTD', value, this.lastPortDValue, undefined, ddr, cpu.cycles);
           this.firePinChangeWithTime(value, this.lastPortDValue, null, 0);
           this.lastPortDValue = value;
+          this.lastDdr.set('PORTD', ddr);
         }
       });
     }
@@ -921,6 +941,7 @@ export class AVRSimulator {
       this.animationFrame = null;
     }
     this.scheduledPinChanges = [];
+    this.lines?.reset();
 
     // Drop any bytes the previous run had queued for the sketch's RX
     // but never delivered (RX disabled, busy, or the sketch hadn't
@@ -937,6 +958,11 @@ export class AVRSimulator {
    */
   reset(): void {
     this.stop();
+    // A reset is a reboot whether or not the loop was running (stop() returns
+    // early when it was not): the edge queue and every hosted line model start
+    // over with the CPU.
+    this.scheduledPinChanges = [];
+    this.lines?.reset();
     if (this.program) {
       // Re-use the stored hex content path: just reload
       const sramBytes =
@@ -1024,10 +1050,13 @@ export class AVRSimulator {
     return this.speed;
   }
 
+  /** One instruction, exactly as the frame loop runs it: execute, tick, and
+   *  apply every scheduled pin edge that came due. */
   step(): void {
     if (!this.cpu) return;
     avrInstruction(this.cpu);
     this.cpu.tick();
+    if (this.scheduledPinChanges.length > 0) this.flushScheduledPinChanges();
   }
 
   /**
@@ -1154,9 +1183,39 @@ export class AVRSimulator {
     return this.i2cBus;
   }
 
-  // ── Generic sensor registration (board-agnostic API) ──────────────────────
-  // AVR handles all sensor protocols locally via schedulePinChange,
-  // so these return false / no-op — the sensor runs its own frontend logic.
+  // ── Line-owning sensors (simulation/line) ─────────────────────────────────
+  // The models run here, in the browser, on this CPU's own cycle counter:
+  // edges are flushed after every instruction and nothing in this family
+  // advances the clock without executing, so the contract holds by
+  // construction. The legacy `registerSensor` stays a no-op for callers that
+  // still probe it; the line contract is the path a part takes.
+
+  lineSupport(): LineSupport {
+    return { mode: 'local' };
+  }
+
+  lineHub(): LineSensorHub {
+    if (!this.lines) {
+      const port: LineHostPort = {
+        now: () => this.getCurrentCycles(),
+        clockHz: () => this.getClockHz(),
+        scheduleEdge: (pin, level, atCycle) => this.schedulePinChange(pin, level, atCycle),
+        onPad: (pin, cb) => this.pinManager.onPadChange(pin, cb),
+        // avr8js has no notion of a host-owned pad: an injected level simply
+        // becomes the PIN register's value, and a released line on its pull-up
+        // reads exactly the level the pull produces. Seeding it is the rest.
+        restPad: (pin, level) => this.setPinState(pin, level),
+      };
+      this.lines = new LineSensorHub(port);
+    }
+    return this.lines;
+  }
+
+  /** Pads a hosted line model drives itself — the SPICE-threshold connector
+   *  asks before pushing a solved level into the guest (connectDigitalInputsToMcu). */
+  ownsPin(pin: number): boolean {
+    return this.lines?.ownsPin(pin) ?? false;
+  }
 
   registerSensor(_type: string, _pin: number, _props: Record<string, unknown>): boolean {
     return false;

--- a/frontend/src/simulation/Esp32Bridge.ts
+++ b/frontend/src/simulation/Esp32Bridge.ts
@@ -38,6 +38,7 @@ import type { BoardKind } from '../types/board';
 import { MicroPythonSession, type MpyProgram } from './micropythonSession';
 import { getProBoard } from '../lib/proBoardRegistry';
 import { sensorRecordOwnsPin as recordOwnsPin } from './sensorModels';
+import type { LineSupport } from './line/LineHost';
 import { generateUUID } from '../utils/uuid';
 
 /**
@@ -698,6 +699,21 @@ export class Esp32Bridge {
    * and reply — pulseIn() then timed out forever while the worker was pulsing
    * the pin correctly. Same shape as the in-browser engines' ownsPin guard.
    */
+  /**
+   * The line-owning sensors the backend QEMU worker models itself, timed on
+   * the guest's clock inside QEMU (esp32_worker.py `_dht22_*` / hc-sr04 sync
+   * handlers). Mirror of that file, the way esp32-signals.ts mirrors
+   * esp32_signals.py: a new worker-side model is one entry here. An overlay
+   * bridge that runs the models in the browser overrides this with the
+   * registry's own list.
+   */
+  static readonly WORKER_LINE_MODELS: readonly string[] = ['dht22', 'hc-sr04'];
+
+  /** What this board can host under the line contract (simulation/line). */
+  lineSupport(): LineSupport {
+    return { mode: 'hosted', models: Esp32Bridge.WORKER_LINE_MODELS };
+  }
+
   ownsSensorPin(gpioPin: number): boolean {
     // ONLY the single-wire sensors own a pad. The same channel registers plenty
     // of other things — an ePaper panel's DC/BUSY pins, a membrane keypad's

--- a/frontend/src/simulation/PinManager.ts
+++ b/frontend/src/simulation/PinManager.ts
@@ -17,6 +17,14 @@
  */
 
 import { requestElectricalResolve } from './spice/electricalResolveHook';
+import {
+  INITIAL_PAD,
+  restingLevel,
+  type PadDrive,
+  type PadEvent,
+  type PadPull,
+  type PadState,
+} from './line/padEvent';
 
 export type PinState = boolean;
 export type PinChangeCallback = (pin: number, state: PinState) => void;
@@ -43,6 +51,50 @@ export class PinManager {
   // inputs read the right idle level (the ESP32's internal pulls live inside
   // QEMU and are otherwise invisible to the netlist).
   private pinPulls: Map<number, 0 | 1 | 2> = new Map();
+
+  // ── Pad drive state (the line contract, simulation/line) ─────────────────
+  //
+  // What the MCU is DOING to each pad — driving low, driving high, or
+  // released — as opposed to `pinStates`, which is the level the wire holds
+  // and which the host also writes. A line-owning sensor waits for the guest
+  // to RELEASE its wire, a direction change that moves no level, and only
+  // this channel carries it. Fed by the simulators through `reportPad`;
+  // consumed through `onPadChange`. Never fired by host-side writes.
+  private padStates: Map<number, PadState> = new Map();
+  private padListeners: Map<number, Set<(e: PadEvent) => void>> = new Map();
+
+  /** Subscribe to guest drive-state changes on one pad. */
+  onPadChange(pin: number, callback: (e: PadEvent) => void): () => void {
+    if (!this.padListeners.has(pin)) this.padListeners.set(pin, new Set());
+    this.padListeners.get(pin)!.add(callback);
+    return () => {
+      this.padListeners.get(pin)?.delete(callback);
+    };
+  }
+
+  /** The pad's current drive state (released with no pull until reported). */
+  getPad(pin: number): Readonly<PadState> {
+    return this.padStates.get(pin) ?? INITIAL_PAD;
+  }
+
+  /**
+   * SIMULATOR -> listeners. Report what the guest did to a pad. Fires only on
+   * a real change of drive or pull; the resting level is derived here so no
+   * simulator computes it. Does NOT touch `pinStates` or fire `onPinChange` —
+   * the level channel keeps its own semantics, and the two must not double
+   * fire for a plain digitalWrite.
+   */
+  reportPad(pin: number, drive: PadDrive, pull: PadPull, cycle: number): void {
+    const prev = this.padStates.get(pin) ?? INITIAL_PAD;
+    if (prev.drive === drive && prev.pull === pull) return;
+    const level = restingLevel(drive, pull, prev.level);
+    const next: PadState = { drive, pull, level, cycle };
+    this.padStates.set(pin, next);
+    const callbacks = this.padListeners.get(pin);
+    if (!callbacks || callbacks.size === 0) return;
+    const event: PadEvent = { pin, ...next, prev };
+    callbacks.forEach((cb) => cb(event));
+  }
 
   // ── Digital pin API ──────────────────────────────────────────────────────
 
@@ -84,6 +136,7 @@ export class PinManager {
     oldValue: number = 0,
     pinMap?: number[],
     ddrMask?: number,
+    cycle: number = -1,
   ) {
     const legacyOffsets: Record<string, number> = { PORTB: 8, PORTC: 14, PORTD: 0 };
 
@@ -93,13 +146,26 @@ export class PinManager {
     // correct idle level (HIGH) under spice-driven inputs — without this, the
     // canonical button-to-GND would float LOW. AVR has no internal pull-down.
     // Runs over all 8 bits (not just changed ones) so DDR/PORT edits both apply.
+    //
+    // The same pass reports each pad's DRIVE state: DDR set means the MCU is
+    // driving the PORT bit's level, DDR clear means the pad is released and the
+    // PORT bit is its pull-up. `reportPad` fires only on a real change, so the
+    // release of a line (DDR 1 -> 0, PORT unchanged) reaches the line contract
+    // even though no level moved — the event a value-only listener never saw.
     if (ddrMask !== undefined) {
       for (let bit = 0; bit < 8; bit++) {
         const mask = 1 << bit;
         const arduinoPin = pinMap ? pinMap[bit] : (legacyOffsets[portName] ?? 0) + bit;
         if (arduinoPin < 0) continue;
         const isInput = (ddrMask & mask) === 0;
-        this.setPinPull(arduinoPin, isInput && (newValue & mask) !== 0 ? 1 : 0);
+        const portBit = (newValue & mask) !== 0;
+        this.setPinPull(arduinoPin, isInput && portBit ? 1 : 0);
+        this.reportPad(
+          arduinoPin,
+          isInput ? 'z' : portBit ? 'high' : 'low',
+          isInput && portBit ? 1 : 0,
+          cycle,
+        );
       }
     }
 
@@ -233,6 +299,9 @@ export class PinManager {
     this.pinStates.clear();
     this.outputPins.clear();
     this.pinPulls.clear();
+    // A cold boot releases every pad; the firmware re-configures each one from
+    // setup(), and the next `reportPad` must see that as a change.
+    this.padStates.clear();
     for (const pin of wereHigh) {
       const callbacks = this.listeners.get(pin);
       if (callbacks) {

--- a/frontend/src/simulation/PinManager.ts
+++ b/frontend/src/simulation/PinManager.ts
@@ -17,14 +17,8 @@
  */
 
 import { requestElectricalResolve } from './spice/electricalResolveHook';
-import {
-  INITIAL_PAD,
-  restingLevel,
-  type PadDrive,
-  type PadEvent,
-  type PadPull,
-  type PadState,
-} from './line/padEvent';
+import type { PadDrive, PadEvent, PadPull, PadState } from './line/padEvent';
+import { PadBus } from './line/padBus';
 
 export type PinState = boolean;
 export type PinChangeCallback = (pin: number, state: PinState) => void;
@@ -60,40 +54,26 @@ export class PinManager {
   // to RELEASE its wire, a direction change that moves no level, and only
   // this channel carries it. Fed by the simulators through `reportPad`;
   // consumed through `onPadChange`. Never fired by host-side writes.
-  private padStates: Map<number, PadState> = new Map();
-  private padListeners: Map<number, Set<(e: PadEvent) => void>> = new Map();
+  private readonly pads = new PadBus();
 
   /** Subscribe to guest drive-state changes on one pad. */
   onPadChange(pin: number, callback: (e: PadEvent) => void): () => void {
-    if (!this.padListeners.has(pin)) this.padListeners.set(pin, new Set());
-    this.padListeners.get(pin)!.add(callback);
-    return () => {
-      this.padListeners.get(pin)?.delete(callback);
-    };
+    return this.pads.onPad(pin, callback);
   }
 
   /** The pad's current drive state (released with no pull until reported). */
   getPad(pin: number): Readonly<PadState> {
-    return this.padStates.get(pin) ?? INITIAL_PAD;
+    return this.pads.get(pin);
   }
 
   /**
    * SIMULATOR -> listeners. Report what the guest did to a pad. Fires only on
-   * a real change of drive or pull; the resting level is derived here so no
-   * simulator computes it. Does NOT touch `pinStates` or fire `onPinChange` —
-   * the level channel keeps its own semantics, and the two must not double
-   * fire for a plain digitalWrite.
+   * a real change of drive or pull. Does NOT touch `pinStates` or fire
+   * `onPinChange` — the level channel keeps its own semantics, and the two
+   * must not double fire for a plain digitalWrite.
    */
   reportPad(pin: number, drive: PadDrive, pull: PadPull, cycle: number): void {
-    const prev = this.padStates.get(pin) ?? INITIAL_PAD;
-    if (prev.drive === drive && prev.pull === pull) return;
-    const level = restingLevel(drive, pull, prev.level);
-    const next: PadState = { drive, pull, level, cycle };
-    this.padStates.set(pin, next);
-    const callbacks = this.padListeners.get(pin);
-    if (!callbacks || callbacks.size === 0) return;
-    const event: PadEvent = { pin, ...next, prev };
-    callbacks.forEach((cb) => cb(event));
+    this.pads.report(pin, drive, pull, cycle);
   }
 
   // ── Digital pin API ──────────────────────────────────────────────────────
@@ -301,7 +281,7 @@ export class PinManager {
     this.pinPulls.clear();
     // A cold boot releases every pad; the firmware re-configures each one from
     // setup(), and the next `reportPad` must see that as a change.
-    this.padStates.clear();
+    this.pads.clear();
     for (const pin of wereHigh) {
       const callbacks = this.listeners.get(pin);
       if (callbacks) {

--- a/frontend/src/simulation/RP2040Simulator.ts
+++ b/frontend/src/simulation/RP2040Simulator.ts
@@ -7,6 +7,8 @@ import { bootromB1 } from './rp2040-bootrom';
 import { loadUF2, loadUserFiles, getFirmware } from './MicroPythonLoader';
 import { type PioPeripheral, createPioPeripheral } from './PioPeripheral';
 import { requestElectricalResolve } from './spice/electricalResolveHook';
+import type { LineCapable, LineHostPort, LineSupport } from './line/LineHost';
+import { LineSensorHub } from './line/LineSensorHub';
 
 /**
  * RP2040Simulator — Emulates Raspberry Pi Pico (RP2040) using rp2040js
@@ -230,7 +232,7 @@ export class IdleSpinDetector {
  */
 export type RP2040I2CDevice = I2CDevice;
 
-export class RP2040Simulator {
+export class RP2040Simulator implements LineCapable {
   // Drive digital INPUT pins from the solved circuit (connectDigitalInputsToMcu)
   // instead of the legacy part-seed, so digitalRead() reflects the REAL wiring:
   // a pin tied to a rail reads that rail, a button-to-GND on an INPUT_PULLUP pin
@@ -248,6 +250,8 @@ export class RP2040Simulator {
   private flashCopy: Uint8Array | null = null;
   private totalCycles = 0;
   private scheduledPinChanges: Array<{ cycle: number; pin: number; state: boolean }> = [];
+  /** Line-owning sensor models hosted on this CPU (simulation/line). Built lazily: it closes over the port. */
+  private lines: LineSensorHub | null = null;
   private pioStepAccum = 0;
   private usbCDC: USBCDC | null = null;
   private micropythonMode = false;
@@ -938,9 +942,17 @@ export class RP2040Simulator {
           if (pull === 1) gpio.setInputValue(true);
           else if (pull === 2) gpio.setInputValue(false);
           requestElectricalResolve();
+          // The pad was RELEASED. This is the event the level channel above
+          // cannot carry (no level moved, so `triggerPinChange` must stay
+          // silent, or every LED on a pin that goes input would flip), and it
+          // is exactly what a single-wire sensor waits for: a DHT22's start
+          // signal ends with pinMode(INPUT_PULLUP). It reaches the line
+          // contract through the pad channel, which reports drive, not level.
+          this.pinManager.reportPad(pin, 'z', pull, this.totalCycles);
           return;
         }
         const isHigh = state === GPIOPinState.High;
+        this.pinManager.reportPad(pin, isHigh ? 'high' : 'low', 0, this.totalCycles);
         this.pinManager.triggerPinChange(pin, isHigh, 'mcu');
         if (this.onPinChangeWithTime && this.rp2040) {
           // IClock interface exposes `nanos` (not `timeUs`)
@@ -1031,7 +1043,17 @@ export class RP2040Simulator {
         // the clock over it instead of grinding every cycle. Capped at the
         // next alarm/scheduled pin change inside advanceClock, and to a small
         // slice so the firmware re-checks its deadline (bounds overshoot).
-        const budget = Math.min(cyclesTarget - cyclesDone, IDLE_SLICE_CYCLES);
+        //
+        // This is a skip taken while the guest EXECUTES, so it is bound by the
+        // line contract's floor as well as its fence: while a self-timed reply
+        // is on a wire the guest may be measuring pulses by counting its own
+        // iterations, and a skip between two edges makes every pulse count the
+        // same (LineTimeline). The WFI branch above is exempt: a sleeping core
+        // retires nothing. `skipBudget` is 0 while the floor holds; the frame
+        // then executes the instruction it would have skipped.
+        const budget = this.lines
+          ? this.lines.skipBudget(Math.min(cyclesTarget - cyclesDone, IDLE_SLICE_CYCLES), this.totalCycles)
+          : Math.min(cyclesTarget - cyclesDone, IDLE_SLICE_CYCLES);
         const jumped = this.advanceClock(budget, pioDiv, clock);
         if (jumped <= 0) {
           cyclesDone += this.execOne(core, clock, pioDiv);
@@ -1122,6 +1144,7 @@ export class RP2040Simulator {
     this.stop();
     this.totalCycles = 0;
     this.scheduledPinChanges = [];
+    this.lines?.reset();
     this.idleDetector.reset();
     if (this.rp2040 && this.flashCopy) {
       if (this.micropythonMode) {
@@ -1400,8 +1423,42 @@ export class RP2040Simulator {
   }
 
   // ── Generic sensor registration (board-agnostic API) ──────────────────────
+  // ── Line-owning sensors (simulation/line) ─────────────────────────────────
+  // The models run here on this CPU's own cycle counter. Two mechanisms here
+  // advance time without executing — the WFI alarm skip and the idle-spin
+  // elision — and both go through advanceClock, which clamps on the next
+  // scheduled edge (the fence); the elision also asks the hub for its budget
+  // (the floor). See LineTimeline for the rule.
+
+  lineSupport(): LineSupport {
+    return { mode: 'local' };
+  }
+
+  lineHub(): LineSensorHub {
+    if (!this.lines) {
+      const port: LineHostPort = {
+        now: () => this.getCurrentCycles(),
+        clockHz: () => this.getClockHz(),
+        scheduleEdge: (pin, level, atCycle) => this.schedulePinChange(pin, level, atCycle),
+        onPad: (pin, cb) => this.pinManager.onPadChange(pin, cb),
+        // rp2040js does not model a host-owned pad: setInputValue is the
+        // input register, and a released line on its pull reads the pull's
+        // level. Seeding it is the rest, for a driven and a released pad alike.
+        restPad: (pin, level) => this.setPinState(pin, level),
+      };
+      this.lines = new LineSensorHub(port);
+    }
+    return this.lines;
+  }
+
   // RP2040 handles all sensor protocols locally via schedulePinChange,
   // so these return false / no-op — the sensor runs its own frontend logic.
+
+  /** Pads a hosted line model drives itself — the SPICE-threshold connector
+   *  asks before pushing a solved level into the guest (connectDigitalInputsToMcu). */
+  ownsPin(pin: number): boolean {
+    return this.lines?.ownsPin(pin) ?? false;
+  }
 
   registerSensor(_type: string, _pin: number, _props: Record<string, unknown>): boolean {
     return false;

--- a/frontend/src/simulation/line/LineHost.ts
+++ b/frontend/src/simulation/line/LineHost.ts
@@ -1,0 +1,73 @@
+/**
+ * LineHost — the four things a line-owning sensor needs from whatever is
+ * emulating the MCU, as one interface a simulator implements, plus the
+ * declaration a board makes about which of them it can honour.
+ *
+ *   1. tell me when the guest drives or releases my line   -> onPad
+ *   2. let me place edges at exact guest instants          -> scheduleEdge
+ *   3. tell me what guest instant it is now                -> now / clockHz
+ *   4. let nobody else drive my pad                        -> the hub claims it
+ *
+ * Every simulator used to implement a random subset of these, silently: a part
+ * on a board with no `schedulePinChange` degraded into a zero-width reply and
+ * the user saw a dead sensor with no message. With the declaration, a part
+ * asks for what it needs and gets one of three honest answers — the model runs
+ * here, the model runs somewhere else (a backend worker, an engine's own hub),
+ * or this board cannot host it and here is why. `none` is a legitimate answer;
+ * silence is not.
+ */
+
+import type { PadEvent } from './padEvent';
+import type { EdgeSink } from './LineTimeline';
+import type { LineSensorHub } from './LineSensorHub';
+
+/** The port a simulator provides for line-owning models. */
+export interface LineHostPort extends EdgeSink {
+  /** Current guest cycle. */
+  now(): number;
+  /** Cycles per second of the guest's CONFIGURED clock (see LineClock.us). */
+  clockHz(): number;
+  /** Guest drive-state changes on one pad, direction included. */
+  onPad(pin: number, cb: (e: PadEvent) => void): () => void;
+  /**
+   * Put a pad at rest. `driven` false: release it, the pull decides the level
+   * (an engine that models host ownership must not own the pad here). `driven`
+   * true: hold the level from the host side.
+   */
+  restPad(pin: number, level: boolean, driven: boolean): void;
+}
+
+/** What a board says about hosting line-owning sensors. */
+export type LineSupport =
+  /** This simulator implements {@link LineHostPort}; the models run here. */
+  | { mode: 'local' }
+  /** The models run elsewhere (a backend worker, an engine's own hub); these `sensor_type`s are served. */
+  | { mode: 'hosted'; models: readonly string[] }
+  /** Cannot host one. `why` is shown to the user. */
+  | { mode: 'none'; why: string };
+
+/**
+ * A simulator that can answer the declaration. A `local` one owns a
+ * {@link LineSensorHub} built over its own port: it needs the hub itself, to
+ * ask `skipBudget` from inside its time-skipping loop, so the hub is not
+ * something a caller creates for it.
+ */
+export interface LineCapable {
+  lineSupport(): LineSupport;
+  /** Present when `lineSupport().mode === 'local'`. */
+  lineHub?(): LineSensorHub;
+}
+
+/** True when a simulator object exposes the declaration. */
+export function isLineCapable(sim: unknown): sim is LineCapable {
+  return !!sim && typeof (sim as LineCapable).lineSupport === 'function';
+}
+
+/** The declaration of an arbitrary simulator object, `none` when it makes none. */
+export function lineSupportOf(sim: unknown): LineSupport {
+  if (isLineCapable(sim)) return sim.lineSupport();
+  return { mode: 'none', why: NO_TIMED_EDGES_WHY };
+}
+
+/** The reason a simulator with no declaration refuses: it cannot place edges in guest time. */
+export const NO_TIMED_EDGES_WHY = "this board's emulator does not place timed edges on a pad";

--- a/frontend/src/simulation/line/LineSensorHub.ts
+++ b/frontend/src/simulation/line/LineSensorHub.ts
@@ -1,0 +1,134 @@
+/**
+ * LineSensorHub — hosts line-owning sensor models on one board.
+ *
+ * One instance per simulator that declares `mode: 'local'`. It is the whole of
+ * the generic half: it turns a sensor record into a model, listens to the pad
+ * events the model asked for, hands the frames the model returns to the
+ * board's timeline, keeps the model's pins at rest between exchanges, and
+ * answers the two questions the rest of the board asks — does anything own
+ * this pad, and may the clock skip right now. It never dispatches on a
+ * sensor's name.
+ *
+ * Usage from a simulator:
+ *   const hub = new LineSensorHub(port);           // port: LineHostPort
+ *   hub.attach({ sensor_type: 'dht22', pin: 4, temperature: 21 });
+ *   // in the time-skipping path, while the guest is executing:
+ *   const allowed = hub.skipBudget(want, port.now());
+ *   // on reboot:
+ *   hub.reset();
+ */
+
+import { LineTimeline } from './LineTimeline';
+import type { LineHostPort } from './LineHost';
+import './models';
+import {
+  createLineModel,
+  type LineClock,
+  type LineModel,
+  type LineSensorRecord,
+} from './lineModels';
+
+interface Attached {
+  rec: LineSensorRecord;
+  model: LineModel;
+  unsubscribe: Array<() => void>;
+}
+
+export class LineSensorHub {
+  readonly timeline: LineTimeline;
+  private readonly port: LineHostPort;
+  private readonly clock: LineClock;
+  /** Keyed by the record's `pin` (the data or trigger pin), like the wire protocol. */
+  private readonly attached = new Map<number, Attached>();
+
+  constructor(port: LineHostPort) {
+    this.port = port;
+    this.timeline = new LineTimeline(port);
+    this.clock = {
+      now: () => port.now(),
+      us: (n) => Math.round((n * port.clockHz()) / 1_000_000),
+    };
+  }
+
+  /** Number of attached sensors. */
+  get size(): number {
+    return this.attached.size;
+  }
+
+  /**
+   * Attach a sensor. Returns false when no model is registered for its
+   * `sensor_type` — the caller reports that; nothing is attached silently. A
+   * record on a pin that already has a sensor replaces it.
+   */
+  attach(rec: LineSensorRecord): boolean {
+    const model = createLineModel(rec);
+    if (!model) return false;
+    this.detach(rec.pin);
+    const unsubscribe = model.listens.map((pin) =>
+      this.port.onPad(pin, (e) => {
+        const frame = model.onPad(e, this.clock);
+        if (frame) this.timeline.emit(frame, this.clock.now());
+      }),
+    );
+    this.attached.set(rec.pin, { rec, model, unsubscribe });
+    this.restPins(model);
+    return true;
+  }
+
+  /** New property values for the sensor keyed on `pin`. */
+  update(pin: number, props: Record<string, unknown>): void {
+    this.attached.get(pin)?.model.update(props);
+  }
+
+  detach(pin: number): void {
+    const a = this.attached.get(pin);
+    if (!a) return;
+    for (const u of a.unsubscribe) u();
+    this.attached.delete(pin);
+  }
+
+  detachAll(): void {
+    for (const pin of [...this.attached.keys()]) this.detach(pin);
+  }
+
+  /** The board rebooted: forget protocol state, forget frames, re-rest pads. */
+  reset(): void {
+    this.timeline.reset();
+    for (const a of this.attached.values()) {
+      a.model.reset();
+      this.restPins(a.model);
+    }
+  }
+
+  /** Pins any attached model drives — off limits to every other layer. */
+  ownsPin(pin: number): boolean {
+    for (const a of this.attached.values()) {
+      if (a.model.drives.includes(pin)) return true;
+    }
+    return false;
+  }
+
+  /** The skip allowed to a mechanism that advances time while the guest executes. */
+  skipBudget(want: number, nowCycle: number): number {
+    return this.timeline.skipBudget(want, nowCycle);
+  }
+
+  /** The floor alone: false while a self-timed frame is on the wire. */
+  maySkip(nowCycle: number): boolean {
+    return this.timeline.maySkip(nowCycle);
+  }
+
+  /** The fence alone: cycles to the nearest pending edge, Infinity if none. */
+  cyclesUntilNextEdge(nowCycle: number): number {
+    return this.timeline.cyclesUntilNextEdge(nowCycle);
+  }
+
+  /** The attached records, for a host that mirrors them somewhere (a worker). */
+  records(): LineSensorRecord[] {
+    return [...this.attached.values()].map((a) => a.rec);
+  }
+
+  private restPins(model: LineModel): void {
+    for (const r of model.rest()) this.port.restPad(r.pin, r.level, r.driven);
+  }
+}

--- a/frontend/src/simulation/line/LineTimeline.ts
+++ b/frontend/src/simulation/line/LineTimeline.ts
@@ -1,0 +1,230 @@
+/**
+ * LineTimeline — the ledger of host-originated pad edges on one board, and
+ * the one place that answers whether the board's clock may skip right now.
+ *
+ * WHAT IT IS FOR. A line-owning sensor answers the guest with a complete
+ * waveform: a train of edges at exact guest-time instants. Three engine
+ * families deliver those edges three ways (a sorted queue flushed after every
+ * instruction, a min-heap the engine applies in step(), a WebSocket to a
+ * worker), and each one also has a mechanism that advances simulated time
+ * WITHOUT retiring the guest's instructions: a WAITI/WFI skip, a busy-spin
+ * elision, a never-idle catch-up. Every such mechanism has to obey the same
+ * rule, and until this file the rule was implemented three times, privately,
+ * and once with a sensor's name in it. The ledger is engine-agnostic: it only
+ * ever sees frames and cycle counts.
+ *
+ * THE RULE, stated once, without naming a device:
+ *
+ *   A mechanism that advances guest time without retiring the guest's
+ *   instructions may advance only across an interval the guest cannot
+ *   measure.
+ *
+ *   (a) FENCE. Never past a pending host-originated edge. Skipping over an
+ *       edge would deliver it late or not at all.
+ *   (b) FLOOR. Not at all while a self-timed frame is open, from the cycle it
+ *       is queued to the cycle of its last edge. Inside that window the
+ *       guest's only clock may be the instructions it retires: a driver that
+ *       measures a pulse by COUNTING loop iterations reads no timer, so no
+ *       deadline exists for the fence to clamp on, and a skip that lands one
+ *       cycle before each edge and then runs a fixed number of instructions
+ *       makes every pulse, whatever its width, count the same. Measured with
+ *       Adafruit DHT.h on esp32js: 4/4 reads good without the catch-up, 0/4
+ *       with it, at ANY number of instructions per skip.
+ *   (c) IDLE EXEMPTION. A halted core — WAITI/WFI, or a spin proven free of
+ *       side effects — retires no instructions, so compressing its time can
+ *       change no count. The floor does not apply to it; the fence still
+ *       does. This clause is not a detail: arduino-pico's delay() SLEEPS,
+ *       and a DHT22 read has delays inside it. Without the exemption the
+ *       floor would freeze the Pico in the middle of every read.
+ *
+ * WHAT MAKES A FRAME SELF-TIMED is derived from its SHAPE, not from what
+ * sensor produced it: more than two edges. Two edges are one interval whose
+ * endpoints are both fenced, which a clock-reading guest measures exactly;
+ * three or more mean the guest must resolve each edge against the last, and
+ * only executing gets it there. The derived rule reproduces, unprompted, the
+ * two decisions that were measured separately before it existed: the DHT22's
+ * 84-edge frame holds the catch-up for its own ~5 ms, and the HC-SR04's 2-edge
+ * echo keeps its catch-up rather than losing up to 24 ms per ping. A model may
+ * set `selfTimed` explicitly, but only with a measurement behind it.
+ *
+ * THE HOLD IS DATA, NOT A QUERY. The model declares the frame as it schedules
+ * it; the engine loop reads only `maySkip(now)` against its own cycle count.
+ * Neither side knows what the other is.
+ *
+ * DELIVERY IS NOT DONE HERE. Each simulator already applies edges its own
+ * way; the timeline forwards every edge to the host's `scheduleEdge` at emit
+ * time and keeps only the bookkeeping the policy needs. A backwards cycle
+ * count means the guest rebooted inside the engine with no hook fired (an
+ * `esp_restart`): every open frame is forgotten, because a gate left in the
+ * old base would hold for the previous uptime.
+ */
+
+export interface HostEdge {
+  level: boolean;
+  /** Absolute guest cycle to apply the edge at. */
+  atCycle: number;
+}
+
+/** One host-originated utterance on one line: a complete waveform. */
+export interface HostEdgeFrame {
+  pin: number;
+  /** Ascending by `atCycle`. */
+  edges: ReadonlyArray<HostEdge>;
+  /**
+   * Hand the pad back to the guest at this cycle. Required on a shared
+   * open-drain line: while the host drives a pad it outranks the guest, and a
+   * sensor that keeps holding the line makes the guest's NEXT start signal
+   * unobservable — it answers once per boot and every later read times out.
+   */
+  releaseAtCycle?: number;
+  /**
+   * Override the derived floor rule. Only with a measurement: `true` on a
+   * two-edge frame a counting driver reads, `false` on a long frame that a
+   * timer-reading driver decodes and that must not hold a never-idle sketch.
+   */
+  selfTimed?: boolean;
+}
+
+/** Where the frames' edges go. Each simulator provides its own. */
+export interface EdgeSink {
+  scheduleEdge(pin: number, level: boolean, atCycle: number): void;
+  /** Optional: an engine that models host ownership of a pad. */
+  scheduleRelease?(pin: number, atCycle: number): void;
+}
+
+interface OpenFrame {
+  pin: number;
+  /** First cycle at which the frame is on the wire. */
+  from: number;
+  /** Last edge cycle. */
+  to: number;
+  edges: ReadonlyArray<HostEdge>;
+  selfTimed: boolean;
+}
+
+/** Edges above this count make a frame self-timed by default (see header). */
+export const SELF_TIMED_EDGE_THRESHOLD = 2;
+
+/** Guest cycles of slack kept past a frame's last edge before it closes. */
+const CLOSE_MARGIN_CYCLES = 0;
+
+export class LineTimeline {
+  private readonly frames: OpenFrame[] = [];
+  private lastSeen = -Infinity;
+  private readonly sink: EdgeSink;
+
+  constructor(sink: EdgeSink) {
+    this.sink = sink;
+  }
+
+  /**
+   * Queue a whole frame. Every edge is handed to the sink at once; the ledger
+   * keeps the window. Returns the cycle of the frame's last edge.
+   */
+  emit(frame: HostEdgeFrame, nowCycle: number): number {
+    this.observe(nowCycle);
+    if (frame.edges.length === 0) return nowCycle;
+    let last = -Infinity;
+    for (const e of frame.edges) {
+      if (e.atCycle < last) {
+        throw new Error(
+          `LineTimeline: edges must be ascending (pin ${frame.pin}: ${e.atCycle} after ${last})`,
+        );
+      }
+      last = e.atCycle;
+      this.sink.scheduleEdge(frame.pin, e.level, e.atCycle);
+    }
+    if (frame.releaseAtCycle !== undefined) {
+      this.sink.scheduleRelease?.(frame.pin, frame.releaseAtCycle);
+    }
+    const selfTimed = frame.selfTimed ?? frame.edges.length > SELF_TIMED_EDGE_THRESHOLD;
+    this.frames.push({
+      pin: frame.pin,
+      from: nowCycle,
+      to: Math.max(last, frame.releaseAtCycle ?? last) + CLOSE_MARGIN_CYCLES,
+      edges: frame.edges,
+      selfTimed,
+    });
+    return last;
+  }
+
+  /**
+   * Cycles from `nowCycle` to the earliest edge not yet due, or Infinity when
+   * nothing is pending. THE FENCE: a skip must stop here.
+   */
+  cyclesUntilNextEdge(nowCycle: number): number {
+    this.observe(nowCycle);
+    let best = Infinity;
+    for (const f of this.frames) {
+      for (const e of f.edges) {
+        if (e.atCycle > nowCycle) {
+          const d = e.atCycle - nowCycle;
+          if (d < best) best = d;
+          break; // edges are ascending: the first pending one is the nearest
+        }
+      }
+    }
+    return best;
+  }
+
+  /**
+   * May a time-skipping mechanism advance the clock at `nowCycle` while the
+   * guest is EXECUTING? False while any self-timed frame is open. THE FLOOR.
+   *
+   * Not for an idle core: a WAITI/WFI skip retires nothing and is bound only
+   * by the fence — see clause (c) in the header.
+   */
+  maySkip(nowCycle: number): boolean {
+    this.observe(nowCycle);
+    for (const f of this.frames) {
+      if (f.selfTimed && nowCycle >= f.from && nowCycle < f.to) return false;
+    }
+    return true;
+  }
+
+  /**
+   * The skip a mechanism is allowed at `nowCycle`: 0 while the floor holds,
+   * else `want` clamped to the fence. One expression for every engine loop.
+   */
+  skipBudget(want: number, nowCycle: number): number {
+    if (want <= 0) return 0;
+    if (!this.maySkip(nowCycle)) return 0;
+    const fence = this.cyclesUntilNextEdge(nowCycle);
+    return Math.max(0, Math.min(want, fence));
+  }
+
+  /** True while a frame on `pin` still has an edge pending or is open. */
+  ownsPin(pin: number, nowCycle: number): boolean {
+    this.observe(nowCycle);
+    return this.frames.some((f) => f.pin === pin && nowCycle < f.to);
+  }
+
+  /** True while any frame is open on any pin. */
+  get busy(): boolean {
+    return this.frames.length > 0;
+  }
+
+  /** Forget everything: run start, and whenever the cycle counter restarts. */
+  reset(): void {
+    this.frames.length = 0;
+    this.lastSeen = -Infinity;
+  }
+
+  /**
+   * Drop frames whose last edge is past. Every query prunes first, and a
+   * counter that went backwards is a reboot: forget every frame.
+   */
+  private observe(nowCycle: number): void {
+    if (nowCycle < this.lastSeen) {
+      this.frames.length = 0;
+    }
+    this.lastSeen = nowCycle;
+    if (this.frames.length === 0) return;
+    let w = 0;
+    for (let r = 0; r < this.frames.length; r++) {
+      const f = this.frames[r];
+      if (nowCycle < f.to) this.frames[w++] = f;
+    }
+    this.frames.length = w;
+  }
+}

--- a/frontend/src/simulation/line/__tests__/LineSensorHub.test.ts
+++ b/frontend/src/simulation/line/__tests__/LineSensorHub.test.ts
@@ -1,0 +1,150 @@
+/**
+ * The generic hub over a fake port: it must never need to know what a DHT22
+ * is to host one.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { LineSensorHub } from '../LineSensorHub';
+import type { LineHostPort } from '../LineHost';
+import { INITIAL_PAD, type PadEvent, type PadState } from '../padEvent';
+import '../index';
+
+function makePort(hz = 16_000_000) {
+  let now = 0;
+  const listeners = new Map<number, Set<(e: PadEvent) => void>>();
+  const pads = new Map<number, PadState>();
+  const port: LineHostPort & {
+    edges: Array<[number, boolean, number]>;
+    rests: Array<[number, boolean, boolean]>;
+    releases: Array<[number, number]>;
+    advance(c: number): void;
+    guest(pin: number, drive: PadState['drive']): void;
+  } = {
+    edges: [],
+    rests: [],
+    releases: [],
+    now: () => now,
+    clockHz: () => hz,
+    scheduleEdge: (pin, level, at) => port.edges.push([pin, level, at]),
+    scheduleRelease: (pin, at) => port.releases.push([pin, at]),
+    onPad: (pin, cb) => {
+      if (!listeners.has(pin)) listeners.set(pin, new Set());
+      listeners.get(pin)!.add(cb);
+      return () => listeners.get(pin)!.delete(cb);
+    },
+    restPad: (pin, level, driven) => port.rests.push([pin, level, driven]),
+    advance: (c) => {
+      now += c;
+    },
+    guest: (pin, drive) => {
+      const prev = pads.get(pin) ?? INITIAL_PAD;
+      const next: PadState = { drive, pull: drive === 'z' ? 1 : 0, level: drive !== 'low', cycle: now };
+      pads.set(pin, next);
+      listeners.get(pin)?.forEach((cb) => cb({ pin, ...next, prev }));
+    },
+  };
+  return port;
+}
+
+describe('LineSensorHub', () => {
+  it('attaches a known model, rests its pads, and refuses an unknown type out loud', () => {
+    const port = makePort();
+    const hub = new LineSensorHub(port);
+    expect(hub.attach({ sensor_type: 'no-such-sensor', pin: 3 })).toBe(false);
+    expect(hub.size).toBe(0);
+    expect(hub.attach({ sensor_type: 'dht22', pin: 4 })).toBe(true);
+    expect(hub.size).toBe(1);
+    expect(port.rests).toEqual([[4, true, false]]);
+    expect(hub.attach({ sensor_type: 'hc-sr04', pin: 5, echo_pin: 6 })).toBe(true);
+    expect(port.rests).toContainEqual([6, false, true]);
+  });
+
+  it('turns the guest start signal into a frame on the wire, through the timeline', () => {
+    const port = makePort();
+    const hub = new LineSensorHub(port);
+    hub.attach({ sensor_type: 'dht22', pin: 4, temperature: 21, humidity: 40 });
+    port.advance(10_000);
+    port.guest(4, 'high');
+    port.guest(4, 'low');
+    port.advance(16 * 1100);
+    port.guest(4, 'z');
+    expect(port.edges).toHaveLength(84);
+    expect(port.edges[0][2]).toBe(10_000 + 16 * 1100 + 16 * 20);
+    expect(port.releases).toHaveLength(1);
+    expect(hub.timeline.busy).toBe(true);
+    expect(hub.maySkip(port.now() + 100)).toBe(false); // 84 edges: self-timed
+    expect(hub.ownsPin(4)).toBe(true);
+  });
+
+  it('a two-edge echo does not hold the clock, only fences it', () => {
+    const port = makePort();
+    const hub = new LineSensorHub(port);
+    hub.attach({ sensor_type: 'hc-sr04', pin: 5, echo_pin: 6, distance: 20 });
+    port.guest(5, 'high');
+    expect(port.edges).toHaveLength(2);
+    expect(hub.maySkip(port.now() + 10)).toBe(true);
+    expect(hub.cyclesUntilNextEdge(port.now() + 10)).toBe(16 * 600 - 10);
+    expect(hub.skipBudget(1_000_000, port.now() + 10)).toBe(16 * 600 - 10);
+  });
+
+  it('routes updates by pin and detaches cleanly', () => {
+    const port = makePort();
+    const hub = new LineSensorHub(port);
+    hub.attach({ sensor_type: 'hc-sr04', pin: 5, echo_pin: 6, distance: 20 });
+    hub.update(5, { distance: 40 });
+    port.guest(5, 'high');
+    const echo = port.edges[1][2] - port.edges[0][2];
+    expect(echo).toBe(Math.round((40 / 17150) * 16e6));
+    hub.detach(5);
+    expect(hub.size).toBe(0);
+    expect(hub.ownsPin(6)).toBe(false);
+    port.edges.length = 0;
+    port.guest(5, 'low');
+    port.guest(5, 'high');
+    expect(port.edges).toHaveLength(0); // unsubscribed
+  });
+
+  it('re-attaching on the same pin replaces the previous model', () => {
+    const port = makePort();
+    const hub = new LineSensorHub(port);
+    hub.attach({ sensor_type: 'dht22', pin: 4, temperature: 1 });
+    hub.attach({ sensor_type: 'dht22', pin: 4, temperature: 2 });
+    expect(hub.size).toBe(1);
+    port.guest(4, 'low');
+    port.guest(4, 'z');
+    expect(port.edges).toHaveLength(84); // one reply, not two
+  });
+
+  it('reset() forgets frames and protocol state and re-rests the pads', () => {
+    const port = makePort();
+    const hub = new LineSensorHub(port);
+    hub.attach({ sensor_type: 'dht22', pin: 4 });
+    port.guest(4, 'low');
+    port.guest(4, 'z');
+    expect(hub.timeline.busy).toBe(true);
+    port.rests.length = 0;
+    hub.reset();
+    expect(hub.timeline.busy).toBe(false);
+    expect(port.rests).toEqual([[4, true, false]]);
+    // the half start signal before the reset is forgotten: a bare release does nothing
+    port.edges.length = 0;
+    port.guest(4, 'low');
+    hub.reset();
+    port.guest(4, 'z');
+    expect(port.edges).toHaveLength(0);
+  });
+
+  it('records what it hosts, for a host that mirrors the records elsewhere', () => {
+    const port = makePort();
+    const hub = new LineSensorHub(port);
+    hub.attach({ sensor_type: 'dht22', pin: 4, temperature: 21 });
+    expect(hub.records()).toEqual([{ sensor_type: 'dht22', pin: 4, temperature: 21 }]);
+  });
+
+  it('never asks the port anything on attach beyond resting pads and subscribing', () => {
+    const port = makePort();
+    const spy = vi.spyOn(port, 'scheduleEdge');
+    const hub = new LineSensorHub(port);
+    hub.attach({ sensor_type: 'dht22', pin: 4 });
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/simulation/line/__tests__/LineTimeline.test.ts
+++ b/frontend/src/simulation/line/__tests__/LineTimeline.test.ts
@@ -1,0 +1,192 @@
+/**
+ * The clock rule, as law: every clause with a negative control, so a future
+ * edit that weakens a clause fails a test whose name says which one.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { LineTimeline, SELF_TIMED_EDGE_THRESHOLD, type EdgeSink } from '../LineTimeline';
+
+function makeSink(): EdgeSink & { edges: Array<[number, boolean, number]>; releases: Array<[number, number]> } {
+  const sink = {
+    edges: [] as Array<[number, boolean, number]>,
+    releases: [] as Array<[number, number]>,
+    scheduleEdge(pin: number, level: boolean, atCycle: number) {
+      sink.edges.push([pin, level, atCycle]);
+    },
+    scheduleRelease(pin: number, atCycle: number) {
+      sink.releases.push([pin, atCycle]);
+    },
+  };
+  return sink;
+}
+
+const threeEdges = (pin: number, t0: number) => ({
+  pin,
+  edges: [
+    { level: false, atCycle: t0 + 100 },
+    { level: true, atCycle: t0 + 200 },
+    { level: false, atCycle: t0 + 300 },
+  ],
+});
+const twoEdges = (pin: number, t0: number) => ({
+  pin,
+  edges: [
+    { level: true, atCycle: t0 + 100 },
+    { level: false, atCycle: t0 + 300 },
+  ],
+});
+
+describe('LineTimeline: delivery', () => {
+  it('hands every edge to the sink at emit time, in order, and the release after them', () => {
+    const sink = makeSink();
+    const tl = new LineTimeline(sink);
+    const last = tl.emit({ ...threeEdges(4, 1000), releaseAtCycle: 1350 }, 1000);
+    expect(last).toBe(1300);
+    expect(sink.edges).toEqual([
+      [4, false, 1100],
+      [4, true, 1200],
+      [4, false, 1300],
+    ]);
+    expect(sink.releases).toEqual([[4, 1350]]);
+  });
+
+  it('refuses a frame whose edges are not ascending', () => {
+    const tl = new LineTimeline(makeSink());
+    expect(() =>
+      tl.emit({ pin: 1, edges: [{ level: true, atCycle: 200 }, { level: false, atCycle: 100 }] }, 0),
+    ).toThrow(/ascending/);
+  });
+
+  it('an empty frame is a no-op', () => {
+    const sink = makeSink();
+    const tl = new LineTimeline(sink);
+    expect(tl.emit({ pin: 1, edges: [] }, 50)).toBe(50);
+    expect(sink.edges).toEqual([]);
+    expect(tl.busy).toBe(false);
+  });
+});
+
+describe('LineTimeline: (a) the fence', () => {
+  it('reports the cycles to the nearest pending edge across frames and pins', () => {
+    const tl = new LineTimeline(makeSink());
+    tl.emit(threeEdges(4, 1000), 1000);
+    tl.emit({ pin: 7, edges: [{ level: true, atCycle: 1150 }] }, 1000);
+    expect(tl.cyclesUntilNextEdge(1000)).toBe(100);
+    expect(tl.cyclesUntilNextEdge(1120)).toBe(30); // pin 7's edge at 1150
+    expect(tl.cyclesUntilNextEdge(1250)).toBe(50);
+    expect(tl.cyclesUntilNextEdge(1300)).toBe(Infinity); // the edge AT now is due, not pending
+  });
+
+  it('skipBudget never crosses the fence', () => {
+    const tl = new LineTimeline(makeSink());
+    tl.emit(twoEdges(4, 1000), 1000); // not self-timed: the floor is open
+    expect(tl.skipBudget(1_000_000, 1000)).toBe(100);
+    expect(tl.skipBudget(50, 1000)).toBe(50);
+    expect(tl.skipBudget(1_000_000, 1100)).toBe(200);
+  });
+
+  it('negative control: with nothing pending the budget is the whole request', () => {
+    const tl = new LineTimeline(makeSink());
+    expect(tl.cyclesUntilNextEdge(0)).toBe(Infinity);
+    expect(tl.skipBudget(1_000_000, 0)).toBe(1_000_000);
+  });
+});
+
+describe('LineTimeline: (b) the floor', () => {
+  it('holds while a self-timed frame is open, from emit to its last edge', () => {
+    const tl = new LineTimeline(makeSink());
+    tl.emit(threeEdges(4, 1000), 1000);
+    expect(tl.maySkip(1000)).toBe(false);
+    expect(tl.maySkip(1150)).toBe(false);
+    expect(tl.skipBudget(10, 1150)).toBe(0);
+    expect(tl.maySkip(1299)).toBe(false);
+    expect(tl.maySkip(1300)).toBe(true);
+  });
+
+  it('a frame with more than SELF_TIMED_EDGE_THRESHOLD edges is self-timed by shape', () => {
+    expect(SELF_TIMED_EDGE_THRESHOLD).toBe(2);
+    const tl = new LineTimeline(makeSink());
+    tl.emit(threeEdges(4, 0), 0);
+    expect(tl.maySkip(50)).toBe(false);
+  });
+
+  it('negative control: a two-edge frame does NOT hold the floor (a fenced interval a clock reads exactly)', () => {
+    const tl = new LineTimeline(makeSink());
+    tl.emit(twoEdges(4, 0), 0);
+    expect(tl.maySkip(50)).toBe(true);
+    expect(tl.skipBudget(1000, 50)).toBe(50); // fenced, not floored
+  });
+
+  it('an explicit selfTimed overrides the shape both ways', () => {
+    const tl = new LineTimeline(makeSink());
+    tl.emit({ ...twoEdges(4, 0), selfTimed: true }, 0);
+    expect(tl.maySkip(50)).toBe(false);
+    const tl2 = new LineTimeline(makeSink());
+    tl2.emit({ ...threeEdges(4, 0), selfTimed: false }, 0);
+    expect(tl2.maySkip(50)).toBe(true);
+  });
+
+  it('a release after the last edge extends the window to the release', () => {
+    const tl = new LineTimeline(makeSink());
+    tl.emit({ ...threeEdges(4, 0), releaseAtCycle: 400 }, 0);
+    expect(tl.maySkip(350)).toBe(false);
+    expect(tl.ownsPin(4, 350)).toBe(true);
+    expect(tl.maySkip(400)).toBe(true);
+    expect(tl.ownsPin(4, 400)).toBe(false);
+  });
+});
+
+describe('LineTimeline: pruning and reboot', () => {
+  it('forgets a frame once its window is past', () => {
+    const tl = new LineTimeline(makeSink());
+    tl.emit(threeEdges(4, 0), 0);
+    expect(tl.busy).toBe(true);
+    tl.maySkip(300);
+    expect(tl.busy).toBe(false);
+  });
+
+  it('forgets every frame when the cycle counter goes backwards (a guest reboot inside the engine)', () => {
+    const tl = new LineTimeline(makeSink());
+    tl.emit(threeEdges(4, 1_000_000_000), 1_000_000_000);
+    expect(tl.maySkip(1_000_000_050)).toBe(false);
+    expect(tl.maySkip(1000)).toBe(true); // rebooted: cycles restarted
+    expect(tl.busy).toBe(false);
+    expect(tl.cyclesUntilNextEdge(1000)).toBe(Infinity);
+  });
+
+  it('negative control: a counter that only moves forward keeps the frame', () => {
+    const tl = new LineTimeline(makeSink());
+    tl.emit(threeEdges(4, 1000), 1000);
+    tl.maySkip(1100);
+    tl.maySkip(1200);
+    expect(tl.busy).toBe(true);
+  });
+
+  it('reset() forgets everything', () => {
+    const tl = new LineTimeline(makeSink());
+    tl.emit(threeEdges(4, 0), 0);
+    tl.reset();
+    expect(tl.busy).toBe(false);
+    expect(tl.maySkip(10)).toBe(true);
+  });
+
+  it('ownsPin is per pin and per window', () => {
+    const tl = new LineTimeline(makeSink());
+    tl.emit(threeEdges(4, 0), 0);
+    expect(tl.ownsPin(4, 10)).toBe(true);
+    expect(tl.ownsPin(5, 10)).toBe(false);
+    expect(tl.ownsPin(4, 300)).toBe(false);
+  });
+
+  it('does not call the sink for bookkeeping queries', () => {
+    const sink = makeSink();
+    const spy = vi.spyOn(sink, 'scheduleEdge');
+    const tl = new LineTimeline(sink);
+    tl.emit(threeEdges(4, 0), 0);
+    spy.mockClear();
+    tl.maySkip(10);
+    tl.cyclesUntilNextEdge(10);
+    tl.skipBudget(5, 10);
+    tl.ownsPin(4, 10);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/simulation/line/__tests__/avr.conformance.test.ts
+++ b/frontend/src/simulation/line/__tests__/avr.conformance.test.ts
@@ -28,6 +28,7 @@ function makeRig(): LineRig {
   const readReg = (a: number) => cpu.data[a] ?? 0;
   return {
     sim,
+    pads: { onPad: (p, cb) => sim.pinManager.onPadChange(p, cb), get: (p) => sim.pinManager.getPad(p) },
     pin: 8,
     otherPin: 9,
     guest: {

--- a/frontend/src/simulation/line/__tests__/avr.conformance.test.ts
+++ b/frontend/src/simulation/line/__tests__/avr.conformance.test.ts
@@ -1,0 +1,57 @@
+/**
+ * The line-host conformance suite against the real avr8js engine.
+ *
+ * The guest is driven through the ATmega328P's own I/O registers (DDRB /
+ * PORTB / PINB) with avr8js's write hooks, exactly what the Arduino core's
+ * pinMode / digitalWrite / digitalRead compile to. Pin 8 = PB0.
+ */
+import { vi } from 'vitest';
+import { AVRSimulator } from '../../AVRSimulator';
+import { PinManager } from '../../PinManager';
+import { describeLineHostConformance, type LineRig } from './lineHostConformance';
+
+vi.stubGlobal('requestAnimationFrame', () => 1);
+vi.stubGlobal('cancelAnimationFrame', () => {});
+
+const DDRB = 0x24;
+const PORTB = 0x25;
+const PINB = 0x23;
+const BIT = 1 << 0; // PB0 = Arduino pin 8
+/** `rjmp .-2`: one instruction that loops on itself, 2 cycles each. */
+const LOOP_HEX = ':02000000FFCF30\n:00000001FF\n';
+
+function makeRig(): LineRig {
+  const pm = new PinManager();
+  const sim = new AVRSimulator(pm);
+  sim.loadHex(LOOP_HEX);
+  const cpu = (sim as unknown as { cpu: { data: Uint8Array; writeData(a: number, v: number): void; readData(a: number): number } }).cpu;
+  const readReg = (a: number) => cpu.data[a] ?? 0;
+  return {
+    sim,
+    pin: 8,
+    otherPin: 9,
+    guest: {
+      modeInput(pull) {
+        cpu.writeData(DDRB, readReg(DDRB) & ~BIT);
+        cpu.writeData(PORTB, pull === 1 ? readReg(PORTB) | BIT : readReg(PORTB) & ~BIT);
+      },
+      modeOutput() {
+        cpu.writeData(DDRB, readReg(DDRB) | BIT);
+      },
+      write(level) {
+        cpu.writeData(PORTB, level ? readReg(PORTB) | BIT : readReg(PORTB) & ~BIT);
+      },
+      read() {
+        return (cpu.readData(PINB) & BIT) !== 0;
+      },
+    },
+    run(cycles) {
+      const until = sim.getCurrentCycles() + cycles;
+      while (sim.getCurrentCycles() < until) sim.step();
+    },
+    now: () => sim.getCurrentCycles(),
+    clockHz: () => sim.getClockHz(),
+  };
+}
+
+describeLineHostConformance('avr8js (Uno, pin 8)', makeRig);

--- a/frontend/src/simulation/line/__tests__/circuitCheck.test.ts
+++ b/frontend/src/simulation/line/__tests__/circuitCheck.test.ts
@@ -1,0 +1,35 @@
+/**
+ * A refused line sensor reaches the circuit check at Run, attached to its
+ * component, and a refusal for a component no longer on the canvas does not.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { verifyCircuit } from '../../verify/circuitVerifier';
+import { clearLineGaps, requestLine } from '../requestLine';
+
+describe('circuit check: unsupported line sensors', () => {
+  beforeEach(() => {
+    clearLineGaps();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('surfaces a recorded refusal as a non-blocking warning on the component', async () => {
+    requestLine(null, { sensor_type: 'dht22', pin: 4 }, { componentId: 'dht22-1' });
+    const result = await verifyCircuit({
+      components: [{ id: 'dht22-1', metadataId: 'dht22', properties: {} }],
+      boards: [],
+      wires: [],
+    } as never);
+    const w = result.warnings.find((x) => x.code === 'unsupported-sensor');
+    expect(w).toBeDefined();
+    expect(w!.componentId).toBe('dht22-1');
+    expect(w!.severity).toBe('warning');
+    expect(w!.message).toContain('dht22 on GPIO 4');
+    expect(result.errors.some((x) => x.code === 'unsupported-sensor')).toBe(false);
+  });
+
+  it('drops a refusal whose component is no longer on the canvas', async () => {
+    requestLine(null, { sensor_type: 'dht22', pin: 4 }, { componentId: 'gone' });
+    const result = await verifyCircuit({ components: [], boards: [], wires: [] } as never);
+    expect(result.warnings.some((x) => x.code === 'unsupported-sensor')).toBe(false);
+  });
+});

--- a/frontend/src/simulation/line/__tests__/lineHostConformance.ts
+++ b/frontend/src/simulation/line/__tests__/lineHostConformance.ts
@@ -160,14 +160,18 @@ export function describeLineHostConformance(name: string, makeRig: () => LineRig
       expect(answer.mode).toBe('local');
       const us = (n: number) => Math.round((n * rig.clockHz()) / 1e6);
       const edgesSeen: boolean[] = [];
-      let last = rig.guest.read();
+      const stamps: string[] = []; // "<us>:<H|L>" per edge, for the failure message
+      let last = false;
+      let sampleStart = 0;
       const sample = (cycles: number) => {
         const step = Math.max(1, us(2));
+        sampleStart = rig.now();
         for (let done = 0; done < cycles; done += step) {
           rig.run(step);
           const v = rig.guest.read();
           if (v !== last) {
             edgesSeen.push(v);
+            stamps.push(`${Math.round((rig.now() - sampleStart) / us(1))}:${v ? 'H' : 'L'}`);
             last = v;
           }
         }
@@ -181,17 +185,23 @@ export function describeLineHostConformance(name: string, makeRig: () => LineRig
         rig.guest.modeInput(1);
       };
       startSignal();
+      // The idle level is what the pull-up makes it once the guest enabled it:
+      // on a board whose released pad floats before that, reading it earlier
+      // would count the pull-up itself as an edge. The reply starts 20 us later.
+      last = rig.guest.read();
+      expect(last).toBe(true);
       sample(us(6000));
       // 2 preamble + 80 data + 2 release edges. The first LOW is the first edge.
-      expect(edgesSeen.length, `edges seen: ${edgesSeen.length}`).toBe(84);
+      expect(edgesSeen.length, `edges seen: ${edgesSeen.length} [${stamps.join(' ')}]`).toBe(84);
       expect(edgesSeen[0]).toBe(false);
       expect(edgesSeen[edgesSeen.length - 1]).toBe(true);
       expect(rig.guest.read()).toBe(true); // idles HIGH between reads
 
       edgesSeen.length = 0;
       startSignal();
+      last = rig.guest.read();
       sample(us(6000));
-      expect(edgesSeen.length, 'the second read got no reply').toBe(84);
+      expect(edgesSeen.length, `the second read: ${edgesSeen.length} edges [${stamps.slice(-90).join(' ')}]`).toBe(84);
       if (answer.mode !== 'none') answer.release();
     });
 

--- a/frontend/src/simulation/line/__tests__/lineHostConformance.ts
+++ b/frontend/src/simulation/line/__tests__/lineHostConformance.ts
@@ -18,15 +18,21 @@
  * to run the guest forward. The rest is the same for every board.
  */
 import { describe, expect, it } from 'vitest';
-import type { PinManager } from '../../PinManager';
 import type { LineCapable } from '../LineHost';
-import type { PadEvent } from '../padEvent';
+import type { PadEvent, PadState } from '../padEvent';
 import { assertedLow, releasedLow } from '../padEvent';
 import { requestLine } from '../requestLine';
 import '../index';
 
+/** Where the board's pad events can be observed: a PinManager, or an engine bridge's own bus. */
+export interface PadSource {
+  onPad(pin: number, cb: (e: PadEvent) => void): () => void;
+  get(pin: number): Readonly<PadState>;
+}
+
 export interface LineRig {
-  sim: LineCapable & { pinManager: PinManager; ownsPin(pin: number): boolean; reset(): void };
+  sim: LineCapable & { ownsPin(pin: number): boolean; reset(): void };
+  pads: PadSource;
   /** The board GPIO under test. */
   pin: number;
   /** A second, unrelated GPIO. */
@@ -48,7 +54,7 @@ export function describeLineHostConformance(name: string, makeRig: () => LineRig
   describe(`line-host conformance: ${name}`, () => {
     const collect = (rig: LineRig): PadEvent[] => {
       const events: PadEvent[] = [];
-      rig.sim.pinManager.onPadChange(rig.pin, (e) => events.push(e));
+      rig.pads.onPad(rig.pin, (e) => events.push(e));
       return events;
     };
 
@@ -67,7 +73,7 @@ export function describeLineHostConformance(name: string, makeRig: () => LineRig
       // pinMode(INPUT_PULLUP) is two register writes on most cores (direction,
       // then pull), so the pull may arrive one event later; what must hold is
       // that the pad ends up released and pulled up.
-      const pad = rig.sim.pinManager.getPad(rig.pin);
+      const pad = rig.pads.get(rig.pin);
       expect(pad.drive).toBe('z');
       expect(pad.pull).toBe(1);
       expect(pad.level).toBe(true);

--- a/frontend/src/simulation/line/__tests__/lineHostConformance.ts
+++ b/frontend/src/simulation/line/__tests__/lineHostConformance.ts
@@ -1,0 +1,208 @@
+/**
+ * The line-host conformance suite — what every board that declares
+ * `mode: 'local'` has to pass, driven through its REAL engine at the register
+ * level so nothing about the guest is mocked.
+ *
+ * Each case is a bug that actually shipped:
+ *
+ *   1. RELEASE IS OBSERVED    the RP2040 early return (ed132afb), the RP2350 listener
+ *   2. PLAIN-INPUT RELEASE    AVR saw pinMode(INPUT_PULLUP) only because PORT moved
+ *   3. ASSERT WITHOUT A LEVEL the 1-Wire reset on AVR: DDR changed, PORT did not
+ *   4. EDGES LAND             a zero-width reply on boards with no scheduler
+ *   5. THE GUEST'S TIME BASE  15 cm decoded as 22.5 cm from the chip-max clock
+ *   6. THE PAD IS OWNED       the SPICE connector latching a DHT22's line HIGH
+ *   7. A WHOLE REPLY ARRIVES  the 84 edges, and again on the NEXT start signal
+ *   8. RESET FORGETS          a stale gate after a reboot
+ *
+ * A rig adapts one board: how the guest configures and reads its pin, and how
+ * to run the guest forward. The rest is the same for every board.
+ */
+import { describe, expect, it } from 'vitest';
+import type { PinManager } from '../../PinManager';
+import type { LineCapable } from '../LineHost';
+import type { PadEvent } from '../padEvent';
+import { assertedLow, releasedLow } from '../padEvent';
+import { requestLine } from '../requestLine';
+import '../index';
+
+export interface LineRig {
+  sim: LineCapable & { pinManager: PinManager; ownsPin(pin: number): boolean; reset(): void };
+  /** The board GPIO under test. */
+  pin: number;
+  /** A second, unrelated GPIO. */
+  otherPin: number;
+  guest: {
+    modeInput(pull: 0 | 1 | 2): void;
+    modeOutput(): void;
+    write(level: boolean): void;
+    /** What digitalRead() returns on `pin`. */
+    read(): boolean;
+  };
+  /** Run the guest forward by about this many cycles, applying due edges. */
+  run(cycles: number): void;
+  now(): number;
+  clockHz(): number;
+}
+
+export function describeLineHostConformance(name: string, makeRig: () => LineRig): void {
+  describe(`line-host conformance: ${name}`, () => {
+    const collect = (rig: LineRig): PadEvent[] => {
+      const events: PadEvent[] = [];
+      rig.sim.pinManager.onPadChange(rig.pin, (e) => events.push(e));
+      return events;
+    };
+
+    it('1. reports the release of a line the guest held low (INPUT_PULLUP after LOW)', () => {
+      const rig = makeRig();
+      const events = collect(rig);
+      rig.guest.modeInput(1);
+      rig.guest.modeOutput();
+      rig.guest.write(false);
+      rig.guest.modeInput(1);
+      const low = events.findIndex(assertedLow);
+      expect(low, 'the start signal (drive low) was not reported').toBeGreaterThanOrEqual(0);
+      const rel = events.slice(low + 1).find(releasedLow);
+      expect(rel, 'the release was not reported').toBeDefined();
+      expect(rel!.drive).toBe('z');
+      // pinMode(INPUT_PULLUP) is two register writes on most cores (direction,
+      // then pull), so the pull may arrive one event later; what must hold is
+      // that the pad ends up released and pulled up.
+      const pad = rig.sim.pinManager.getPad(rig.pin);
+      expect(pad.drive).toBe('z');
+      expect(pad.pull).toBe(1);
+      expect(pad.level).toBe(true);
+    });
+
+    it('2. reports a plain-input release too (no pull-up written)', () => {
+      const rig = makeRig();
+      const events = collect(rig);
+      rig.guest.modeOutput();
+      rig.guest.write(false);
+      rig.guest.modeInput(0);
+      const rel = events.find(releasedLow);
+      expect(rel).toBeDefined();
+      expect(rel!.drive).toBe('z');
+      expect(rel!.pull).toBe(0);
+    });
+
+    it('3. reports a drive-low that moves no level (latch already zero, input -> output)', () => {
+      const rig = makeRig();
+      rig.guest.modeOutput();
+      rig.guest.write(false);
+      rig.guest.modeInput(0);
+      const events = collect(rig);
+      rig.guest.modeOutput(); // latch still 0: a level listener sees nothing
+      expect(events.some(assertedLow)).toBe(true);
+    });
+
+    it('4. lands scheduled edges where the guest reads them, in order', () => {
+      const rig = makeRig();
+      rig.guest.modeInput(0);
+      const hub = rig.sim.lineHub!();
+      const us = (n: number) => Math.round((n * rig.clockHz()) / 1e6);
+      const t0 = rig.now();
+      hub.timeline.emit(
+        {
+          pin: rig.pin,
+          edges: [
+            { level: true, atCycle: t0 + us(100) },
+            { level: false, atCycle: t0 + us(200) },
+            { level: true, atCycle: t0 + us(300) },
+          ],
+        },
+        t0,
+      );
+      rig.run(us(150) - (rig.now() - t0));
+      expect(rig.guest.read()).toBe(true);
+      rig.run(us(250) - (rig.now() - t0));
+      expect(rig.guest.read()).toBe(false);
+      rig.run(us(350) - (rig.now() - t0));
+      expect(rig.guest.read()).toBe(true);
+    });
+
+    it("5. times edges in the guest's own base: a 100 us edge lands 100 us later", () => {
+      const rig = makeRig();
+      rig.guest.modeInput(0);
+      const hub = rig.sim.lineHub!();
+      const perUs = rig.clockHz() / 1e6;
+      const t0 = rig.now();
+      hub.timeline.emit({ pin: rig.pin, edges: [{ level: true, atCycle: t0 + Math.round(100 * perUs) }] }, t0);
+      // Walk forward in small steps until the level flips; the flip must be
+      // within 2% of 100 us of guest time.
+      let landed = -1;
+      for (let i = 0; i < 400 && landed < 0; i++) {
+        rig.run(Math.max(1, Math.round(perUs)));
+        if (rig.guest.read()) landed = rig.now() - t0;
+      }
+      expect(landed).toBeGreaterThan(0);
+      expect(Math.abs(landed / perUs - 100)).toBeLessThan(2 + 1 / perUs);
+    });
+
+    it('6. owns the pads of an attached model and nothing else', () => {
+      const rig = makeRig();
+      const answer = requestLine(rig.sim, { sensor_type: 'dht22', pin: rig.pin });
+      expect(answer.mode).toBe('local');
+      expect(rig.sim.ownsPin(rig.pin)).toBe(true);
+      expect(rig.sim.ownsPin(rig.otherPin)).toBe(false);
+      if (answer.mode !== 'none') answer.release();
+      expect(rig.sim.ownsPin(rig.pin)).toBe(false);
+    });
+
+    it('7. delivers a whole DHT22 reply to a real start signal, and again on the next one', () => {
+      const rig = makeRig();
+      const answer = requestLine(rig.sim, { sensor_type: 'dht22', pin: rig.pin, temperature: 28, humidity: 65 });
+      expect(answer.mode).toBe('local');
+      const us = (n: number) => Math.round((n * rig.clockHz()) / 1e6);
+      const edgesSeen: boolean[] = [];
+      let last = rig.guest.read();
+      const sample = (cycles: number) => {
+        const step = Math.max(1, us(2));
+        for (let done = 0; done < cycles; done += step) {
+          rig.run(step);
+          const v = rig.guest.read();
+          if (v !== last) {
+            edgesSeen.push(v);
+            last = v;
+          }
+        }
+      };
+      const startSignal = () => {
+        rig.guest.modeInput(1);
+        rig.run(us(50));
+        rig.guest.modeOutput();
+        rig.guest.write(false);
+        rig.run(us(1100));
+        rig.guest.modeInput(1);
+      };
+      startSignal();
+      sample(us(6000));
+      // 2 preamble + 80 data + 2 release edges. The first LOW is the first edge.
+      expect(edgesSeen.length, `edges seen: ${edgesSeen.length}`).toBe(84);
+      expect(edgesSeen[0]).toBe(false);
+      expect(edgesSeen[edgesSeen.length - 1]).toBe(true);
+      expect(rig.guest.read()).toBe(true); // idles HIGH between reads
+
+      edgesSeen.length = 0;
+      startSignal();
+      sample(us(6000));
+      expect(edgesSeen.length, 'the second read got no reply').toBe(84);
+      if (answer.mode !== 'none') answer.release();
+    });
+
+    it('8. forgets its frames on reset', () => {
+      const rig = makeRig();
+      rig.guest.modeInput(0);
+      const hub = rig.sim.lineHub!();
+      const t0 = rig.now();
+      hub.timeline.emit(
+        { pin: rig.pin, edges: [{ level: true, atCycle: t0 + 1000 }, { level: false, atCycle: t0 + 2000 }, { level: true, atCycle: t0 + 3000 }] },
+        t0,
+      );
+      expect(hub.timeline.busy).toBe(true);
+      expect(hub.maySkip(t0 + 10)).toBe(false);
+      rig.sim.reset();
+      expect(hub.timeline.busy).toBe(false);
+      expect(hub.maySkip(0)).toBe(true);
+    });
+  });
+}

--- a/frontend/src/simulation/line/__tests__/lineHostConformance.ts
+++ b/frontend/src/simulation/line/__tests__/lineHostConformance.ts
@@ -50,7 +50,23 @@ export interface LineRig {
   clockHz(): number;
 }
 
-export function describeLineHostConformance(name: string, makeRig: () => LineRig): void {
+export interface LineConformanceOptions {
+  /**
+   * How far a scheduled edge may land from its target, in guest microseconds
+   * (case 5). Register-precise engines meet 2 us; an engine whose clock only
+   * advances in coarse spin-elision slices while it fast-forwards lands within
+   * a slice, and its own case-7 decode of a real 84-edge frame is the tighter
+   * proof that the time base is right.
+   */
+  edgeToleranceUs?: number;
+}
+
+export function describeLineHostConformance(
+  name: string,
+  makeRig: () => LineRig,
+  opts: LineConformanceOptions = {},
+): void {
+  const edgeToleranceUs = opts.edgeToleranceUs ?? 2;
   describe(`line-host conformance: ${name}`, () => {
     const collect = (rig: LineRig): PadEvent[] => {
       const events: PadEvent[] = [];
@@ -141,7 +157,7 @@ export function describeLineHostConformance(name: string, makeRig: () => LineRig
         if (rig.guest.read()) landed = rig.now() - t0;
       }
       expect(landed).toBeGreaterThan(0);
-      expect(Math.abs(landed / perUs - 100)).toBeLessThan(2 + 1 / perUs);
+      expect(Math.abs(landed / perUs - 100)).toBeLessThan(edgeToleranceUs + 1 / perUs);
     });
 
     it('6. owns the pads of an attached model and nothing else', () => {

--- a/frontend/src/simulation/line/__tests__/lineModels.test.ts
+++ b/frontend/src/simulation/line/__tests__/lineModels.test.ts
@@ -1,0 +1,191 @@
+/**
+ * The registry and the two built-in models, exercised through the same
+ * PadEvent stream a simulator would feed them.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  createLineModel,
+  hasLineModel,
+  lineModelTypes,
+  numberField,
+  registerLineModel,
+  type LineClock,
+} from '../lineModels';
+import { INITIAL_PAD, type PadEvent, type PadState } from '../padEvent';
+import { dht22Payload, dht22Frame } from '../models/dht22';
+import { hcsr04Frame, clampDistanceCm } from '../models/hc-sr04';
+import '../index';
+
+/** A 16 MHz clock the models can be run against in isolation. */
+function clockAt(now: number, hz = 16_000_000): LineClock {
+  return { now: () => now, us: (n) => Math.round((n * hz) / 1e6) };
+}
+
+/** Build the event stream a guest produces, one drive state after another. */
+function events(pin: number, drives: Array<PadState['drive']>, cycle = 0): PadEvent[] {
+  const out: PadEvent[] = [];
+  let prev: PadState = INITIAL_PAD;
+  for (const drive of drives) {
+    const next: PadState = { drive, pull: drive === 'z' ? 1 : 0, level: drive !== 'low', cycle };
+    out.push({ pin, ...next, prev });
+    prev = next;
+  }
+  return out;
+}
+
+describe('lineModels registry', () => {
+  it('knows the two built-in models and nothing it was not told', () => {
+    expect(hasLineModel('dht22')).toBe(true);
+    expect(hasLineModel('hc-sr04')).toBe(true);
+    expect(hasLineModel('ds18b20-not-registered')).toBe(false);
+    expect(createLineModel({ sensor_type: 'nope', pin: 1 })).toBeNull();
+    expect(lineModelTypes()).toEqual(expect.arrayContaining(['dht22', 'hc-sr04']));
+  });
+
+  it('adding a sensor is one registration, with no other file involved', () => {
+    registerLineModel('test-blip', (rec) => ({
+      listens: [rec.pin],
+      drives: [rec.pin],
+      rest: () => [{ pin: rec.pin, level: true, driven: false }],
+      onPad: (e, clock) =>
+        e.drive === 'z' ? { pin: rec.pin, edges: [{ level: false, atCycle: clock.now() + 1 }] } : null,
+      update: () => {},
+      reset: () => {},
+    }));
+    const m = createLineModel({ sensor_type: 'test-blip', pin: 9 })!;
+    expect(m.drives).toEqual([9]);
+    const [e] = events(9, ['z']);
+    expect(m.onPad(e, clockAt(100))!.edges[0].atCycle).toBe(101);
+  });
+
+  it('numberField accepts numbers and numeric strings, else the default', () => {
+    expect(numberField(3, 1)).toBe(3);
+    expect(numberField('24.5', 1)).toBe(24.5);
+    expect(numberField('abc', 1)).toBe(1);
+    expect(numberField(undefined, 7)).toBe(7);
+    expect(numberField(NaN, 7)).toBe(7);
+  });
+});
+
+describe('dht22 model', () => {
+  it('encodes the AM2302 payload byte for byte, sign in bit 15', () => {
+    expect([...dht22Payload(25.0, 50.0)]).toEqual([0x01, 0xf4, 0x00, 0xfa, 0xef]);
+    expect([...dht22Payload(-10.5, 33.3)]).toEqual([0x01, 0x4d, 0x80, 0x69, 0x37]);
+  });
+
+  it('answers with 84 edges: 20 us in, 80/80 preamble, 40 bits of 50 + 26|70, and a release', () => {
+    const us = clockAt(0).us;
+    const f = dht22Frame(4, 1000, dht22Payload(25, 50), us);
+    expect(f.edges).toHaveLength(84);
+    expect(f.edges[0]).toEqual({ level: false, atCycle: 1000 + us(20) });
+    expect(f.edges[1]).toEqual({ level: true, atCycle: 1000 + us(20) + us(80) });
+    expect(f.edges[2].atCycle - f.edges[1].atCycle).toBe(us(80));
+    // First data bit of 0x01 is a '0': 50 us low then 26 us high.
+    expect(f.edges[3].atCycle - f.edges[2].atCycle).toBe(us(50));
+    expect(f.edges[4].atCycle - f.edges[3].atCycle).toBe(us(26));
+    expect(f.edges[83].level).toBe(true);
+    expect(f.releaseAtCycle).toBe(f.edges[83].atCycle + us(50));
+  });
+
+  it('triggers only on a release after a low, never on the low itself or on a bare release', () => {
+    const m = createLineModel({ sensor_type: 'dht22', pin: 4, temperature: 21, humidity: 40 })!;
+    const clk = clockAt(5000);
+    const [toHigh, toLow, release] = events(4, ['high', 'low', 'z']);
+    expect(m.onPad(toHigh, clk)).toBeNull();
+    expect(m.onPad(toLow, clk)).toBeNull();
+    const frame = m.onPad(release, clk);
+    expect(frame).not.toBeNull();
+    expect(frame!.pin).toBe(4);
+    expect(frame!.edges).toHaveLength(84);
+    // A release with no preceding low is not a start signal.
+    const m2 = createLineModel({ sensor_type: 'dht22', pin: 4 })!;
+    const [bare] = events(4, ['z']);
+    expect(m2.onPad(bare, clk)).toBeNull();
+  });
+
+  it('ignores the master while its own frame is on the wire, then listens again', () => {
+    const m = createLineModel({ sensor_type: 'dht22', pin: 4 })!;
+    const [, toLow, release] = events(4, ['high', 'low', 'z']);
+    const first = m.onPad(release, clockAt(0)) ?? (m.onPad(toLow, clockAt(0)), m.onPad(release, clockAt(0)));
+    expect(first).not.toBeNull();
+    const busy = first!.releaseAtCycle! - 1;
+    expect(m.onPad(toLow, clockAt(busy))).toBeNull();
+    expect(m.onPad(release, clockAt(busy))).toBeNull();
+    const after = first!.releaseAtCycle! + 1;
+    m.onPad(toLow, clockAt(after));
+    expect(m.onPad(release, clockAt(after))).not.toBeNull();
+  });
+
+  it('update() changes the next payload; reset() forgets a half start signal', () => {
+    const m = createLineModel({ sensor_type: 'dht22', pin: 4, temperature: 25, humidity: 50 })!;
+    m.update({ temperature: -10.5, humidity: '33.3' });
+    const [, toLow, release] = events(4, ['high', 'low', 'z']);
+    m.onPad(toLow, clockAt(0));
+    m.reset();
+    expect(m.onPad(release, clockAt(0))).toBeNull(); // the low was forgotten
+    m.onPad(toLow, clockAt(0));
+    const f = m.onPad(release, clockAt(0))!;
+    // -10.5 C / 33.3 %: first data byte 0x01, so bit 7 is '0' (26 us high).
+    const us = clockAt(0).us;
+    expect(f.edges[4].atCycle - f.edges[3].atCycle).toBe(us(26));
+    // temp_H 0x80 = sign: bit 23 (edges 2 + 2*16 .. ) is '1'
+    const bit16High = f.edges[2 + 2 * 16 + 2].atCycle - f.edges[2 + 2 * 16 + 1].atCycle;
+    expect(bit16High).toBe(us(70));
+  });
+
+  it('rests its DATA line released, on the pull-up', () => {
+    const m = createLineModel({ sensor_type: 'dht22', pin: 4 })!;
+    expect(m.rest()).toEqual([{ pin: 4, level: true, driven: false }]);
+    expect(m.listens).toEqual([4]);
+    expect(m.drives).toEqual([4]);
+  });
+});
+
+describe('hc-sr04 model', () => {
+  it('answers a TRIG rise with a two-edge ECHO: 600 us later, 58 us per cm long', () => {
+    const us = clockAt(0).us;
+    const f = hcsr04Frame(6, 1000, 15, us);
+    expect(f.edges).toHaveLength(2);
+    expect(f.edges[0]).toEqual({ level: true, atCycle: 1000 + us(600) });
+    expect(f.edges[1].atCycle - f.edges[0].atCycle).toBe(us((15 / 17150) * 1e6));
+    expect(f.selfTimed).toBeUndefined(); // by shape: two edges do not hold the clock
+  });
+
+  it('listens on TRIG, drives ECHO, rests ECHO low and driven', () => {
+    const m = createLineModel({ sensor_type: 'hc-sr04', pin: 5, echo_pin: 6, distance: 30 })!;
+    expect(m.listens).toEqual([5]);
+    expect(m.drives).toEqual([6]);
+    expect(m.rest()).toEqual([{ pin: 6, level: false, driven: true }]);
+  });
+
+  it('triggers on the rise only, and not while an echo is still out', () => {
+    const m = createLineModel({ sensor_type: 'hc-sr04', pin: 5, echo_pin: 6, distance: 100 })!;
+    const [rise, fall] = events(5, ['high', 'low']);
+    expect(m.onPad(fall, clockAt(0))).toBeNull();
+    const f = m.onPad(rise, clockAt(0))!;
+    expect(f.pin).toBe(6);
+    expect(m.onPad(rise, clockAt(f.edges[1].atCycle - 1))).toBeNull();
+    expect(m.onPad(rise, clockAt(f.edges[1].atCycle + 1))).not.toBeNull();
+  });
+
+  it('clamps the distance to the sensor range and takes updates', () => {
+    expect(clampDistanceCm(1)).toBe(2);
+    expect(clampDistanceCm(999)).toBe(400);
+    const m = createLineModel({ sensor_type: 'hc-sr04', pin: 5, echo_pin: 6, distance: 999 })!;
+    const [rise] = events(5, ['high']);
+    const us = clockAt(0).us;
+    let f = m.onPad(rise, clockAt(0))!;
+    expect(f.edges[1].atCycle - f.edges[0].atCycle).toBe(us((400 / 17150) * 1e6));
+    m.update({ distance: 10 });
+    m.reset();
+    f = m.onPad(rise, clockAt(0))!;
+    expect(f.edges[1].atCycle - f.edges[0].atCycle).toBe(us((10 / 17150) * 1e6));
+  });
+
+  it('with no echo pin it drives nothing and answers nothing', () => {
+    const m = createLineModel({ sensor_type: 'hc-sr04', pin: 5 })!;
+    expect(m.drives).toEqual([]);
+    const [rise] = events(5, ['high']);
+    expect(m.onPad(rise, clockAt(0))).toBeNull();
+  });
+});

--- a/frontend/src/simulation/line/__tests__/padEvent.test.ts
+++ b/frontend/src/simulation/line/__tests__/padEvent.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertedHigh,
+  assertedLow,
+  INITIAL_PAD,
+  releasedLow,
+  restingLevel,
+  wentHiZ,
+  type PadEvent,
+  type PadState,
+} from '../padEvent';
+import { PinManager } from '../../PinManager';
+
+const ev = (prev: Partial<PadState>, next: Partial<PadState>): PadEvent => ({
+  pin: 1,
+  ...INITIAL_PAD,
+  ...next,
+  prev: { ...INITIAL_PAD, ...prev },
+});
+
+describe('padEvent predicates', () => {
+  it('releasedLow covers both release idioms and nothing else', () => {
+    expect(releasedLow(ev({ drive: 'low' }, { drive: 'z' }))).toBe(true); // push-pull: to input
+    expect(releasedLow(ev({ drive: 'low' }, { drive: 'high' }))).toBe(true); // open-drain: write a one
+    expect(releasedLow(ev({ drive: 'high' }, { drive: 'z' }))).toBe(false);
+    expect(releasedLow(ev({ drive: 'z' }, { drive: 'z', pull: 1 }))).toBe(false); // a pull change
+  });
+
+  it('assertedLow includes the level-less case (latch already zero, input -> output)', () => {
+    expect(assertedLow(ev({ drive: 'z' }, { drive: 'low' }))).toBe(true);
+    expect(assertedLow(ev({ drive: 'high' }, { drive: 'low' }))).toBe(true);
+    expect(assertedLow(ev({ drive: 'low' }, { drive: 'low', pull: 1 }))).toBe(false);
+  });
+
+  it('assertedHigh and wentHiZ', () => {
+    expect(assertedHigh(ev({ drive: 'low' }, { drive: 'high' }))).toBe(true);
+    expect(assertedHigh(ev({ drive: 'high' }, { drive: 'high' }))).toBe(false);
+    expect(wentHiZ(ev({ drive: 'high' }, { drive: 'z' }))).toBe(true);
+    expect(wentHiZ(ev({ drive: 'z' }, { drive: 'z' }))).toBe(false);
+  });
+
+  it('restingLevel: the driver, else the pull, else the previous level', () => {
+    expect(restingLevel('high', 2, false)).toBe(true);
+    expect(restingLevel('low', 1, true)).toBe(false);
+    expect(restingLevel('z', 1, false)).toBe(true);
+    expect(restingLevel('z', 2, true)).toBe(false);
+    expect(restingLevel('z', 0, true)).toBe(true);
+    expect(restingLevel('z', 0, false)).toBe(false);
+  });
+});
+
+describe('PinManager pad channel', () => {
+  it('fires on a change of drive or pull, with the previous state, and derives the level', () => {
+    const pm = new PinManager();
+    const seen: PadEvent[] = [];
+    pm.onPadChange(4, (e) => seen.push(e));
+    pm.reportPad(4, 'low', 0, 100);
+    pm.reportPad(4, 'low', 0, 200); // repeat: silent
+    pm.reportPad(4, 'z', 1, 300);
+    expect(seen).toHaveLength(2);
+    expect(seen[0]).toMatchObject({ pin: 4, drive: 'low', level: false, cycle: 100, prev: INITIAL_PAD });
+    expect(seen[1]).toMatchObject({ drive: 'z', pull: 1, level: true, cycle: 300, prev: { drive: 'low' } });
+    expect(pm.getPad(4)).toMatchObject({ drive: 'z', pull: 1, level: true });
+    expect(pm.getPad(5)).toBe(INITIAL_PAD);
+  });
+
+  it('does not double-fire the level channel: reportPad leaves onPinChange alone', () => {
+    const pm = new PinManager();
+    const levels: boolean[] = [];
+    pm.onPinChange(4, (_p, s) => levels.push(s));
+    pm.reportPad(4, 'high', 0, 1);
+    expect(levels).toEqual([]);
+  });
+
+  it('updatePort with a DDR mask reports each bit\'s drive, including a DDR-only release', () => {
+    const pm = new PinManager();
+    const seen: PadEvent[] = [];
+    pm.onPadChange(8, (e) => seen.push(e)); // PORTB bit 0
+    pm.updatePort('PORTB', 0b0000_0001, 0, undefined, 0b0000_0001, 10); // DDR=1, PORT=1: high
+    pm.updatePort('PORTB', 0b0000_0000, 1, undefined, 0b0000_0001, 20); // low
+    pm.updatePort('PORTB', 0b0000_0000, 0, undefined, 0b0000_0000, 30); // DDR cleared, PORT same: released
+    pm.updatePort('PORTB', 0b0000_0001, 0, undefined, 0b0000_0000, 40); // pull-up on
+    expect(seen.map((e) => [e.drive, e.pull, e.cycle])).toEqual([
+      ['high', 0, 10],
+      ['low', 0, 20],
+      ['z', 0, 30],
+      ['z', 1, 40],
+    ]);
+    expect(releasedLow(seen[2])).toBe(true);
+  });
+
+  it('hardResetPinStates clears the pad states so the next report is a change again', () => {
+    const pm = new PinManager();
+    pm.reportPad(4, 'high', 0, 1);
+    pm.hardResetPinStates();
+    expect(pm.getPad(4)).toBe(INITIAL_PAD);
+    const seen: PadEvent[] = [];
+    pm.onPadChange(4, (e) => seen.push(e));
+    pm.reportPad(4, 'high', 0, 2);
+    expect(seen).toHaveLength(1);
+  });
+});

--- a/frontend/src/simulation/line/__tests__/requestLine.test.ts
+++ b/frontend/src/simulation/line/__tests__/requestLine.test.ts
@@ -1,0 +1,111 @@
+/**
+ * The three honest answers, and that a refusal is recorded and loud.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearLineGaps, lineGaps, requestLine } from '../requestLine';
+import { LineSensorHub } from '../LineSensorHub';
+import type { LineCapable, LineHostPort } from '../LineHost';
+import { NO_TIMED_EDGES_WHY } from '../LineHost';
+import '../index';
+
+function fakePort(): LineHostPort {
+  return {
+    now: () => 0,
+    clockHz: () => 16e6,
+    scheduleEdge: () => {},
+    onPad: () => () => {},
+    restPad: () => {},
+  };
+}
+
+describe('requestLine', () => {
+  beforeEach(() => {
+    clearLineGaps();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('local: attaches to the board\'s own hub and hands back update/release', () => {
+    const hub = new LineSensorHub(fakePort());
+    const sim: LineCapable = { lineSupport: () => ({ mode: 'local' }), lineHub: () => hub };
+    const a = requestLine(sim, { sensor_type: 'dht22', pin: 4, temperature: 20 });
+    expect(a.mode).toBe('local');
+    expect(hub.size).toBe(1);
+    expect(hub.ownsPin(4)).toBe(true);
+    if (a.mode === 'none') throw new Error('unreachable');
+    a.update({ temperature: 30 });
+    a.release();
+    expect(hub.size).toBe(0);
+    expect(lineGaps()).toEqual([]);
+  });
+
+  it('local: refuses a sensor with no registered model, and records it', () => {
+    const sim: LineCapable = { lineSupport: () => ({ mode: 'local' }), lineHub: () => new LineSensorHub(fakePort()) };
+    const a = requestLine(sim, { sensor_type: 'ds18b20', pin: 4 });
+    expect(a.mode).toBe('none');
+    expect(lineGaps()).toEqual([{ sensorType: 'ds18b20', pin: 4, why: expect.stringContaining('no line model') }]);
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('ds18b20'));
+  });
+
+  it('hosted: goes through the legacy sensor channel when the host lists the type', () => {
+    const registerSensor = vi.fn().mockReturnValue(true);
+    const updateSensor = vi.fn();
+    const unregisterSensor = vi.fn();
+    const sim = {
+      lineSupport: () => ({ mode: 'hosted' as const, models: ['dht22', 'hc-sr04'] }),
+      registerSensor,
+      updateSensor,
+      unregisterSensor,
+    };
+    const a = requestLine(sim, { sensor_type: 'hc-sr04', pin: 5, echo_pin: 6, distance: 12 });
+    expect(a.mode).toBe('hosted');
+    expect(registerSensor).toHaveBeenCalledWith('hc-sr04', 5, { echo_pin: 6, distance: 12 });
+    if (a.mode === 'none') throw new Error('unreachable');
+    a.update({ distance: 40 });
+    expect(updateSensor).toHaveBeenCalledWith(5, { echo_pin: 6, distance: 40 }); // extra pins kept
+    a.release();
+    expect(unregisterSensor).toHaveBeenCalledWith(5);
+  });
+
+  it('hosted: refuses a type the host does not list, naming what it does model', () => {
+    const sim = { lineSupport: () => ({ mode: 'hosted' as const, models: ['dht22'] }), registerSensor: vi.fn() };
+    const a = requestLine(sim, { sensor_type: 'hc-sr04', pin: 5, echo_pin: 6 });
+    expect(a.mode).toBe('none');
+    if (a.mode !== 'none') throw new Error('unreachable');
+    expect(a.why).toContain('dht22');
+    expect(sim.registerSensor).not.toHaveBeenCalled();
+  });
+
+  it('hosted: a host that declines is a refusal, not a silent success', () => {
+    const sim = { lineSupport: () => ({ mode: 'hosted' as const, models: ['dht22'] }), registerSensor: () => false };
+    expect(requestLine(sim, { sensor_type: 'dht22', pin: 4 }).mode).toBe('none');
+  });
+
+  it('none: a board with no declaration refuses with the timed-edges reason', () => {
+    const a = requestLine({ setPinState() {}, isRunning: () => false }, { sensor_type: 'dht22', pin: 4 });
+    expect(a).toEqual({ mode: 'none', why: NO_TIMED_EDGES_WHY });
+    expect(lineGaps()).toHaveLength(1);
+  });
+
+  it('none: a board that declares why passes its reason through', () => {
+    const sim: LineCapable = { lineSupport: () => ({ mode: 'none', why: 'the guest polls its pins over a serial link' }) };
+    const a = requestLine(sim, { sensor_type: 'dht22', pin: 4 });
+    expect(a.mode === 'none' && a.why).toBe('the guest polls its pins over a serial link');
+  });
+
+  it('records the asking component so the circuit check can point at it', () => {
+    requestLine(null, { sensor_type: 'dht22', pin: 4 }, { componentId: 'dht22-7' });
+    expect(lineGaps()[0].componentId).toBe('dht22-7');
+  });
+
+  it('no board at all is a refusal too', () => {
+    expect(requestLine(null, { sensor_type: 'dht22', pin: 4 }).mode).toBe('none');
+  });
+
+  it('a later success clears the recorded gap for that sensor and pin', () => {
+    requestLine(null, { sensor_type: 'dht22', pin: 4 });
+    expect(lineGaps()).toHaveLength(1);
+    const sim: LineCapable = { lineSupport: () => ({ mode: 'local' }), lineHub: () => new LineSensorHub(fakePort()) };
+    requestLine(sim, { sensor_type: 'dht22', pin: 4 });
+    expect(lineGaps()).toHaveLength(0);
+  });
+});

--- a/frontend/src/simulation/line/__tests__/rp2040.conformance.test.ts
+++ b/frontend/src/simulation/line/__tests__/rp2040.conformance.test.ts
@@ -1,0 +1,156 @@
+/**
+ * The line-host conformance suite against the real rp2040js engine, plus the
+ * one rule that is this board's own: its idle-spin elision is a skip taken
+ * while the guest executes, so it must hold while a self-timed reply is on a
+ * wire.
+ *
+ * The guest is driven through the RP2040's own registers — SIO OE/OUT, the
+ * PADS pull bits, IO_BANK0 funcsel — exactly what the pico-sdk's gpio_* and
+ * arduino-pico's pinMode / digitalWrite compile to. GPIO5 under test.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { RP2040 } from 'rp2040js';
+import { RP2040Simulator } from '../../RP2040Simulator';
+import { PinManager } from '../../PinManager';
+import { describeLineHostConformance, type LineRig } from './lineHostConformance';
+
+vi.stubGlobal('requestAnimationFrame', () => 1);
+vi.stubGlobal('cancelAnimationFrame', () => {});
+
+const RAM = 0x20000000;
+const NOP = 0xbf00;
+const B_BACK_1 = 0xe7fd; // b .-2 : a side-effect-free spin the elision recognises
+const SIO = 0xd0000000;
+const GPIO_IN = SIO + 0x004;
+const GPIO_OUT_SET = SIO + 0x014;
+const GPIO_OUT_CLR = SIO + 0x018;
+const GPIO_OE_SET = SIO + 0x024;
+const GPIO_OE_CLR = SIO + 0x028;
+const IO_BANK0 = 0x40014000;
+const PADS_BANK0 = 0x4001c000;
+const FUNCSEL_SIO = 5;
+/** PADS: IE | DRIVE=4mA | SCHMITT, plus the pull bits (PUE = 8, PDE = 4). */
+const PAD_BASE = 0x52;
+const F_CPU = 125_000_000;
+
+function makeRig(pin = 5): LineRig {
+  const rp = new RP2040();
+  [NOP, B_BACK_1].forEach((op, i) => rp.writeUint16(RAM + i * 2, op));
+  rp.core.PC = RAM;
+  const sim = new RP2040Simulator(new PinManager());
+  // The bare core goes in directly (the loader needs a firmware image); the
+  // GPIO listeners the loader would have wired are attached the same way.
+  (sim as unknown as { rp2040: RP2040 }).rp2040 = rp;
+  (sim as unknown as { setupGpioListeners(): void }).setupGpioListeners();
+  rp.writeUint32(IO_BANK0 + 4 + 8 * pin, FUNCSEL_SIO);
+  rp.writeUint32(PADS_BANK0 + 4 + 4 * pin, PAD_BASE);
+  const mask = 1 << pin;
+  return {
+    sim,
+    pin,
+    otherPin: pin + 1,
+    guest: {
+      modeInput(pull) {
+        rp.writeUint32(GPIO_OE_CLR, mask);
+        rp.writeUint32(PADS_BANK0 + 4 + 4 * pin, PAD_BASE | (pull === 1 ? 8 : pull === 2 ? 4 : 0));
+      },
+      modeOutput() {
+        rp.writeUint32(GPIO_OE_SET, mask);
+      },
+      write(level) {
+        rp.writeUint32(level ? GPIO_OUT_SET : GPIO_OUT_CLR, mask);
+      },
+      read() {
+        return (rp.readUint32(GPIO_IN) & mask) !== 0;
+      },
+    },
+    run(cycles) {
+      const until = sim.getCurrentCycles() + cycles;
+      while (sim.getCurrentCycles() < until) sim.runFrameForTime(Math.max(0.01, (until - sim.getCurrentCycles()) / (F_CPU / 1000)));
+    },
+    now: () => sim.getCurrentCycles(),
+    clockHz: () => sim.getClockHz(),
+  };
+}
+
+describeLineHostConformance('rp2040js (Pico, GPIO5)', () => makeRig());
+
+describe('rp2040js: the clock rule on the idle-spin elision', () => {
+  it('elides the spin freely while no reply is on a wire', () => {
+    const rig = makeRig();
+    const { instructionsExecuted, cyclesAdvanced } = (rig.sim as RP2040Simulator).runFrameForTime(16);
+    expect(cyclesAdvanced).toBeGreaterThan(1_900_000);
+    expect(instructionsExecuted).toBeLessThan(5_000); // the win the elision exists for
+  });
+
+  it('does NOT elide the spin while a self-timed reply is open (the floor)', () => {
+    const rig = makeRig();
+    const hub = rig.sim.lineHub!();
+    const t0 = rig.now();
+    // A frame of the shape a counting driver reads: three edges spread over 4 ms.
+    hub.timeline.emit(
+      {
+        pin: rig.pin,
+        edges: [
+          { level: true, atCycle: t0 + 125_000 },
+          { level: false, atCycle: t0 + 250_000 },
+          { level: true, atCycle: t0 + 500_000 },
+        ],
+      },
+      t0,
+    );
+    const { instructionsExecuted } = (rig.sim as RP2040Simulator).runFrameForTime(4); // 4 ms = 500k cycles
+    // Every cycle inside the open frame is executed, not skipped.
+    expect(instructionsExecuted).toBeGreaterThan(200_000);
+  });
+
+  it('negative control: the same frame with selfTimed:false lets the elision run', () => {
+    const rig = makeRig();
+    const hub = rig.sim.lineHub!();
+    const t0 = rig.now();
+    hub.timeline.emit(
+      {
+        pin: rig.pin,
+        edges: [
+          { level: true, atCycle: t0 + 125_000 },
+          { level: false, atCycle: t0 + 250_000 },
+          { level: true, atCycle: t0 + 500_000 },
+        ],
+        selfTimed: false,
+      },
+      t0,
+    );
+    const { instructionsExecuted } = (rig.sim as RP2040Simulator).runFrameForTime(4);
+    expect(instructionsExecuted).toBeLessThan(5_000);
+  });
+
+  it('still lands every edge of the frame while the floor holds (the fence keeps working)', () => {
+    const rig = makeRig();
+    rig.guest.modeInput(0);
+    const hub = rig.sim.lineHub!();
+    const t0 = rig.now();
+    hub.timeline.emit(
+      {
+        pin: rig.pin,
+        edges: [
+          { level: true, atCycle: t0 + 125_000 },
+          { level: false, atCycle: t0 + 250_000 },
+          { level: true, atCycle: t0 + 500_000 },
+        ],
+      },
+      t0,
+    );
+    // Sample the guest's own GPIO_IN as it runs: every edge is observed, in order.
+    const seen: boolean[] = [];
+    let last = rig.guest.read();
+    while (rig.now() - t0 < 600_000) {
+      rig.run(2_000);
+      const v = rig.guest.read();
+      if (v !== last) {
+        seen.push(v);
+        last = v;
+      }
+    }
+    expect(seen).toEqual([true, false, true]);
+  });
+});

--- a/frontend/src/simulation/line/__tests__/rp2040.conformance.test.ts
+++ b/frontend/src/simulation/line/__tests__/rp2040.conformance.test.ts
@@ -47,6 +47,7 @@ function makeRig(pin = 5): LineRig {
   const mask = 1 << pin;
   return {
     sim,
+    pads: { onPad: (p, cb) => sim.pinManager.onPadChange(p, cb), get: (p) => sim.pinManager.getPad(p) },
     pin,
     otherPin: pin + 1,
     guest: {

--- a/frontend/src/simulation/line/index.ts
+++ b/frontend/src/simulation/line/index.ts
@@ -5,6 +5,7 @@
  */
 
 export * from './padEvent';
+export { PadBus } from './padBus';
 export * from './LineTimeline';
 export * from './lineModels';
 export * from './LineHost';

--- a/frontend/src/simulation/line/index.ts
+++ b/frontend/src/simulation/line/index.ts
@@ -1,0 +1,14 @@
+/**
+ * The line-owning sensor contract. Import this module (not its files) so the
+ * built-in models register themselves; a new device adds one file under
+ * `./models/` and one import line here.
+ */
+
+export * from './padEvent';
+export * from './LineTimeline';
+export * from './lineModels';
+export * from './LineHost';
+export { LineSensorHub } from './LineSensorHub';
+export * from './requestLine';
+
+import './models';

--- a/frontend/src/simulation/line/lineModels.ts
+++ b/frontend/src/simulation/line/lineModels.ts
@@ -1,0 +1,117 @@
+/**
+ * lineModels — the registry of line-owning sensor models, and the shape of
+ * one.
+ *
+ * A line-owning sensor is a device that answers the guest on a wire the guest
+ * also drives (DHT22, DS18B20, an IR demodulator) or on a companion wire it
+ * pulses back (HC-SR04's ECHO). Its MODEL is real per-device behaviour — the
+ * waveform it answers with — and belongs in one file per device under
+ * `./models/`. Everything else about hosting such a sensor is generic and
+ * lives in {@link LineSensorHub}: which pad events reach the model, where its
+ * edges go, how its pads are claimed, and when the board's clock may skip.
+ *
+ * Adding a sensor is therefore two data edits and no code edits anywhere else:
+ * one entry in `simulation/sensorModels.ts` (the canvas-facing declaration:
+ * which component pins carry data, which properties the model reads) and one
+ * `registerLineModel(sensorType, factory)` call in a new file under
+ * `./models/`. No simulator, bridge or engine learns the sensor's name; they
+ * only ever see frames and cycle counts.
+ */
+
+import type { PadEvent } from './padEvent';
+import type { HostEdgeFrame } from './LineTimeline';
+
+/** What a model needs from the board's clock. */
+export interface LineClock {
+  /** Current guest cycle. */
+  now(): number;
+  /**
+   * Microseconds to guest cycles at the frequency THE GUEST HAS CONFIGURED, not
+   * the chip maximum. `core.cycles` is the guest's own counter, and a driver
+   * measures a pulse as (fall - rise) / its configured MHz; a fixture on the
+   * bare-IDF 160 MHz default once decoded an injected 15 cm as 22.5 cm because
+   * the host used the chip's 240 MHz.
+   */
+  us(microseconds: number): number;
+}
+
+/** A pad's resting state when nobody is talking on it. */
+export interface PadRest {
+  pin: number;
+  level: boolean;
+  /**
+   * `true`: the sensor holds the level itself (an HC-SR04 drives ECHO low
+   * between pings). `false`: the line is released and the level is what the
+   * pull produces (a DHT22's DATA idles on its pull-up). The distinction
+   * matters to engines that model host ownership of a pad: a released line
+   * must not be host-owned, or the guest's next start signal becomes
+   * unobservable.
+   */
+  driven: boolean;
+}
+
+export interface LineModel {
+  /** Board pins the model must hear guest pad events on. */
+  readonly listens: readonly number[];
+  /** Board pins the model drives, so they can be claimed. */
+  readonly drives: readonly number[];
+  /** Resting state of each driven pin, applied at attach and reset. */
+  rest(): PadRest[];
+  /**
+   * One guest pad event on a pin from `listens`. Return the frame to put on
+   * the wire, or null. Host-originated edges never arrive here: a simulator
+   * reports the GUEST's drive state, and an injected input changes none of it.
+   */
+  onPad(e: PadEvent, clock: LineClock): HostEdgeFrame | null;
+  /** New values from the canvas (a slider moved). Unknown keys are ignored. */
+  update(props: Record<string, unknown>): void;
+  /** Forget protocol state: the board rebooted. */
+  reset(): void;
+}
+
+/**
+ * The record the canvas hands over: `sensor_type`, the resolved board GPIO
+ * of the data (or trigger) pin, extra pins by field name (`echo_pin`), and
+ * the property values (`temperature`, `distance`, …). Same shape the wire
+ * protocol to a backend worker carries, so one record serves both hosts.
+ */
+export interface LineSensorRecord {
+  sensor_type: string;
+  pin: number;
+  [field: string]: unknown;
+}
+
+export type LineModelFactory = (rec: LineSensorRecord) => LineModel;
+
+const factories = new Map<string, LineModelFactory>();
+
+/** Register the model for one `sensor_type`. Re-registering replaces. */
+export function registerLineModel(sensorType: string, factory: LineModelFactory): void {
+  factories.set(sensorType, factory);
+}
+
+/** Whether a model exists for `sensor_type` (what a host can promise to run). */
+export function hasLineModel(sensorType: string): boolean {
+  return factories.has(sensorType);
+}
+
+/** Every registered `sensor_type`. */
+export function lineModelTypes(): string[] {
+  return [...factories.keys()];
+}
+
+/** Build a model for a record, or null when no model is registered for it. */
+export function createLineModel(rec: LineSensorRecord): LineModel | null {
+  const make = factories.get(rec.sensor_type);
+  return make ? make(rec) : null;
+}
+
+/** A finite number off a record field, else the default. */
+export function numberField(v: unknown, dflt: number): number {
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  if (typeof v === 'string') {
+    const n = parseFloat(v);
+    if (Number.isFinite(n)) return n;
+  }
+  return dflt;
+}

--- a/frontend/src/simulation/line/models/dht22.ts
+++ b/frontend/src/simulation/line/models/dht22.ts
@@ -1,0 +1,111 @@
+/**
+ * DHT22 (AM2302) — single-wire, bidirectional, self-timed.
+ *
+ *  1. MCU holds DATA LOW for >= 1 ms (start signal)
+ *  2. MCU RELEASES DATA (a direction change; the pull-up raises the line)
+ *  3. Sensor: 80 us LOW, 80 us HIGH (response preamble)
+ *  4. 40 bits MSB first, each 50 us LOW + (26 us HIGH = '0' | 70 us HIGH = '1')
+ *  5. 50 us LOW, then the sensor releases the line
+ *
+ * Payload: [hum_H, hum_L, temp_H, temp_L, checksum], humidity in 0.1 %RH,
+ * temperature in 0.1 C with the sign in bit 15.
+ *
+ * The frame has 84 edges, so the timeline treats it as self-timed and holds
+ * the board's clock catch-up for its ~5 ms: Adafruit's DHT.h measures each
+ * pulse by counting digitalRead() iterations, and a clock skip between two
+ * edges collapses every count to the same value.
+ */
+
+import { assertedLow, releasedLow } from '../padEvent';
+import type { HostEdge, HostEdgeFrame } from '../LineTimeline';
+import { numberField, registerLineModel, type LineClock, type LineModel } from '../lineModels';
+
+export const DHT22_DEFAULT_TEMPERATURE_C = 25.0;
+export const DHT22_DEFAULT_HUMIDITY_PCT = 50.0;
+
+/** The 5-byte payload, byte-for-byte what a real AM2302 sends. */
+export function dht22Payload(temperatureC: number, humidityPct: number): Uint8Array {
+  const humidity = Math.round(humidityPct * 10);
+  const temperature = Math.round(temperatureC * 10);
+  const h_H = (humidity >> 8) & 0xff;
+  const h_L = humidity & 0xff;
+  const rawTemp = temperature < 0 ? (-temperature & 0x7fff) | 0x8000 : temperature & 0x7fff;
+  const t_H = (rawTemp >> 8) & 0xff;
+  const t_L = rawTemp & 0xff;
+  const chk = (h_H + h_L + t_H + t_L) & 0xff;
+  return new Uint8Array([h_H, h_L, t_H, t_L, chk]);
+}
+
+/** The response waveform on DATA, starting ~20 us after the MCU's release. */
+export function dht22Frame(
+  pin: number,
+  releaseCycle: number,
+  payload: Uint8Array,
+  us: (n: number) => number,
+): HostEdgeFrame {
+  const RESPONSE_START = us(20);
+  const LOW80 = us(80);
+  const HIGH80 = us(80);
+  const LOW50 = us(50);
+  const HIGH0 = us(26);
+  const HIGH1 = us(70);
+
+  const edges: HostEdge[] = [];
+  let t = releaseCycle + RESPONSE_START;
+  edges.push({ level: false, atCycle: t });
+  t += LOW80;
+  edges.push({ level: true, atCycle: t });
+  t += HIGH80;
+  for (const byte of payload) {
+    for (let b = 7; b >= 0; b--) {
+      const bit = (byte >> b) & 1;
+      edges.push({ level: false, atCycle: t });
+      t += LOW50;
+      edges.push({ level: true, atCycle: t });
+      t += bit ? HIGH1 : HIGH0;
+    }
+  }
+  edges.push({ level: false, atCycle: t });
+  t += LOW50;
+  edges.push({ level: true, atCycle: t });
+  // The sensor lets go right after its final HIGH: a small margin so the last
+  // edge is applied before the pad returns to the guest.
+  return { pin, edges, releaseAtCycle: t + us(50) };
+}
+
+registerLineModel('dht22', (rec) => {
+  const pin = rec.pin;
+  let temperatureC = numberField(rec.temperature, DHT22_DEFAULT_TEMPERATURE_C);
+  let humidityPct = numberField(rec.humidity, DHT22_DEFAULT_HUMIDITY_PCT);
+  let wasLow = false;
+  /** While the sensor talks it does not listen: real hardware ignores the master until its frame is out. */
+  let busyUntil = -Infinity;
+
+  const model: LineModel = {
+    listens: [pin],
+    drives: [pin],
+    rest: () => [{ pin, level: true, driven: false }],
+    onPad(e, clock: LineClock) {
+      const now = clock.now();
+      if (now < busyUntil) return null;
+      if (assertedLow(e)) {
+        wasLow = true;
+        return null;
+      }
+      if (!releasedLow(e) || !wasLow) return null;
+      wasLow = false;
+      const frame = dht22Frame(pin, now, dht22Payload(temperatureC, humidityPct), clock.us);
+      busyUntil = frame.releaseAtCycle ?? frame.edges[frame.edges.length - 1].atCycle;
+      return frame;
+    },
+    update(props) {
+      if ('temperature' in props) temperatureC = numberField(props.temperature, temperatureC);
+      if ('humidity' in props) humidityPct = numberField(props.humidity, humidityPct);
+    },
+    reset() {
+      wasLow = false;
+      busyUntil = -Infinity;
+    },
+  };
+  return model;
+});

--- a/frontend/src/simulation/line/models/hc-sr04.ts
+++ b/frontend/src/simulation/line/models/hc-sr04.ts
@@ -1,0 +1,78 @@
+/**
+ * HC-SR04 ultrasonic ranger — a trigger on one wire, a timed pulse back on
+ * another.
+ *
+ *  1. MCU raises TRIG (>= 10 us)
+ *  2. ~600 us later the sensor raises ECHO
+ *  3. ECHO stays high for the round trip: distance_cm / 17150 s (~58 us/cm)
+ *  4. ECHO falls
+ *
+ * Two edges, so the timeline does NOT treat the frame as self-timed: every
+ * ultrasonic driver in the catalog (arduino-esp32 pulseIn, NewPing, the hcsr04
+ * library) times the echo with micros(), which a fenced skip keeps exact, and
+ * holding a never-idle sketch's catch-up for up to 24 ms per ping would cost
+ * it almost all of it.
+ */
+
+import { assertedHigh } from '../padEvent';
+import type { HostEdgeFrame } from '../LineTimeline';
+import { numberField, registerLineModel, type LineClock, type LineModel } from '../lineModels';
+
+export const HCSR04_DEFAULT_DISTANCE_CM = 10;
+export const HCSR04_MIN_DISTANCE_CM = 2;
+export const HCSR04_MAX_DISTANCE_CM = 400;
+/** Sensor overhead between the trigger and the start of the echo. */
+export const HCSR04_PROCESSING_US = 600;
+/** Round-trip speed of sound: distance_cm / 17150 seconds of echo. */
+export const HCSR04_CM_PER_SECOND = 17150;
+
+export function clampDistanceCm(cm: number): number {
+  return Math.max(HCSR04_MIN_DISTANCE_CM, Math.min(HCSR04_MAX_DISTANCE_CM, cm));
+}
+
+/** The ECHO pulse for a trigger at `triggerCycle`. */
+export function hcsr04Frame(
+  echoPin: number,
+  triggerCycle: number,
+  distanceCm: number,
+  us: (n: number) => number,
+): HostEdgeFrame {
+  const processing = us(HCSR04_PROCESSING_US);
+  const echo = us((distanceCm / HCSR04_CM_PER_SECOND) * 1e6);
+  return {
+    pin: echoPin,
+    edges: [
+      { level: true, atCycle: triggerCycle + processing },
+      { level: false, atCycle: triggerCycle + processing + echo },
+    ],
+  };
+}
+
+registerLineModel('hc-sr04', (rec) => {
+  const trigPin = rec.pin;
+  const echoPin = numberField(rec.echo_pin, NaN);
+  let distanceCm = clampDistanceCm(numberField(rec.distance, HCSR04_DEFAULT_DISTANCE_CM));
+  let busyUntil = -Infinity;
+
+  const model: LineModel = {
+    listens: [trigPin],
+    drives: Number.isFinite(echoPin) ? [echoPin] : [],
+    rest: () => (Number.isFinite(echoPin) ? [{ pin: echoPin, level: false, driven: true }] : []),
+    onPad(e, clock: LineClock) {
+      if (!Number.isFinite(echoPin)) return null;
+      if (!assertedHigh(e)) return null;
+      const now = clock.now();
+      if (now < busyUntil) return null; // still emitting the previous echo
+      const frame = hcsr04Frame(echoPin, now, distanceCm, clock.us);
+      busyUntil = frame.edges[frame.edges.length - 1].atCycle;
+      return frame;
+    },
+    update(props) {
+      if ('distance' in props) distanceCm = clampDistanceCm(numberField(props.distance, distanceCm));
+    },
+    reset() {
+      busyUntil = -Infinity;
+    },
+  };
+  return model;
+});

--- a/frontend/src/simulation/line/models/index.ts
+++ b/frontend/src/simulation/line/models/index.ts
@@ -1,0 +1,8 @@
+/**
+ * The built-in line-owning sensor models. Importing this module registers
+ * them; `requestLine` and `LineSensorHub` import it so a model is on the
+ * registry wherever a sensor can be asked for or hosted, with no caller having
+ * to remember. A new device is one file here and one line below.
+ */
+import './dht22';
+import './hc-sr04';

--- a/frontend/src/simulation/line/padBus.ts
+++ b/frontend/src/simulation/line/padBus.ts
@@ -1,0 +1,51 @@
+/**
+ * PadBus — the pad drive-state channel, as one reusable piece.
+ *
+ * `PinManager` carries it for the boards whose simulator reports through the
+ * manager (AVR, RP2040, RP2350). A bridge that owns an engine directly (the
+ * in-browser ESP32 engines) carries its own bus, fed from the engine's
+ * callbacks, and hands it to the same {@link LineSensorHub}. Same dedup, same
+ * derived resting level, same event shape, one implementation.
+ */
+
+import { INITIAL_PAD, restingLevel, type PadDrive, type PadEvent, type PadPull, type PadState } from './padEvent';
+
+export class PadBus {
+  private readonly states = new Map<number, PadState>();
+  private readonly listeners = new Map<number, Set<(e: PadEvent) => void>>();
+
+  /** Subscribe to guest drive-state changes on one pad. */
+  onPad(pin: number, callback: (e: PadEvent) => void): () => void {
+    if (!this.listeners.has(pin)) this.listeners.set(pin, new Set());
+    this.listeners.get(pin)!.add(callback);
+    return () => {
+      this.listeners.get(pin)?.delete(callback);
+    };
+  }
+
+  /** The pad's current drive state (released with no pull until reported). */
+  get(pin: number): Readonly<PadState> {
+    return this.states.get(pin) ?? INITIAL_PAD;
+  }
+
+  /**
+   * Report what the guest did to a pad. Fires only on a real change of drive
+   * or pull; the resting level is derived here so no reporter computes it.
+   */
+  report(pin: number, drive: PadDrive, pull: PadPull, cycle: number): void {
+    const prev = this.states.get(pin) ?? INITIAL_PAD;
+    if (prev.drive === drive && prev.pull === pull) return;
+    const level = restingLevel(drive, pull, prev.level);
+    const next: PadState = { drive, pull, level, cycle };
+    this.states.set(pin, next);
+    const callbacks = this.listeners.get(pin);
+    if (!callbacks || callbacks.size === 0) return;
+    const event: PadEvent = { pin, ...next, prev };
+    callbacks.forEach((cb) => cb(event));
+  }
+
+  /** Every pad back to released-with-no-pull, silently: a cold boot. */
+  clear(): void {
+    this.states.clear();
+  }
+}

--- a/frontend/src/simulation/line/padEvent.ts
+++ b/frontend/src/simulation/line/padEvent.ts
@@ -1,0 +1,87 @@
+/**
+ * padEvent — what a board pad is DOING, reported the same way by every
+ * simulator.
+ *
+ * Every simulator used to report the LEVEL it happened to write: avr8js the
+ * PORT bit, rp2040js the latch, the ESP32 engines GPIO_OUT. That loses the one
+ * event a single-wire sensor is waiting for. A DHT22, a DS18B20, an HC-SR04's
+ * partner on a shared line — all of them end the master's start signal by
+ * RELEASING the wire: `pinMode(INPUT_PULLUP)`, a change of DIRECTION that
+ * writes no level. A level-only listener sees the falling edge of the start
+ * signal and then nothing, the sensor never answers, and the sketch prints its
+ * failure line forever. That is how the same DHT22 went dead on three board
+ * families for three different-looking reasons.
+ *
+ * So the unit of reporting is the pad's drive state, not a level: driving low,
+ * driving high, or released (`'z'`), plus the pull the guest programmed and
+ * the guest cycle it happened at. The two questions every line-owning model
+ * asks are derived once, below, so no part re-derives them and gets them
+ * subtly wrong.
+ */
+
+/** What the MCU is doing to the pad. `'z'` = released: an input, high-Z. */
+export type PadDrive = 'low' | 'high' | 'z';
+
+/** Internal pull the guest programmed: 0 none, 1 up, 2 down. */
+export type PadPull = 0 | 1 | 2;
+
+export interface PadState {
+  drive: PadDrive;
+  pull: PadPull;
+  /**
+   * The line's resting level: the driven level while driving, else what the
+   * pull would produce, else the previous level (a bus keeper, or nothing at
+   * all on the pad — a released line with no pull keeps what it had).
+   */
+  level: boolean;
+  /** Guest cycles at the change, in the board's own base. -1 = no counter. */
+  cycle: number;
+}
+
+export interface PadEvent extends PadState {
+  pin: number;
+  prev: Readonly<PadState>;
+}
+
+/** The state a pad has before the guest ever touches it: released, no pull. */
+export const INITIAL_PAD: Readonly<PadState> = Object.freeze({
+  drive: 'z' as PadDrive,
+  pull: 0 as PadPull,
+  level: false,
+  cycle: -1,
+});
+
+/**
+ * The MCU let go of a line it was holding low. Both release idioms qualify:
+ * push-pull drivers release by going to input (`drive` becomes `'z'`), and
+ * open-drain drivers release by writing a one (`drive` becomes `'high'`). A
+ * model that genuinely needs the high-Z form tests `e.drive === 'z'` on top.
+ */
+export const releasedLow = (e: PadEvent): boolean => e.prev.drive === 'low' && e.drive !== 'low';
+
+/**
+ * The MCU started holding a line low. Includes the case a level listener can
+ * never see: the latch already reads zero and the pin goes input -> output. That
+ * is a 1-Wire reset pulse on AVR, where DDR changes with PORT unchanged.
+ */
+export const assertedLow = (e: PadEvent): boolean => e.prev.drive !== 'low' && e.drive === 'low';
+
+/** The MCU started driving the line high (a TRIG pulse starts this way). */
+export const assertedHigh = (e: PadEvent): boolean =>
+  e.prev.drive !== 'high' && e.drive === 'high';
+
+/** The pad went high-Z from any driven state. */
+export const wentHiZ = (e: PadEvent): boolean => e.prev.drive !== 'z' && e.drive === 'z';
+
+/**
+ * The resting level of a pad from its drive and pull. `previous` is what the
+ * line held before, for a released pad with no pull — nothing on silicon moves
+ * it, so the model keeps it.
+ */
+export function restingLevel(drive: PadDrive, pull: PadPull, previous: boolean): boolean {
+  if (drive === 'high') return true;
+  if (drive === 'low') return false;
+  if (pull === 1) return true;
+  if (pull === 2) return false;
+  return previous;
+}

--- a/frontend/src/simulation/line/requestLine.ts
+++ b/frontend/src/simulation/line/requestLine.ts
@@ -1,0 +1,140 @@
+/**
+ * requestLine — what a canvas part calls instead of poking a simulator for
+ * `schedulePinChange` and falling back to something silent when it is not
+ * there.
+ *
+ * The part states what it is (`sensor_type`), which board pins it sits on and
+ * its current property values, and gets back one of three answers:
+ *
+ *   local   the board's own hub attached the model; the part forwards property
+ *           updates to `update()` and calls `release()` on unmount.
+ *   hosted  the model runs elsewhere (a backend worker, an engine's hub) and
+ *           the board was told; same two methods.
+ *   none    the board cannot host this sensor. The part gets `why`, the gap is
+ *           recorded for the circuit check, and nothing pretends to work.
+ *
+ * The part never learns which host it got, and the host never learns which
+ * part asked.
+ */
+
+import { hasLineModel, type LineSensorRecord } from './lineModels';
+import { isLineCapable, NO_TIMED_EDGES_WHY, type LineSupport } from './LineHost';
+import './models';
+
+export interface LineLease {
+  mode: 'local' | 'hosted';
+  update(props: Record<string, unknown>): void;
+  release(): void;
+}
+
+export interface LineRefusal {
+  mode: 'none';
+  why: string;
+}
+
+export type LineAnswer = LineLease | LineRefusal;
+
+/**
+ * The legacy sensor channel a simulator may expose: `registerSensor` returns
+ * true when a worker or an engine hub took the sensor. Kept as the transport
+ * behind `mode: 'hosted'` so the ESP32 and STM32 shims need no new surface.
+ */
+interface LegacySensorChannel {
+  registerSensor(type: string, pin: number, props: Record<string, unknown>): boolean;
+  updateSensor(pin: number, props: Record<string, unknown>): void;
+  unregisterSensor(pin: number): void;
+}
+
+/** Recorded refusals, for the circuit check to surface at Run. */
+export interface LineGap {
+  sensorType: string;
+  pin: number;
+  why: string;
+  /** The canvas component that asked, when it said so — for the circuit check to point at it. */
+  componentId?: string;
+}
+
+export interface LineRequestOptions {
+  /** The canvas component asking, so a refusal can be attached to it. */
+  componentId?: string;
+}
+const gaps = new Map<string, LineGap>();
+
+/** Every refusal recorded since the last `clearLineGaps()`. */
+export function lineGaps(): LineGap[] {
+  return [...gaps.values()];
+}
+
+export function clearLineGaps(): void {
+  gaps.clear();
+}
+
+function refuse(rec: LineSensorRecord, why: string, opts?: LineRequestOptions): LineRefusal {
+  gaps.set(`${rec.sensor_type}@${rec.pin}`, {
+    sensorType: rec.sensor_type,
+    pin: rec.pin,
+    why,
+    componentId: opts?.componentId,
+  });
+  console.warn(`[line] ${rec.sensor_type} on pin ${rec.pin}: ${why}`);
+  return { mode: 'none', why };
+}
+
+/**
+ * Ask `sim` to host the sensor described by `rec`.
+ *
+ * Order: a `local` declaration wins (the model runs in the browser, on the
+ * board's own clock); a `hosted` declaration that lists this `sensor_type`
+ * goes through the legacy sensor channel; anything else is refused with the
+ * board's own reason.
+ */
+export function requestLine(
+  sim: object | null | undefined,
+  rec: LineSensorRecord,
+  opts?: LineRequestOptions,
+): LineAnswer {
+  if (!sim) return refuse(rec, 'no board is wired to this sensor', opts);
+  const support: LineSupport = isLineCapable(sim)
+    ? sim.lineSupport()
+    : { mode: 'none', why: NO_TIMED_EDGES_WHY };
+
+  if (support.mode === 'local') {
+    if (!hasLineModel(rec.sensor_type)) {
+      return refuse(rec, `no line model is registered for '${rec.sensor_type}'`, opts);
+    }
+    const hub = isLineCapable(sim) && sim.lineHub ? sim.lineHub() : null;
+    if (!hub) return refuse(rec, 'the board declares local line support but provides no hub', opts);
+    hub.attach(rec);
+    gaps.delete(`${rec.sensor_type}@${rec.pin}`);
+    return {
+      mode: 'local',
+      update: (props) => hub.update(rec.pin, props),
+      release: () => hub.detach(rec.pin),
+    };
+  }
+
+  if (support.mode === 'hosted') {
+    if (!support.models.includes(rec.sensor_type)) {
+      return refuse(
+        rec,
+        `this board's emulator models ${support.models.length ? support.models.join(', ') : 'no line sensors'}, not '${rec.sensor_type}'`,
+        opts,
+      );
+    }
+    const chan = sim as Partial<LegacySensorChannel>;
+    if (typeof chan.registerSensor !== 'function') {
+      return refuse(rec, 'the board declares hosted line support but has no sensor channel', opts);
+    }
+    const { sensor_type, pin, ...props } = rec;
+    const taken = chan.registerSensor(sensor_type, pin, props);
+    if (!taken) return refuse(rec, 'the host declined the sensor', opts);
+    gaps.delete(`${rec.sensor_type}@${rec.pin}`);
+    return {
+      mode: 'hosted',
+      update: (p) => chan.updateSensor?.(pin, { ...props, ...p }),
+      release: () => chan.unregisterSensor?.(pin),
+    };
+  }
+
+  return refuse(rec, support.why, opts);
+}

--- a/frontend/src/simulation/parts/ProtocolParts.ts
+++ b/frontend/src/simulation/parts/ProtocolParts.ts
@@ -19,6 +19,7 @@
  */
 
 import { PartSimulationRegistry } from './PartSimulationRegistry';
+import { requestLine } from '../line/requestLine';
 import { VirtualDS1307, VirtualBMP280, VirtualDS3231, VirtualPCF8574 } from '../I2CBusManager';
 import type { I2CDevice } from '../I2CBusManager';
 import { HD44780Decoder } from '../HD44780Decoder';
@@ -597,196 +598,42 @@ PartSimulationRegistry.register('mpu6050', {
 // ─── DHT22 Temperature / Humidity Sensor ─────────────────────────────────────
 
 /**
- * DHT22 (AM2302) — single-wire bidirectional protocol.
+ * DHT22 (AM2302) — a line-owning sensor. The protocol (start signal, 40-bit
+ * self-timed reply on the same wire) is the MODEL in simulation/line/models/
+ * dht22.ts, hosted by whichever board the part is wired to under the line
+ * contract. This part only binds the canvas element to that contract: it says
+ * what it is and where it sits, forwards slider changes, and shows the
+ * board's answer when the board cannot host it.
  *
- * Protocol summary:
- *  1. MCU drives DATA LOW for ≥1 ms  (start signal)
- *  2. MCU releases DATA HIGH
- *  3. DHT22 drives: 80 µs LOW → 80 µs HIGH (response)
- *  4. DHT22 transmits 40 bits: each bit = 50 µs LOW + (26 µs=0 | 70 µs=1) HIGH
- *  5. Data layout: [humidity_H, humidity_L, temp_H, temp_L, checksum]
- *     Humidity in 0.1%, Temperature in 0.1°C (MSB = sign for temp)
- *
- * TIMING NOTE:
- *  Full µs-accuracy requires injecting pin changes inside the CPU execution
- *  loop. This implementation drives DATA via setPinState() after detecting the
- *  start sequence. It works with simple polling-based DHT22 code. The standard
- *  Arduino DHT library uses pulseIn() counts; exact cycle-accuracy is not
- *  achievable without modifying the AVR execution loop.
- *
- * Default values: 50.0% humidity, 25.0°C temperature.
- * These can be changed by setting element properties: `el.temperature`, `el.humidity`.
+ * Default values: 50.0% humidity, 25.0 C. Change via `el.temperature` /
+ * `el.humidity`.
  */
-function buildDHT22Payload(element: HTMLElement): Uint8Array {
-  const el = element as any;
-  const humidity = Math.round((el.humidity ?? 50.0) * 10); // tenths of %
-  const temperature = Math.round((el.temperature ?? 25.0) * 10); // tenths of °C
-  const h_H = (humidity >> 8) & 0xff;
-  const h_L = humidity & 0xff;
-  // Temperature sign bit is bit 15 of the 16-bit value
-  const rawTemp = temperature < 0 ? (-temperature & 0x7fff) | 0x8000 : temperature & 0x7fff;
-  const t_H = (rawTemp >> 8) & 0xff;
-  const t_L = rawTemp & 0xff;
-  const chk = (h_H + h_L + t_H + t_L) & 0xff;
-  return new Uint8Array([h_H, h_L, t_H, t_L, chk]);
-}
-
-/**
- * Schedule the full DHT22 waveform on DATA using cycle-accurate pin changes.
- *
- * DHT22 protocol (after MCU releases DATA HIGH):
- *  - 80 µs LOW  → 80 µs HIGH  (response preamble)
- *  - 40 bits, each: 50 µs LOW + (26 µs HIGH = '0', 70 µs HIGH = '1')
- *  - Line released HIGH after last bit
- *
- * At 16 MHz: 1 µs = 16 cycles
- *  - 80 µs = 1280 cycles, 50 µs = 800 cycles, 26 µs = 416 cycles, 70 µs = 1120 cycles
- */
-function scheduleDHT22Response(simulator: any, pin: number, element: HTMLElement): void {
-  if (typeof simulator.schedulePinChange !== 'function') {
-    // Fallback: synchronous drive (legacy / non-AVR simulators)
-    const payload = buildDHT22Payload(element);
-    simulator.setPinState(pin, false);
-    simulator.setPinState(pin, true);
-    for (const byte of payload) {
-      for (let b = 7; b >= 0; b--) {
-        const bit = (byte >> b) & 1;
-        simulator.setPinState(pin, false);
-        simulator.setPinState(pin, !!bit);
-      }
-    }
-    simulator.setPinState(pin, true);
-    return;
-  }
-
-  const payload = buildDHT22Payload(element);
-  const now = simulator.getCurrentCycles() as number;
-
-  // Scale timing by CPU clock — AVR runs at 16 MHz, RP2040 at 125 MHz.
-  const clockHz: number =
-    typeof simulator.getClockHz === 'function' ? simulator.getClockHz() : 16_000_000;
-  const us = (microseconds: number) => Math.round((microseconds * clockHz) / 1_000_000);
-
-  const RESPONSE_START = us(20); // DHT22 response start (~20 µs after MCU releases)
-  const LOW80 = us(80); // 80 µs LOW preamble
-  const HIGH80 = us(80); // 80 µs HIGH preamble
-  const LOW50 = us(50); // 50 µs LOW marker before each bit
-  const HIGH0 = us(26); // 26 µs HIGH → bit '0'
-  const HIGH1 = us(70); // 70 µs HIGH → bit '1'
-
-  let t = now + RESPONSE_START;
-
-  // Preamble: 80 µs LOW
-  simulator.schedulePinChange(pin, false, t);
-  t += LOW80;
-  // Preamble: 80 µs HIGH
-  simulator.schedulePinChange(pin, true, t);
-  t += HIGH80;
-
-  // 40 data bits, MSB first — schedule LOW then advance, schedule HIGH then advance
-  for (const byte of payload) {
-    for (let b = 7; b >= 0; b--) {
-      const bit = (byte >> b) & 1;
-      simulator.schedulePinChange(pin, false, t);
-      t += LOW50;
-      simulator.schedulePinChange(pin, true, t);
-      t += bit ? HIGH1 : HIGH0;
-    }
-  }
-
-  // Final release
-  simulator.schedulePinChange(pin, false, t);
-  t += LOW50;
-  simulator.schedulePinChange(pin, true, t);
-}
-
 PartSimulationRegistry.register('dht22', {
   attachEvents: (element, simulator, getPin, componentId) => {
     // wokwi-dht22 element uses 'SDA' as the data pin name (not 'DATA')
     const pin = getPin('SDA') ?? getPin('DATA');
     if (pin === null) return () => {};
 
-    // Ask the simulator if it handles sensor protocols natively (e.g. ESP32
-    // delegates to backend QEMU).  If so, we only forward property updates.
-    const el = element as any;
-    const temperature = el.temperature ?? 25.0;
-    const humidity = el.humidity ?? 50.0;
+    const el = element as { temperature?: number; humidity?: number };
+    const answer = requestLine(simulator, {
+      sensor_type: 'dht22',
+      pin,
+      temperature: el.temperature ?? 25.0,
+      humidity: el.humidity ?? 50.0,
+    }, { componentId });
 
-    const handledNatively =
-      typeof (simulator as any).registerSensor === 'function' &&
-      (simulator as any).registerSensor('dht22', pin, { temperature, humidity });
-
-    if (handledNatively) {
-      registerSensorUpdate(componentId, (values) => {
-        if ('temperature' in values) el.temperature = values.temperature as number;
-        if ('humidity' in values) el.humidity = values.humidity as number;
-        (simulator as any).updateSensor(pin, {
-          temperature: el.temperature ?? 25.0,
-          humidity: el.humidity ?? 50.0,
-        });
-      });
-
-      return () => {
-        (simulator as any).unregisterSensor(pin);
-        unregisterSensorUpdate(componentId);
-      };
-    }
-
-    let wasLow = false;
-    // Prevent DHT22's own scheduled pin changes from re-triggering the response.
-    // After the MCU releases DATA HIGH and we begin responding, we ignore all
-    // pin-change callbacks until the full waveform has been emitted.
-    // DHT22 response is ~5 ms; gate for ~12.5 ms scaled to the CPU clock.
-
-    const clockHz: number =
-      typeof (simulator as any).getClockHz === 'function'
-        ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (simulator as any).getClockHz()
-        : 16_000_000;
-    const RESPONSE_GATE_CYCLES = Math.round((12_500 * clockHz) / 1_000_000);
-    let responseEndCycle = 0;
-    let responseEndTimeMs = 0; // time-based fallback for ESP32 (no cycle counter)
-
-    const getCycles = (): number =>
-      typeof (simulator as any).getCurrentCycles === 'function'
-        ? ((simulator as any).getCurrentCycles() as number)
-        : -1;
-
-    const unsub = (simulator as any).pinManager.onPinChange(pin, (_: number, state: boolean) => {
-      // While DHT22 is driving the line, ignore our own scheduled changes.
-      const now = getCycles();
-      if (now >= 0 && now < responseEndCycle) return;
-      // Time-based fallback for ESP32 (no cycle counter available)
-      if (now < 0 && Date.now() < responseEndTimeMs) return;
-
-      if (!state) {
-        // MCU drove DATA LOW — start signal detected
-        wasLow = true;
-        return;
-      }
-      if (wasLow) {
-        // MCU released DATA HIGH — begin DHT22 response
-        wasLow = false;
-        const cur = getCycles();
-        responseEndCycle = cur >= 0 ? cur + RESPONSE_GATE_CYCLES : 0;
-        responseEndTimeMs = Date.now() + 20; // 20ms gate for non-cycle simulators
-        scheduleDHT22Response(simulator, pin, element);
-      }
-    });
-
-    // Idle state: DATA HIGH (pulled up)
-    simulator.setPinState(pin, true);
-
-    // SensorControlPanel: update temperature / humidity on the element
+    // SensorControlPanel: update temperature / humidity on the element, and
+    // tell the host when there is one.
     registerSensorUpdate(componentId, (values) => {
-      const el = element as any;
       if ('temperature' in values) el.temperature = values.temperature as number;
       if ('humidity' in values) el.humidity = values.humidity as number;
+      if (answer.mode !== 'none') {
+        answer.update({ temperature: el.temperature ?? 25.0, humidity: el.humidity ?? 50.0 });
+      }
     });
 
     return () => {
-      unsub();
-      simulator.setPinState(pin, true);
+      if (answer.mode !== 'none') answer.release();
       unregisterSensorUpdate(componentId);
     };
   },

--- a/frontend/src/simulation/parts/SensorParts.ts
+++ b/frontend/src/simulation/parts/SensorParts.ts
@@ -18,6 +18,7 @@
  */
 
 import { PartSimulationRegistry } from './PartSimulationRegistry';
+import { requestLine } from '../line/requestLine';
 import { setAdcVoltage, emitPropertyChange, analogRailVolts } from './partUtils';
 import { registerSensorUpdate, unregisterSensorUpdate } from '../SensorUpdateRegistry';
 
@@ -651,12 +652,11 @@ PartSimulationRegistry.register('ks2e-m-dc5', {
 // ─── HC-SR04 Ultrasonic Distance Sensor ──────────────────────────────────────
 
 /**
- * Ultrasonic sensor — monitors the TRIG pin.
- * When TRIG goes HIGH, responds with an ECHO HIGH pulse whose duration
- * encodes the configured distance (default 10 cm).
- *
- * Echo timing: echoMs = distanceCm / 17.15
- * (speed of sound ~343 m/s; round-trip halves: 17150 cm/s)
+ * HC-SR04 — a line-owning sensor: a trigger on one wire, a timed ECHO pulse
+ * back on another. The pulse (600 us overhead, then distance_cm / 17150 s) is
+ * the MODEL in simulation/line/models/hc-sr04.ts, hosted by the board under
+ * the line contract. This part binds the canvas element to it and forwards
+ * the distance slider.
  */
 PartSimulationRegistry.register('hc-sr04', {
   attachEvents: (element, simulator, getArduinoPinHelper, componentId) => {
@@ -664,77 +664,22 @@ PartSimulationRegistry.register('hc-sr04', {
     const echoPin = getArduinoPinHelper('ECHO');
     if (trigPin === null || echoPin === null) return () => {};
 
-    const el = element as any;
-    let distanceCm = parseFloat(el.distance) || 10; // default distance in cm
-
-    // ── ESP32 path: delegate protocol to backend QEMU worker ──
-
-    const handledNatively =
-      typeof (simulator as any).registerSensor === 'function' &&
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (simulator as any).registerSensor('hc-sr04', trigPin, {
-        distance: distanceCm,
-        echo_pin: echoPin,
-      });
-
-    if (handledNatively) {
-      registerSensorUpdate(componentId, (values) => {
-        if ('distance' in values) {
-          distanceCm = Math.max(2, Math.min(400, values.distance as number));
-        }
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (simulator as any).updateSensor(trigPin, {
-          distance: distanceCm,
-          echo_pin: echoPin,
-        });
-      });
-
-      return () => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (simulator as any).unregisterSensor(trigPin);
-        unregisterSensorUpdate(componentId);
-      };
-    }
-
-    // ── AVR / RP2040 path: local pin scheduling ──
-    simulator.setPinState(echoPin, false); // ECHO LOW initially
-
-    const cleanup = simulator.pinManager.onPinChange(trigPin, (_: number, state: boolean) => {
-      if (!state) return; // only react on TRIG HIGH
-      if (typeof simulator.schedulePinChange === 'function') {
-        const clockHz: number =
-          typeof (simulator as any).getClockHz === 'function'
-            ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              (simulator as any).getClockHz()
-            : 16_000_000;
-        const now = simulator.getCurrentCycles() as number;
-        const processingCycles = Math.round(600e-6 * clockHz); // 600 µs sensor overhead
-        const echoCycles = Math.round((distanceCm / 17150) * clockHz);
-        simulator.schedulePinChange(echoPin, true, now + processingCycles);
-        simulator.schedulePinChange(echoPin, false, now + processingCycles + echoCycles);
-        console.log(
-          `[HC-SR04] Scheduled ECHO (${distanceCm} cm, echo=${(echoCycles / (clockHz / 1e6)).toFixed(1)} µs)`,
-        );
-      } else {
-        // Fallback: best-effort async (works with delay()-based sketches, not pulseIn)
-        const echoMs = Math.max(1, distanceCm / 17.15);
-        setTimeout(() => {
-          simulator.setPinState(echoPin, true);
-          setTimeout(() => {
-            simulator.setPinState(echoPin, false);
-          }, echoMs);
-        }, 1);
-      }
-    });
+    const el = element as { distance?: string | number };
+    const answer = requestLine(simulator, {
+      sensor_type: 'hc-sr04',
+      pin: trigPin,
+      echo_pin: echoPin,
+      distance: parseFloat(String(el.distance)) || 10,
+    }, { componentId });
 
     registerSensorUpdate(componentId, (values) => {
-      if ('distance' in values) {
-        distanceCm = Math.max(2, Math.min(400, values.distance as number));
+      if ('distance' in values && answer.mode !== 'none') {
+        answer.update({ distance: values.distance as number });
       }
     });
 
     return () => {
-      cleanup();
+      if (answer.mode !== 'none') answer.release();
       unregisterSensorUpdate(componentId);
     };
   },

--- a/frontend/src/simulation/verify/circuitVerifier.ts
+++ b/frontend/src/simulation/verify/circuitVerifier.ts
@@ -21,6 +21,7 @@
  * The verifier never throws; if ngspice fails to converge it returns a
  * single solver-error warning and the rest of the rules are skipped.
  */
+import { lineGaps } from '../line/requestLine';
 import { buildNetlist } from '../spice/NetlistBuilder';
 import { runNetlist as runSpice } from '../spice/runNetlist';
 import { UnionFind } from '../spice/unionFind';
@@ -43,6 +44,7 @@ export type WarningCode =
   | 'shorted-component'
   | 'resistor-overpower'
   | 'led-no-current'
+  | 'unsupported-sensor'
   | 'unpowered-net'
   | 'no-return-path'
   | 'voltage-mismatch';
@@ -109,6 +111,25 @@ export async function verifyCircuit(
   // Run a forced .op solve so currents are scalar and deterministic.
   const opInput: BuildNetlistInput = { ...input, analysis: { kind: 'op' } };
   const { netlist, pinNetMap } = buildNetlist(opInput);
+
+  // ── Line-owning sensors the wired board cannot host (no solve) ────────
+  // A DHT22 or an HC-SR04 asks the board it is wired to for the line
+  // contract when it mounts (simulation/line/requestLine). A board that
+  // cannot honour it refuses with a reason, and that reason is the only thing
+  // standing between the user and a sensor that silently never answers: the
+  // Pi family reads its pins over a serial link, the STM32 worker has no
+  // single-wire handlers, a QEMU engine that does not exist for this chip.
+  // Surfaced here, at Run, next to the electrical checks. Non-blocking: the
+  // rest of the circuit may be fine.
+  for (const gap of lineGaps()) {
+    if (gap.componentId && !input.components.some((c) => c.id === gap.componentId)) continue;
+    warnings.push({
+      severity: 'warning',
+      code: 'unsupported-sensor',
+      componentId: gap.componentId,
+      message: `${gap.sensorType} on GPIO ${gap.pin} will not answer here: ${gap.why}`,
+    });
+  }
 
   // ── Board over-voltage (graph-based, no solve) ─────────────────────────
   // Runs BEFORE the solve so it still reports even when an external source on

--- a/frontend/src/store/useSimulatorStore.ts
+++ b/frontend/src/store/useSimulatorStore.ts
@@ -69,6 +69,7 @@ import {
 } from '../simulation/Interconnect';
 import { SENSOR_CONTROLS, getSensorControl, getSensorControlForComponent } from '../simulation/sensorControlConfig';
 import { SINGLE_WIRE_SENSOR_MODELS } from '../simulation/sensorModels';
+import type { LineSupport } from '../simulation/line/LineHost';
 import { traceBoardGpio } from '../simulation/PinTrace';
 import { dispatchSensorUpdate } from '../simulation/SensorUpdateRegistry';
 
@@ -328,6 +329,12 @@ class Esp32BridgeShim {
 
   // ── Generic sensor registration (board-agnostic API) ──────────────────────
   // ESP32 delegates sensor protocols to the backend QEMU.
+
+  /** The line contract's declaration: whatever the bridge behind this shim
+   *  can host (the QEMU worker's models, or an in-browser engine's). */
+  lineSupport(): LineSupport {
+    return this.bridge.lineSupport();
+  }
 
   registerSensor(type: string, pin: number, properties: Record<string, unknown>): boolean {
     this.bridge.sendSensorAttach(type, pin, properties);
@@ -834,6 +841,17 @@ class Stm32BridgeShim {
   feedUart(uart: number, data: string): boolean {
     this.bridge.sendSerialBytes(Array.from(new TextEncoder().encode(data)), uart);
     return true;
+  }
+
+  /** The STM32 worker reuses the ESP32 worker's device models but leaves out
+   *  the DHT22 / HC-SR04 sync handlers (stm32_worker.py header), so a
+   *  line-owning sensor on an STM32 has nothing to answer it. Said here, so
+   *  the part hears it instead of waiting on a silent pad. */
+  lineSupport(): LineSupport {
+    return {
+      mode: 'none',
+      why: "the STM32 emulator's worker does not model single-wire sensors (no DHT22 / HC-SR04 handlers)",
+    };
   }
 
   // ── Generic sensor registration (delegated to the backend QEMU worker) ──


### PR DESCRIPTION
## What

A **contract** for line-owning sensors (DHT22, HC-SR04, and every future single-wire device), replacing the per-simulator guesswork that had the same DHT22 dead on three board families for three different reasons.

`frontend/src/simulation/line/`:

- **padEvent**: what a pad is *doing* (`low` / `high` / `z`) + pull + guest cycle, reported by every simulator through `PinManager.reportPad`. `releasedLow` / `assertedLow` derived once. This is the event every board was losing: a single-wire sensor's start signal ends with `pinMode(INPUT_PULLUP)`, a direction change that writes no level.
- **LineTimeline**: the ledger of host-originated frames and the clock rule for every time-skipping mechanism: (a) never skip past a pending edge, (b) never skip while a self-timed frame is open, (c) an idle core is exempt. A frame with more than two edges is self-timed *by shape*; the rule reproduces the two measured decisions (DHT22 holds the catch-up, HC-SR04 does not) without naming either.
- **lineModels** + `models/`: the registry; a sensor is one file returning its waveform from the pad events it hears.
- **LineSensorHub**: the generic host: record -> model -> pad subscription -> timeline; owns pins; answers `skipBudget`.
- **LineHost**: the port a simulator implements and its declaration: `local`, `hosted` (these types), or `none` with a reason.
- **requestLine**: what a part calls. One of three honest answers, never silence; a refusal is recorded and the circuit check shows it at Run.

## Boards

- `AVRSimulator`, `RP2040Simulator`: declare `local`, build their hub over their own port. RP2040's idle-spin elision asks the hub for its budget (the WFI skip stays exempt so a sleeping `delay()` inside a read does not freeze). AVR's port listeners now react to DDR changes too.
- `Esp32Bridge`: declares `hosted` with the QEMU worker's models. STM32 and Pi shims declare `none` with their reason.
- The DHT22 and HC-SR04 parts lose their protocol code and their three silent fallbacks.

## Fixes

- **Pico / Pico W: DHT22 dead since ed132afb (2026-06-26).** The early return on the input branch swallowed the release. The shipped `pico-dht22` example reads again. `ed132afb`'s purpose (SPICE-driven inputs) is preserved.

## Tests

Contract law with negative controls, models, hub, requestLine, circuit check, and a **conformance suite run against the real avr8js and rp2040js engines at the register level** (release observed in both idioms and the level-less assert, edges land, guest time base, pad ownership, a whole 84-edge reply on two consecutive reads, reset). The RP2040 suite proves the floor holds the elision while a frame is open and lets it run otherwise.

Full suite: 2762 passed.

Companion overlay change in velxio-prod moves the five in-browser ESP32 bridges and the RP2350 simulator onto the same contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQ8CjHtC1yL4rjs8TS6kWC
