### PR TITLE
fix(store): one ADC channel map, so the S3 and C3 stop resolving -1

### DIFF
--- a/frontend/src/__tests__/esp32-adc-channel-map.test.ts
+++ b/frontend/src/__tests__/esp32-adc-channel-map.test.ts
@@ -1,0 +1,116 @@
+/**
+ * GPIO -> ADC channel for the ESP32 shim, per chip.
+ *
+ * `Esp32BridgeShim.adcChannelForPin` was declared TWICE in the same class
+ * body. Only the later definition existed at runtime, so the per-chip map in
+ * the earlier one was dead code and every QEMU-backed run fell through to the
+ * classic ESP32 map. On an S3 or a C3 that meant the board's real ADC pins
+ * resolved to -1 and `setAdcVoltage` returned false, so a potentiometer, a
+ * joystick or a SPICE-driven analog node silently did nothing. Nothing threw.
+ * esbuild warned on every single build ("Duplicate member adcChannelForPin in
+ * class body") and the warning scrolled past for months.
+ *
+ * The map is exercised through `setAdcVoltage`, which is how the app reaches
+ * it, with a stub bridge recording what channel it was handed.
+ */
+
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { Esp32BridgeShim } from '../store/useSimulatorStore';
+
+type Recorded = { channel: number; millivolts: number };
+
+/**
+ * A bridge stub. `adcChannelForGpio` is optional on purpose: the plain
+ * Esp32Bridge does not implement it, which is exactly the case that used to
+ * fall through to the wrong map.
+ */
+function shimFor(
+  boardKind: string,
+  adcChannelForGpio?: (gpio: number) => number,
+): { shim: { setAdcVoltage(pin: number, v: number): boolean }; seen: Recorded[] } {
+  const seen: Recorded[] = [];
+  const bridge = {
+    boardKind,
+    setAdc: (channel: number, millivolts: number) => seen.push({ channel, millivolts }),
+    ...(adcChannelForGpio ? { adcChannelForGpio } : {}),
+  };
+  const shim = new Esp32BridgeShim(bridge as never, {} as never) as unknown as {
+    setAdcVoltage(pin: number, v: number): boolean;
+  };
+  return { shim, seen };
+}
+
+/** Resolve one pin: the channel it reached, or -1 when it was rejected. */
+function channelFor(boardKind: string, pin: number): number {
+  const { shim, seen } = shimFor(boardKind);
+  return shim.setAdcVoltage(pin, 1.5) ? seen[0].channel : -1;
+}
+
+describe('Esp32BridgeShim ADC channel map', () => {
+  it('is declared exactly once', () => {
+    // The whole bug in one line. Two declarations type-check, build, and ship.
+    const src = fs.readFileSync(
+      path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'store', 'useSimulatorStore.ts'),
+      'utf8',
+    );
+    expect(src.match(/private adcChannelForPin\(/g)?.length).toBe(1);
+  });
+
+  it('maps the classic ESP32 (ADC1 = GPIO32-39)', () => {
+    expect(channelFor('esp32', 36)).toBe(0);
+    expect(channelFor('esp32', 39)).toBe(3);
+    expect(channelFor('esp32', 32)).toBe(4);
+    expect(channelFor('esp32', 35)).toBe(7);
+    expect(channelFor('esp32', 1)).toBe(-1);
+  });
+
+  it('maps the ESP32-S3 family, ADC2 included', () => {
+    // Every one of these returned -1 while the map was dead code.
+    for (const kind of ['esp32-s3', 'xiao-esp32-s3', 'arduino-nano-esp32']) {
+      expect(channelFor(kind, 1)).toBe(0);
+      expect(channelFor(kind, 10)).toBe(9);
+      // ADC2 = GPIO11-20 at channel index 10-19, matching the machine's
+      // SENS stub. Not the same numbering as ADC1, and not optional.
+      expect(channelFor(kind, 11)).toBe(10);
+      expect(channelFor(kind, 20)).toBe(19);
+      expect(channelFor(kind, 21)).toBe(-1);
+      // The classic map's pins are NOT ADC pins on an S3. Answering 0 here
+      // is how the dead-code regression showed up: it injected onto a
+      // channel the chip does not have there.
+      expect(channelFor(kind, 36)).toBe(-1);
+    }
+  });
+
+  it('maps the ESP32-C3 family, including ADC2_CH0 on GPIO5', () => {
+    for (const kind of ['esp32-c3', 'xiao-esp32-c3', 'aitewinrobot-esp32c3-supermini']) {
+      expect(channelFor(kind, 0)).toBe(0);
+      expect(channelFor(kind, 4)).toBe(4);
+      expect(channelFor(kind, 5)).toBe(5);
+      expect(channelFor(kind, 6)).toBe(-1);
+      expect(channelFor(kind, 36)).toBe(-1);
+    }
+  });
+
+  it('lets a bridge that knows its chip answer instead', () => {
+    // A private overlay installs a bridge that resolves the map itself,
+    // because the answer can differ per BACKEND and not only per chip. That
+    // bridge must win over the table here, for every pin, including ones the
+    // table would have rejected.
+    const { shim, seen } = shimFor('esp32', (gpio) => (gpio === 7 ? 3 : -1));
+    expect(shim.setAdcVoltage(7, 2)).toBe(true);
+    expect(seen[0]).toEqual({ channel: 3, millivolts: 2000 });
+    // 36 is channel 0 in the fallback table; the bridge says it is not an
+    // ADC pin, and the bridge is the authority.
+    expect(shim.setAdcVoltage(36, 1)).toBe(false);
+  });
+
+  it('converts volts to millivolts', () => {
+    const { shim, seen } = shimFor('esp32');
+    expect(shim.setAdcVoltage(36, 3.3)).toBe(true);
+    expect(seen[0].millivolts).toBe(3300);
+  });
+});

