### PR TITLE
feat(sim): per-board line-support declaration, and honest Linux boards

### DIFF
--- a/frontend/src/__tests__/board-line-support.test.ts
+++ b/frontend/src/__tests__/board-line-support.test.ts
@@ -1,0 +1,14 @@
+import { it, expect } from 'vitest';
+import {
+  registerBoardLineSupport,
+  getBoardLineSupport,
+} from '../lib/proBoardRegistry';
+
+it('per-kind line support: registered wins, unregistered is undefined (caller defaults)', () => {
+  expect(getBoardLineSupport('unihiker-m10')).toBeUndefined();
+  registerBoardLineSupport('unihiker-m10', { mode: 'hosted', models: ['dht22', 'hc-sr04'] });
+  expect(getBoardLineSupport('unihiker-m10')).toEqual({ mode: 'hosted', models: ['dht22', 'hc-sr04'] });
+  // A kind nobody registered stays undefined, so the Pi shim falls to its
+  // own `none` default rather than a bogus support object.
+  expect(getBoardLineSupport('raspberry-pi-5')).toBeUndefined();
+});

--- a/frontend/src/components/DynamicComponent.tsx
+++ b/frontend/src/components/DynamicComponent.tsx
@@ -25,6 +25,7 @@ import { buildProjectSdImage, decodeSdFiles } from '../utils/sdCardFiles';
 import { PartSimulationRegistry } from '../simulation/parts';
 import { dispatchSensorUpdate } from '../simulation/SensorUpdateRegistry';
 import { isPiBoardKind } from '../types/board';
+import { getBoardLineSupport } from '../lib/proBoardRegistry';
 import { isKeyBindable, formatKeyLabel } from '../utils/keyButtonBindings';
 import {
   createDefaultPinResolver,
@@ -509,9 +510,10 @@ export const DynamicComponent: React.FC<DynamicComponentProps> = ({
           const board = boardId ? st.boards.find((b) => b.id === boardId) : undefined;
           if (!board) continue;
           if (anyBoardId === null) anyBoardId = board.id;
-          if (isPiBoardKind(board.boardKind)) return { piBoardId: board.id, wiredBoardId: board.id };
+          if (isPiBoardKind(board.boardKind))
+            return { piBoardId: board.id, piBoardKind: board.boardKind, wiredBoardId: board.id };
         }
-        return { piBoardId: null, wiredBoardId: anyBoardId };
+        return { piBoardId: null, piBoardKind: null, wiredBoardId: anyBoardId };
       })();
       const piSimulator = piBoardId
         ? ({
@@ -523,16 +525,21 @@ export const DynamicComponent: React.FC<DynamicComponentProps> = ({
             isRunning: () =>
               !!useSimulatorStore.getState().boards.find((b) => b.id === piBoardId)?.running,
             pinManager: getBoardPinManager(piBoardId),
-            // The line contract's declaration. A QEMU-Linux guest reads its
-            // pins over a serial link to the backend (measured: ~120 reads/s,
-            // 8 ms per read) and the bridge carries levels, not timed edges,
-            // so a single-wire sensor's reply has nowhere to land in guest
-            // time. Said here, so the part hears it instead of waiting on a
-            // silent pad.
-            lineSupport: () => ({
-              mode: 'none' as const,
-              why: 'this board runs a Linux guest that reads its pins over a serial link; timed single-wire sensors are not modelled',
-            }),
+            // The line contract's declaration for this Pi-family board. Most
+            // QEMU-Linux boards read their pins over a serial link to the
+            // backend (measured ~120 reads/s) and carry levels, not timed
+            // edges, so a single-wire sensor's reply has nowhere to land in
+            // guest time: they DEFAULT to a refusal, said here so the part
+            // hears it and the circuit check shows it, instead of waiting on a
+            // silent pad. A board that DOES serve those sensors another way
+            // overrides this through registerBoardLineSupport (the UNIHIKER
+            // delivers DHT22 / HC-SR04 as named slider values, so the overlay
+            // declares it `hosted`).
+            lineSupport: () =>
+              (piBoardKind && getBoardLineSupport(piBoardKind)) ?? {
+                mode: 'none' as const,
+                why: 'this board runs a Linux guest that reads its pins over a serial link; timed single-wire sensors are not modelled here',
+              },
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
           } as any)
         : null;

--- a/frontend/src/lib/proBoardRegistry.ts
+++ b/frontend/src/lib/proBoardRegistry.ts
@@ -320,6 +320,35 @@ export function getBoardBuiltins(kind: string): BuiltinsAttach | undefined {
   return registry.get(kind)?.attachBuiltins ?? boardBuiltins.get(kind);
 }
 
+// ── Line-owning sensor support per board kind (simulation/line) ────────────
+// A board that hosts a line-owning sensor (DHT22, HC-SR04) a way the generic
+// simulator shim cannot see declares it here. The Raspberry Pi family reads
+// its pins over a serial link and models no timed edges, so it defaults to a
+// refusal; the UNIHIKER serves those two sensors as named slider values (a
+// hosted model, like the ESP32 QEMU worker), so the overlay registers a
+// `hosted` declaration for it. Kept as a per-kind registry rather than a
+// ProBoardDef field so an OSS-rendered kind can carry it without a stub def —
+// the same seam as registerBoardBuiltins / registerGuestSetup above.
+//
+// Typed structurally so this OSS module does not import the line contract's
+// types: `mode` is 'local' | 'hosted' | 'none', with the fields each carries.
+export type BoardLineSupport =
+  | { mode: 'local' }
+  | { mode: 'hosted'; models: readonly string[] }
+  | { mode: 'none'; why: string };
+
+const boardLineSupport = new Map<string, BoardLineSupport>();
+
+export function registerBoardLineSupport(kind: string, support: BoardLineSupport): void {
+  boardLineSupport.set(kind, support);
+}
+
+/** The line-support declaration an overlay registered for a board kind, or
+ *  undefined when none — the caller applies its own default. */
+export function getBoardLineSupport(kind: string): BoardLineSupport | undefined {
+  return boardLineSupport.get(kind);
+}
+
 /**
  * Seed files for a board kind in a given language mode, or undefined when the
  * board carries no seed of its own (the editor's family default applies).


### PR DESCRIPTION
## What

A per-board line-support declaration seam, so a board that serves a line-owning sensor (DHT22, HC-SR04) a way the generic Pi-family simulator shim can't see declares it explicitly, instead of falling under a blanket refusal.

- `registerBoardLineSupport(kind, support)` / `getBoardLineSupport(kind)` in `proBoardRegistry.ts` — same per-kind seam as `registerBoardBuiltins` / `registerGuestSetup`. Typed structurally so this OSS module doesn't import the line contract's types.
- The Pi-family simulator shim (`DynamicComponent.tsx`) reads the registered declaration and falls to its own `none` refusal only when a kind registered nothing.

## Why

The Raspberry Pi family reads its pins over a serial link (~120 reads/s) and models no timed edges, so a wired single-wire sensor correctly warns at Run. But the **UNIHIKER M10** serves DHT22 / HC-SR04 as named slider values through its pinpong shim (a hosted model, the same shape as the ESP32 QEMU worker). The shim's blanket `none` made the circuit check falsely warn "will not answer here" for a sensor that does read. The velxio-prod overlay now registers the UNIHIKER as `hosted` for those two, and gates the named-value delivery on the sensor being wired to the board.

Companion overlay change lives in velxio-prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQ8CjHtC1yL4rjs8TS6kWC