--- a/frontend/src/store/useSimulatorStore.ts
+++ b/frontend/src/store/useSimulatorStore.ts
@@ -138,7 +138,9 @@ export const ARDUINO_POSITION = DEFAULT_BOARD_POSITION;
 
 // ── Lightweight shim wrapping Esp32Bridge so component simulations (DHT22, etc.)
 // can call setPinState / pinManager just like they would on a local simulator. ──
-class Esp32BridgeShim {
+// Exported for tests only: the ADC channel map below is chip-specific and was
+// wrong for two whole chip families for months with nothing asserting it.
+export class Esp32BridgeShim {
   pinManager: PinManager;
   // Digital input pins are driven from the SPICE solve
   // (connectDigitalInputsToMcu), not the part-level seed — so a button reads
@@ -240,17 +242,42 @@ class Esp32BridgeShim {
   }
 
   /**
-   * Set ADC value for an ESP32 GPIO pin.
-   * ESP32 ADC1: GPIO 36-39 → CH0-3, GPIO 32-35 → CH4-7
-   * Returns true if the pin is a valid ADC pin.
+   * GPIO -> ADC channel, for `setAdcVoltage` and `setAdcWaveform`.
+   *
+   * The mapping is CHIP-specific, and there are two sources for it:
+   *
+   *   1. The bridge, when it implements `adcChannelForGpio`. A bridge that
+   *      knows which engine will run the board is the better authority,
+   *      because the answer can differ per BACKEND and not just per chip
+   *      (see the QEMU-only indices below). Private overlays install such a
+   *      bridge; it answers before connect(), which matters because part
+   *      attaches seed their ADC values before the run starts.
+   *   2. This map, otherwise. The plain `Esp32Bridge` does not implement
+   *      the method, so every QEMU-backed run lands here.
+   *
+   * Chip coverage of the fallback, all QEMU-backed:
+   *   - Classic ESP32: ADC1 on GPIO 36-39 (CH0-3) and 32-35 (CH4-7).
+   *   - ESP32-S3 family, including xiao-esp32-s3 and the S3-based
+   *     arduino-nano-esp32: ADC1 = GPIO 1-10 (CH0-9), ADC2 = GPIO 11-20 at
+   *     channel index 10-19, which is what the machine's SENS stub uses.
+   *     Without this branch analogRead always saw 0 there (2026-07
+   *     emulation-gaps audit, F1).
+   *   - ESP32-C3 family: ADC1 = GPIO0-4 -> CH0-4, and GPIO5 (ADC2_CH0) at
+   *     index 5. Verified against the qemu SARADC: esp32_adc_set{channel:3}
+   *     is what analogRead(3) returns (emulation-gaps harness, 2026-07-31).
+   *
+   * This used to be TWO methods with the same name in this class body, one
+   * holding the per-chip map and one holding the bridge delegation. Only
+   * the later definition existed at runtime, so the per-chip map was dead
+   * code and every QEMU run fell through to the classic ESP32 map: an S3 or
+   * C3 board resolved -1 for its real ADC pins and setAdcVoltage dropped the
+   * value, silently, which is the regression the per-chip map had been
+   * written to fix. esbuild warned on every build ("Duplicate member
+   * adcChannelForPin in class body") and the warning scrolled past.
    */
-  /** GPIO -> ADC channel for the bridge's board family. Classic ESP32:
-   * ADC1 on GPIO 36-39 (CH0-3) + 32-35 (CH4-7). ESP32-S3 family (incl.
-   * xiao-esp32-s3 and the S3-based arduino-nano-esp32): ADC1 = GPIO 1-10
-   * (CH0-9), ADC2 = GPIO 11-20 (stored at channel index 10-19, matching
-   * the machine's SENS stub). Without the S3 branch analogRead always saw
-   * 0 there (2026-07 emulation-gaps audit, F1). */
   private adcChannelForPin(pin: number): number {
+    const b = this.bridge as unknown as { adcChannelForGpio?: (gpio: number) => number };
+    if (typeof b.adcChannelForGpio === 'function') return b.adcChannelForGpio(pin);
     const kind = this.bridge.boardKind as string;
     if (kind === 'esp32-s3' || kind === 'xiao-esp32-s3' || kind === 'arduino-nano-esp32') {
       if (pin >= 1 && pin <= 10) return pin - 1;
@@ -258,9 +285,6 @@ class Esp32BridgeShim {
       return -1;
     }
     if (kind === 'esp32-c3' || kind === 'xiao-esp32-c3' || kind === 'aitewinrobot-esp32c3-supermini') {
-      // C3: ADC1 = GPIO0-4 -> CH0-4, GPIO5 (ADC2_CH0) -> index 5.
-      // Verified against the qemu SARADC: esp32_adc_set{channel:3} is what
-      // analogRead(3) returns (emulation-gaps harness, 2026-07-31).
       return pin >= 0 && pin <= 5 ? pin : -1;
     }
     if (pin >= 36 && pin <= 39) return pin - 36; // GPIO 36→CH0 … 39→CH3
@@ -274,18 +298,6 @@ class Esp32BridgeShim {
     const millivolts = Math.round(voltage * 1000);
     this.bridge.setAdc(channel, millivolts);
     return true;
-  }
-
-  /** GPIO -> ADC channel. The mapping is CHIP-specific, so ask the bridge
-   *  when it knows its chip (S3: GPIO1..10 -> ADC1 ch0..9; C-family differs);
-   *  fall back to the classic ESP32 map, which was the only one this shim
-   *  handled before and silently returned false for every S3 pin. */
-  private adcChannelForPin(pin: number): number {
-    const b = this.bridge as unknown as { adcChannelForGpio?: (gpio: number) => number };
-    if (typeof b.adcChannelForGpio === 'function') return b.adcChannelForGpio(pin);
-    if (pin >= 36 && pin <= 39) return pin - 36; // GPIO 36→CH0 .. 39→CH3
-    if (pin >= 32 && pin <= 35) return pin - 28; // GPIO 32→CH4 .. 35→CH7
-    return -1;
   }
 
   /**


### PR DESCRIPTION
## What

`Esp32BridgeShim.adcChannelForPin` was declared **twice** in the same class body. The later declaration wins in JavaScript, so the earlier one, the half holding the per-chip ADC maps, was dead code.

What survived asks the bridge for `adcChannelForGpio` and otherwise falls back to the **classic ESP32** map. The plain `Esp32Bridge` does not implement `adcChannelForGpio`, so every QEMU-backed run took that fallback.

## Why it matters

On an ESP32-S3 or ESP32-C3 the real ADC pins are nowhere near GPIO32-39, so:

- `adcChannelForPin` returned -1, `setAdcVoltage` returned false, and the value was dropped. A potentiometer, a joystick or a SPICE-driven analog node silently did nothing.
- GPIO32-39 resolved to channels those chips do not have there.

That is exactly the regression the dead half had been written to fix (emulation-gaps audit F1, 2026-07).

Nothing failed loudly. esbuild printed `Duplicate member "adcChannelForPin" in class body` on every build and dev-server start, and it scrolled past for months.

## The fix

One method. Ask the bridge when it implements the map, because the answer can differ per **backend** and not only per chip, and otherwise use the per-chip table. The table keeps both QEMU-specific details only the dead code had recorded:

- the S3's ADC2 at channel index 10-19 for GPIO11-20, matching the machine's SENS stub
- the C3's GPIO5 (ADC2_CH0) at index 5, verified against the qemu SARADC

## Tests

`frontend/src/__tests__/esp32-adc-channel-map.test.ts` covers all three chip families through `setAdcVoltage`, asserts a bridge that knows its own chip still wins over the table, and asserts the method is declared exactly once. Every S3 and C3 assertion fails against the pre-fix behaviour (verified by reverting).

Full frontend suite: 3455 passed with this change, 3449 on the pristine baseline, the +6 being these tests. One pre-existing flake (`chipbus-galaksija-keyboard`) fails under the full parallel run on the baseline too and passes in isolation either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
