### PR TITLE
perf(compile): warm ESP-IDF builds skip cmake, replicas of hot variants, priority burst

### DIFF
--- a/backend/app/api/routes/compile.py
+++ b/backend/app/api/routes/compile.py
@@ -20,6 +20,7 @@ from app.core.hooks import (
     record_compile,
 )
 from app.services import build_queue
+from app.services import espidf_compiler as espidf_compiler_module
 from app.services.arduino_cli import ArduinoCLIService
 from app.services.espidf_compiler import espidf_compiler
 
@@ -50,8 +51,35 @@ JOB_TTL_S = 1800  # purge results 30 min after completion
 ARTIFACT_CACHE_DIR = Path(
     os.environ.get("VELXIO_ARTIFACT_CACHE", "/var/lib/velxio-build/artifacts")
 )
-ARTIFACT_CACHE_MAX_ENTRIES = 400
+
+
+def _env_int(name: str, default: int, lo: int, hi: int) -> int:
+    try:
+        value = int(os.environ.get(name, "").strip() or default)
+    except ValueError:
+        logger.warning("[compile] %s is not an integer; using %d", name, default)
+        return default
+    return max(lo, min(hi, value))
+
+
+# Entries are bimodal — a 2 KB AVR hex or a 5 MB merged ESP32 flash image —
+# so the cache is capped both by count and by bytes. 400 entries turned over
+# in under five hours of velxio.dev traffic; the deployment raises it (see
+# docker-compose.yml). 0 bytes = no byte cap.
+ARTIFACT_CACHE_MAX_ENTRIES = _env_int("VELXIO_ARTIFACT_CACHE_MAX_ENTRIES", 400, 10, 100_000)
+ARTIFACT_CACHE_MAX_BYTES = _env_int("VELXIO_ARTIFACT_CACHE_MAX_BYTES", 0, 0, 1 << 40)
 ARTIFACT_CACHE_MAX_AGE_S = 14 * 24 * 3600
+# A store walks the whole directory to prune; with thousands of entries that
+# is ~100 ms of stat calls, so it runs off the event loop and only every so
+# many stores. The cap is therefore soft by up to this many entries.
+_ARTIFACT_PRUNE_EVERY = 25
+_artifact_stores_since_prune = 0
+
+# A request carrying this header with the deployment's token skips the
+# artifact cache LOOKUP (the result is still stored). It exists for the
+# nightly example smoke, which must exercise the compiler rather than read
+# yesterday's binaries back. Unset (the OSS default) = the header is ignored.
+_CACHE_BYPASS_TOKEN = os.environ.get("VELXIO_CACHE_BYPASS_TOKEN", "").strip()
 
 
 def _toolchain_epoch() -> str:
@@ -96,9 +124,14 @@ def _artifact_load(key: str) -> dict | None:
         return None
 
 
-def _artifact_store(key: str, result: dict) -> None:
+def _artifact_store_sync(key: str, result: dict) -> None:
     """Persist a SUCCESSFUL build. Failures are never cached — a compile error
-    is usually the user's half-written code, and they will edit and retry."""
+    is usually the user's half-written code, and they will edit and retry.
+
+    Blocking: json.dumps of a 5 MB image plus the write plus (every so many
+    stores) the prune walk. Call through `_artifact_store` from the loop.
+    """
+    global _artifact_stores_since_prune
     if not result.get("success"):
         return
     try:
@@ -110,19 +143,39 @@ def _artifact_store(key: str, result: dict) -> None:
         tmp = _artifact_path(key).with_suffix(".tmp")
         tmp.write_text(json.dumps(slim))
         tmp.replace(_artifact_path(key))
-        _artifact_prune()
+        _artifact_stores_since_prune += 1
+        if _artifact_stores_since_prune >= _ARTIFACT_PRUNE_EVERY:
+            _artifact_stores_since_prune = 0
+            _artifact_prune()
     except Exception:
         logger.warning("[compile] artifact cache write failed", exc_info=True)
 
 
+async def _artifact_store(key: str, result: dict) -> None:
+    await asyncio.to_thread(_artifact_store_sync, key, result)
+
+
 def _artifact_prune() -> None:
-    """Keep the newest ARTIFACT_CACHE_MAX_ENTRIES files (LRU by mtime)."""
+    """Keep the newest ARTIFACT_CACHE_MAX_ENTRIES files (LRU by mtime), and
+    within ARTIFACT_CACHE_MAX_BYTES when a byte cap is set."""
     try:
-        files = sorted(
-            ARTIFACT_CACHE_DIR.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True
-        )
-        for stale in files[ARTIFACT_CACHE_MAX_ENTRIES:]:
-            stale.unlink(missing_ok=True)
+        entries = []
+        with os.scandir(ARTIFACT_CACHE_DIR) as it:
+            for entry in it:
+                if entry.name.endswith(".json") and entry.is_file():
+                    st = entry.stat()
+                    entries.append((st.st_mtime, st.st_size, entry.path))
+        entries.sort(reverse=True)  # newest first
+        total = 0
+        for idx, (_mtime, size, path) in enumerate(entries):
+            total += size
+            over_count = idx >= ARTIFACT_CACHE_MAX_ENTRIES
+            over_bytes = ARTIFACT_CACHE_MAX_BYTES > 0 and total > ARTIFACT_CACHE_MAX_BYTES
+            if over_count or over_bytes:
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
     except Exception:
         pass
 
@@ -133,15 +186,21 @@ def _artifact_prune() -> None:
 # RP2040, STM32...): seconds each, so they get their own slots and never queue
 # behind an ESP-IDF cold build. Before the split a single Semaphore(2) gated
 # both, and a Uno blink could sit "compiling" for minutes while two ESP32 builds
-# ran. Concurrent compiles to the SAME ESP-IDF target would corrupt the
-# persistent build dir, so those are serialized with a per-target lock layered
-# on top.
+# ran.
 #
 # BuildQueue replaced the two semaphores when velxio.dev started queueing for
 # real: a semaphore is FIFO and anonymous, so a paid build could not get past a
 # wall of gallery clicks and the route had nothing to tell the waiting user. The
 # queue is unbounded on purpose — a build is never refused, only delayed.
-_TARGET_LOCKS: dict[str, asyncio.Lock] = {}
+#
+# There is NO per-target lock here any more. There used to be one, taken
+# INSIDE the lane slot, keyed on (idf_target, arduino variant): with 78% of
+# heavy builds on esp32:esp32:esp32 the second heavy slot spent whole hours
+# holding a slot while blocked on it (2026-09-02 12:00: one slot 3647 s of
+# build, the other 943 s, queue p50 43 min). The shared resource is the
+# persistent build DIRECTORY, and espidf_compiler serialises on exactly that
+# (`_variant_lock`, one per variant or replica); arduino-cli builds in a fresh
+# temp dir per call and never needed a lock.
 
 
 def _is_heavy_compile(board_fqbn: str) -> bool:
@@ -152,9 +211,11 @@ def _is_heavy_compile(board_fqbn: str) -> bool:
 def _build_identity(board_fqbn: str) -> str:
     """The identity of the persistent BUILD DIRECTORY this FQBN compiles in.
 
-    The lock below has to be keyed on the shared resource, and that resource is
-    the build dir — which `_prepare_persistent_project_dir` keys on
-    (idf_target, variant), NOT on the FQBN. Several FQBNs map to one variant:
+    Used to key the per-target duration estimate (`_estimate_key`). It was
+    also the key of a route-level build lock until 2026-09; the compiler now
+    serialises on its own per-variant locks. The identity is still the build
+    dir's, which `_prepare_persistent_project_dir` keys on (idf_target,
+    variant), NOT on the FQBN. Several FQBNs map to one variant:
     arduino-esp32's boards.txt gives both `esp32` and `esp32cam`
     `build.variant=esp32`, so they land in the SAME directory.
 
@@ -183,18 +244,6 @@ def _build_identity(board_fqbn: str) -> str:
         return f"{target}::{variant}"
     except Exception:  # noqa: BLE001 - identity is best-effort; FQBN is a safe fallback
         return board_fqbn
-
-
-def _target_lock(board_fqbn: str) -> asyncio.Lock:
-    """Lazy-initialised lock so concurrent compiles that SHARE A BUILD DIR
-    serialise. Boards with genuinely different build dirs still run in
-    parallel up to the semaphore cap."""
-    key = _build_identity(board_fqbn)
-    lock = _TARGET_LOCKS.get(key)
-    if lock is None:
-        lock = asyncio.Lock()
-        _TARGET_LOCKS[key] = lock
-    return lock
 
 
 # ── Progress + duration estimation ───────────────────────────────────────────
@@ -332,22 +381,32 @@ def _job_display_fields(job_id: str) -> dict[str, Any]:
     }
 
 
-async def _resolve_queue_priority(user_id: str | None) -> tuple[int, str]:
-    """(priority, display tier) for a compile. OSS default: everyone equal.
+async def _resolve_queue_priority(user_id: str | None) -> tuple[int, str, int | None]:
+    """(priority, display tier, cpu_nice) for a compile. OSS default: everyone equal.
 
     The tier string only ever reaches the client as a label ('pro' shows a
     priority badge, 'free' shows the upgrade line). 'local' means no plan
     vocabulary applies — a self-hosted OSS build — and the UI shows neither.
+
+    `cpu_nice` is the nice level for this build's compiler processes (None =
+    inherit). It only ranks CPU time between builds that are ALREADY running;
+    nobody is stopped or refused. Without an overlay every build inherits.
     """
     info = await compile_priority(user_id)
     if not isinstance(info, dict):
-        return build_queue.PRIORITY_STANDARD, "local"
+        return build_queue.PRIORITY_STANDARD, "local", None
     try:
         priority = int(info.get("priority", build_queue.PRIORITY_STANDARD))
     except (TypeError, ValueError):
         priority = build_queue.PRIORITY_STANDARD
     tier = str(info.get("tier") or "standard")
-    return priority, tier
+    cpu_nice: int | None
+    try:
+        raw_nice = info.get("cpu_nice")
+        cpu_nice = None if raw_nice is None else max(0, min(19, int(raw_nice)))
+    except (TypeError, ValueError):
+        cpu_nice = None
+    return priority, tier, cpu_nice
 
 
 def _job_key(
@@ -619,6 +678,7 @@ async def _run_compile(
     progress_callback: Any = None,
     requester_id: str | None = None,
     scope: tuple[set[str] | None, str | None] | None = None,
+    cpu_nice: int | None = None,
 ) -> CompileResponse:
     """Do the actual compile (ESP-IDF for esp32:*, arduino-cli otherwise).
 
@@ -663,6 +723,7 @@ async def _run_compile(
             [f.model_dump() for f in request.spiffs_files]
             if request.spiffs_files else None
         )
+        espidf_compiler_module.build_timing.set({})
         result = await espidf_compiler.compile(
             files, request.board_fqbn,
             progress_callback=progress_callback,
@@ -672,6 +733,7 @@ async def _run_compile(
             owner_id=owner_id,
             pure_idf=pure_idf,
             custom_wifi_ssids=request.custom_wifi_ssids,
+            cpu_nice=cpu_nice,
         )
         return CompileResponse(
             success=result["success"],
@@ -759,9 +821,10 @@ async def _compile_job(
     user_id: str | None,
     scope: tuple[set[str] | None, str | None] | None = None,
     priority: int = build_queue.PRIORITY_STANDARD,
+    cpu_nice: int | None = None,
 ) -> None:
-    """Background worker: acquire a build slot + per-target lock, run the
-    compile, store result in COMPILE_JOBS.
+    """Background worker: acquire a build slot, run the compile (which takes
+    its own build-dir lock), store result in COMPILE_JOBS.
 
     `scope` is the (allowed_libraries, owner_id) already resolved by
     compile_start for the dedup key — threaded through so the build uses the
@@ -822,28 +885,31 @@ async def _compile_job(
             "automatically, and is never dropped.\n"
         )
 
+    slot_acquired = started
+    compiler_timing: dict[str, Any] = {}
     try:
         async with lane.slot(priority=priority, key=job_id, on_queued=on_queued):
-            async with _target_lock(request.board_fqbn):
-                # Job may have been purged or replaced while we were queued.
-                # Re-fetch and bail out if so.
-                if COMPILE_JOBS.get(job_id) is None:
-                    logger.info(f"[compile] job {job_id} purged before run; skipping")
-                    return
-                COMPILE_JOBS[job_id]["state"] = "running"
-                COMPILE_JOBS[job_id]["stage"] = "preparing"
-                # Progress and ETA are measured from HERE, not from the moment
-                # the job was queued — otherwise every build that waited would
-                # render as already half-finished the instant it starts.
-                COMPILE_JOBS[job_id]["run_started_at"] = time.time()
-                COMPILE_JOBS[job_id]["estimate_s"] = _estimated_seconds(
-                    lane_name, request.board_fqbn
-                )
-                build_started = time.monotonic()
-                response = await _run_compile(
-                    request, files, progress_callback=on_progress_line,
-                    requester_id=user_id, scope=scope,
-                )
+            slot_acquired = time.monotonic()
+            # Job may have been purged or replaced while we were queued.
+            # Re-fetch and bail out if so.
+            if COMPILE_JOBS.get(job_id) is None:
+                logger.info(f"[compile] job {job_id} purged before run; skipping")
+                return
+            COMPILE_JOBS[job_id]["state"] = "running"
+            COMPILE_JOBS[job_id]["stage"] = "preparing"
+            # Progress and ETA are measured from HERE, not from the moment
+            # the job was queued — otherwise every build that waited would
+            # render as already half-finished the instant it starts.
+            COMPILE_JOBS[job_id]["run_started_at"] = time.time()
+            COMPILE_JOBS[job_id]["estimate_s"] = _estimated_seconds(
+                lane_name, request.board_fqbn
+            )
+            build_started = time.monotonic()
+            response = await _run_compile(
+                request, files, progress_callback=on_progress_line,
+                requester_id=user_id, scope=scope, cpu_nice=cpu_nice,
+            )
+            compiler_timing = dict(espidf_compiler_module.build_timing.get() or {})
         if response.success:
             _record_duration(
                 lane_name, request.board_fqbn, time.monotonic() - build_started
@@ -862,7 +928,7 @@ async def _compile_job(
             "stdout_buffer": COMPILE_JOBS.get(job_id, {}).get("stdout_buffer", ""),
         }
         if job_key:
-            _artifact_store(job_key, response.model_dump())
+            await _artifact_store(job_key, response.model_dump())
         error_kind = (
             None if response.success
             else _classify_compile_error(response.stderr, response.error)
@@ -888,8 +954,19 @@ async def _compile_job(
                 # tells the operator whether a slow week means slow builds or a
                 # deep queue — i.e. whether to buy CPU or raise the lane caps.
                 "queue_ms": int((build_started - started) * 1000),
+                # queue_ms used to bundle the wait for a build slot with the
+                # wait for the build DIRECTORY (the old per-target lock). They
+                # answer different questions: slot_ms says the lane is full,
+                # variant_wait_ms says one variant is hot. Kept separate.
+                "slot_ms": int((slot_acquired - started) * 1000),
+                "variant_wait_ms": compiler_timing.get("variant_wait_ms"),
+                "configure_skipped": compiler_timing.get("configure_skipped"),
+                "configure_ms": compiler_timing.get("configure_ms"),
+                "ninja_ms": compiler_timing.get("ninja_ms"),
+                "replica": compiler_timing.get("replica"),
                 "lane": lane_name,
                 "priority": priority,
+                "cpu_nice": cpu_nice,
             },
         )
     except Exception as exc:
@@ -935,19 +1012,18 @@ async def compile_sketch(
     files = _resolve_files(request)
     started = time.monotonic()
 
-    priority, _tier = await _resolve_queue_priority(user_id)
+    priority, _tier, cpu_nice = await _resolve_queue_priority(user_id)
     lane = build_queue.lane_for(_is_heavy_compile(request.board_fqbn))
 
     async def _gated_compile() -> CompileResponse:
-        # This path used to call _run_compile directly — no build slot and, far
-        # worse, no per-target lock, so a sync compile could run inside the
-        # same persistent ESP-IDF build dir as an async one and hand back the
-        # other sketch's firmware (the failure _build_identity documents). It
-        # also meant an API caller bypassed the queue entirely while everyone
-        # in the editor waited.
+        # This path used to call _run_compile directly with no build slot, so
+        # an API caller bypassed the queue entirely while everyone in the
+        # editor waited. The build dir itself is protected inside the
+        # compiler (per-variant lock), the same as for the async path.
         async with lane.slot(priority=priority):
-            async with _target_lock(request.board_fqbn):
-                return await _run_compile(request, files, requester_id=user_id)
+            return await _run_compile(
+                request, files, requester_id=user_id, cpu_nice=cpu_nice,
+            )
 
     try:
         # Shielded: when the client (or a proxy timeout - nginx 504s a cold
@@ -1055,6 +1131,7 @@ class CompileStatusResponse(BaseModel):
 @router.post("/start", response_model=CompileStartResponse)
 async def compile_start(
     request: CompileRequest,
+    http_request: Request,
     user_id: str | None = Depends(get_current_user_id),
 ):
     """
@@ -1087,7 +1164,7 @@ async def compile_start(
     # Where this build sits in the queue. Resolved once, here, so a single
     # plan lookup covers the whole job and the tier the UI displays is the
     # same one the queue actually ordered on.
-    priority, tier = await _resolve_queue_priority(user_id)
+    priority, tier, cpu_nice = await _resolve_queue_priority(user_id)
     heavy = _is_heavy_compile(request.board_fqbn)
     queue_fields = {
         "tier": tier,
@@ -1130,7 +1207,11 @@ async def compile_start(
 
     # Same sources, same flags, already built: hand the stored artifact back as
     # an already-finished job so the client's normal poll loop just sees `done`.
-    cached = _artifact_load(key)
+    bypass_cache = bool(
+        _CACHE_BYPASS_TOKEN
+        and http_request.headers.get("x-velxio-cache-bypass", "") == _CACHE_BYPASS_TOKEN
+    )
+    cached = None if bypass_cache else _artifact_load(key)
     if cached is not None:
         job_id = uuid.uuid4().hex
         now = time.time()
@@ -1185,6 +1266,7 @@ async def compile_start(
             user_id=user_id,
             scope=(allowed_libraries, owner_id),
             priority=priority,
+            cpu_nice=cpu_nice,
         ),
     )
     return CompileStartResponse(job_id=job_id)

--- a/backend/app/core/hooks.py
+++ b/backend/app/core/hooks.py
@@ -374,9 +374,12 @@ async def dispatch_gateway_proxy(
 # `app.services.build_queue` (PRIORITY_HIGH / MEDIUM / STANDARD) so paid builds
 # are admitted first.
 #
-# Returns {'priority': int, 'tier': str} or None. `tier` is a DISPLAY label the
-# compile-status endpoint echoes back so the frontend can say "priority build"
-# vs. offer an upgrade — it is not used for any access decision. Never return
+# Returns {'priority': int, 'tier': str, 'cpu_nice': int | None} or None.
+# `tier` is a DISPLAY label the compile-status endpoint echoes back so the
+# frontend can say "priority build" vs. offer an upgrade — it is not used for
+# any access decision. `cpu_nice` (optional) is the nice level for the build's
+# compiler processes: it ranks CPU time between builds that are already
+# running and never stops or refuses one; None/absent = inherit. Never return
 # queue depth or position from here: those stay server-side (see build_queue).
 
 CompilePriorityHook = Callable[[Optional[str]], Awaitable[Optional[dict]]]

--- a/backend/app/services/arduino_cli.py
+++ b/backend/app/services/arduino_cli.py
@@ -2,6 +2,7 @@ import subprocess
 import tempfile
 import asyncio
 import base64
+import hashlib
 import shutil
 import re
 import os
@@ -135,6 +136,27 @@ def humanize_cli_error(raw: str | None, *, action: str = "run arduino-cli") -> s
         return f"Could not {action}: arduino-cli returned no output."
     first = next((ln.strip() for ln in text.splitlines() if ln.strip()), text)
     return f"Could not {action}: {first[:300]}"
+
+
+def _discard_sketch_build_cache(sketch_dir: Path) -> None:
+    """Remove the per-sketch build cache arduino-cli left for this compile.
+
+    arduino-cli keys its sketch build cache on the MD5 of the sketch's
+    absolute path, and this service compiles every request in a fresh temp
+    dir: the entry is never reused, and arduino-cli 1.5.x never purges it
+    either (its purge scans /tmp/arduino, not the real cache dir). Measured
+    on velxio.dev: 17,000 directories and 15 GB in 15 days, growing 1 GB a
+    day. The core cache next to it (`cores/`, keyed on the FQBN) is what makes
+    warm builds fast and is left alone.
+    """
+    try:
+        cache_root = Path.home() / '.cache' / 'arduino' / 'sketches'
+        digest = hashlib.md5(str(sketch_dir).encode('utf-8')).hexdigest().upper()
+        target = cache_root / digest
+        if target.is_dir():
+            shutil.rmtree(target, ignore_errors=True)
+    except Exception:
+        pass
 
 
 class ArduinoCLIService:
@@ -551,6 +573,7 @@ class ArduinoCLIService:
                     )
 
                 result = await asyncio.to_thread(run_compile)
+                _discard_sketch_build_cache(sketch_dir)
 
                 print(f"Process return code: {result.returncode}")
                 print(f"Stdout: {result.stdout}")

--- a/backend/app/services/arduino_cli.py
+++ b/backend/app/services/arduino_cli.py
@@ -151,7 +151,8 @@ def _discard_sketch_build_cache(sketch_dir: Path) -> None:
     """
     try:
         cache_root = Path.home() / '.cache' / 'arduino' / 'sketches'
-        digest = hashlib.md5(str(sketch_dir).encode('utf-8')).hexdigest().upper()
+        # MD5 because that is arduino-cli's own cache key (not a security use).
+        digest = hashlib.md5(str(sketch_dir).encode('utf-8'), usedforsecurity=False).hexdigest().upper()
         target = cache_root / digest
         if target.is_dir():
             shutil.rmtree(target, ignore_errors=True)

--- a/backend/app/services/build_queue.py
+++ b/backend/app/services/build_queue.py
@@ -29,6 +29,18 @@ priority jobs use the whole lane.
 The reservation is skipped for a lane with `capacity < 2`, where holding a slot
 back would invert the priority order instead of merely softening it.
 
+Priority burst
+--------------
+Ordering alone still leaves a paid build waiting for a slot when the lane is
+full of standard builds. A lane may therefore carry `priority_burst` extra
+admissions that ONLY priority jobs can use: while fewer than `capacity +
+priority_burst` jobs run, a waiting priority job is admitted at once, above
+capacity. Standard jobs never use the burst, and the reserved standard slot
+still holds on the regular slots, so a free build keeps advancing exactly as
+before; the cost is one extra build on the box for the seconds it runs. The
+burst is what turns "compiled first" into "starts now" for a subscriber on
+velxio.dev, and it is 0 (off) unless the deployment sets it.
+
 Privacy
 -------
 `load_level()` is the ONLY queue fact this module is meant to reach a client
@@ -95,6 +107,8 @@ class _Waiter:
     future: "asyncio.Future[None]"
     enqueued_at: float = field(default_factory=time.monotonic)
     admitted: bool = False
+    #: Admitted above capacity through the priority burst.
+    burst: bool = False
     #: Caller-supplied handle (the compile job id) so a job can be re-ordered
     #: after it is already queued — see `reprioritize`.
     key: Optional[str] = None
@@ -107,10 +121,13 @@ class BuildQueue:
     so the counters can never be observed halfway through an admission.
     """
 
-    def __init__(self, name: str, capacity: int) -> None:
+    def __init__(self, name: str, capacity: int, priority_burst: int = 0) -> None:
         self.name = name
         self.capacity = max(1, capacity)
+        #: Admissions above `capacity` reserved for priority jobs (0 = none).
+        self.priority_burst = max(0, int(priority_burst))
         self._active = 0
+        self._burst_active = 0
         self._priority_active = 0
         self._standard_waiting = 0
         self._heap: list[tuple[int, int, _Waiter]] = []
@@ -130,6 +147,11 @@ class BuildQueue:
     @property
     def waiting(self) -> int:
         return len(self._heap)
+
+    @property
+    def burst_active(self) -> int:
+        """Jobs currently running above capacity (priority burst admissions)."""
+        return self._burst_active
 
     @property
     def pressure(self) -> float:
@@ -201,9 +223,34 @@ class BuildQueue:
                 return standard
         return self._take_best()
 
+    def _take_best_priority(self) -> Optional[_Waiter]:
+        """The best waiter, but only if it is a priority job (burst admission).
+
+        The heap orders by (priority, seq), so when its head is a standard job
+        there is no priority job waiting at all.
+        """
+        self._drop_cancelled()
+        if self._heap and not self._heap[0][2].standard:
+            return self._take_best()
+        return None
+
     def _pump(self) -> None:
-        while self._active < self.capacity:
-            waiter = self._select()
+        # Regular slots and burst slots are accounted separately on purpose.
+        # Deriving "burst" from active - capacity looked simpler but broke the
+        # standard reservation: once a burst job was running, every regular
+        # slot that freed up was re-filled through the burst path, which knows
+        # nothing about the reserved slot, and a free build sat behind twelve
+        # paid ones. A regular slot that frees up is filled by `_select`, with
+        # all its fairness rules; the burst only ever admits ABOVE that.
+        while True:
+            burst = False
+            if self._active - self._burst_active < self.capacity:
+                waiter = self._select()
+            elif self._burst_active < self.priority_burst:
+                waiter = self._take_best_priority()
+                burst = True
+            else:
+                return
             if waiter is None:
                 return
             if waiter.future.done():
@@ -211,16 +258,25 @@ class BuildQueue:
                 # the slot to, so try the next waiter without consuming it.
                 continue
             waiter.admitted = True
+            waiter.burst = burst
             self._active += 1
+            if burst:
+                self._burst_active += 1
             if waiter.standard:
                 self._consecutive_priority = 0
             else:
                 self._priority_active += 1
-                self._consecutive_priority += 1
+                # A burst admission took nothing a standard job could have
+                # used, so it does not count against the consecutive-priority
+                # fairness counter of a one-slot lane.
+                if not burst:
+                    self._consecutive_priority += 1
             waiter.future.set_result(None)
 
     def _release(self, waiter: _Waiter) -> None:
         self._active -= 1
+        if waiter.burst:
+            self._burst_active -= 1
         if not waiter.standard:
             self._priority_active -= 1
         self._pump()
@@ -260,6 +316,8 @@ class BuildQueue:
             waiter.standard = False
             self._heap[idx] = (priority, seq, waiter)
             heapq.heapify(self._heap)
+            # A lifted job may now qualify for a burst admission.
+            self._pump()
             return True
         return False
 
@@ -319,8 +377,26 @@ class BuildQueue:
 # 30 and made every build slower than running them two at a time.
 # LIGHT = arduino-cli boards (AVR, RP2040, STM32...): seconds each, so they get
 # their own lane and never queue behind an ESP-IDF cold build.
-HEAVY = BuildQueue("heavy", _env_slots("VELXIO_HEAVY_BUILD_SLOTS", 2))
-LIGHT = BuildQueue("light", _env_slots("VELXIO_LIGHT_BUILD_SLOTS", 3))
+def _env_burst(name: str, default: int) -> int:
+    """Priority-burst admissions for a lane, 0..8. 0 (the OSS default) = off."""
+    try:
+        value = int(os.environ.get(name, "").strip() or default)
+    except ValueError:
+        logger.warning("[queue] %s is not an integer; using %d", name, default)
+        return default
+    return max(0, min(8, value))
+
+
+HEAVY = BuildQueue(
+    "heavy",
+    _env_slots("VELXIO_HEAVY_BUILD_SLOTS", 2),
+    priority_burst=_env_burst("VELXIO_HEAVY_PRIORITY_BURST", 0),
+)
+LIGHT = BuildQueue(
+    "light",
+    _env_slots("VELXIO_LIGHT_BUILD_SLOTS", 3),
+    priority_burst=_env_burst("VELXIO_LIGHT_PRIORITY_BURST", 0),
+)
 
 _LANES = (HEAVY, LIGHT)
 
@@ -359,6 +435,8 @@ def debug_snapshot() -> dict:
             "active": lane.active,
             "waiting": lane.waiting,
             "capacity": lane.capacity,
+            "priority_burst": lane.priority_burst,
+            "burst_active": lane.burst_active,
         }
         for lane in _LANES
     }

--- a/backend/app/services/esp-idf-template/main/CMakeLists.txt
+++ b/backend/app/services/esp-idf-template/main/CMakeLists.txt
@@ -90,9 +90,12 @@ elseif(DEFINED ENV{ARDUINO_ESP32_PATH})
     # evaluates each component's CMakeLists in script mode where
     # CONFIGURE_DEPENDS isn't supported, and the build aborts with
     # "CONFIGURE_DEPENDS is invalid for script and find package modes".
-    # We don't need it anyway: espidf_compiler wipes + restores main/
-    # from the template on every compile (touching CMakeLists.txt's
-    # mtime), so cmake re-globs naturally on the next configure run.
+    # The glob is only re-evaluated by a cmake configure, and a warm build
+    # dir goes straight to ninja. espidf_compiler therefore records the set
+    # of compilable files per build (.velxio-sources) and bumps this file's
+    # mtime when the set changes, which makes ninja's RERUN_CMAKE rule run
+    # cmake again. (Restoring main/ from the template does NOT bump it:
+    # copytree preserves the template's mtimes.)
     file(GLOB _user_srcs
         "${CMAKE_CURRENT_LIST_DIR}/*.cpp"
         "${CMAKE_CURRENT_LIST_DIR}/*.c")

--- a/backend/app/services/espidf_compiler.py
+++ b/backend/app/services/espidf_compiler.py
@@ -26,6 +26,9 @@ import string
 import subprocess
 import tempfile
 import threading
+import time
+from collections import deque
+from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Callable, Optional
@@ -33,6 +36,49 @@ from typing import Callable, Optional
 from app.core.hooks import materialize_library_scope
 
 logger = logging.getLogger(__name__)
+
+# Per-task timing of the LAST compile() call: how long it waited for its build
+# dir, whether the configure was skipped, and how long cmake / ninja ran. The
+# compile route reads it right after `await compile()` (same asyncio task, so
+# the ContextVar is visible) and folds it into the usage metric. Kept out of
+# the result dict on purpose: the result is what the client receives, and the
+# wait behind another build is an operator number, not a user one.
+build_timing: ContextVar[Optional[dict]] = ContextVar('espidf_build_timing', default=None)
+
+
+def _timing_note(**fields) -> None:
+    current = build_timing.get() or {}
+    current.update(fields)
+    build_timing.set(current)
+
+
+# Set VELXIO_ESPIDF_ALWAYS_CONFIGURE=1 to run `cmake` before every ninja run
+# (the pre-2026-09 behaviour) without rebuilding the image. The default lets a
+# warm build dir go straight to ninja, which re-runs cmake by itself when a
+# configure input changed (build.ninja's RERUN_CMAKE rule).
+_ALWAYS_CONFIGURE = (
+    os.environ.get('VELXIO_ESPIDF_ALWAYS_CONFIGURE', '')
+    in ('1', 'true', 'True', 'yes')
+)
+
+
+def _write_if_changed(path: Path, text: str) -> bool:
+    """Write `text` to `path` only when the bytes differ. Returns True if written.
+
+    Every generated file that cmake lists as a configure dependency
+    (partitions.csv, velxio_board.cmake, a component's CMakeLists.txt) must go
+    through here: an unconditional write bumps the mtime, and ninja's
+    RERUN_CMAKE rule then re-runs the whole configure for a file that did not
+    change. That configure is 60% of a warm ESP32 build (measured 2026-09-04).
+    """
+    try:
+        if path.exists() and path.read_text(encoding='utf-8') == text:
+            return False
+    except (OSError, UnicodeDecodeError):
+        pass
+    path.write_text(text, encoding='utf-8')
+    return True
+
 
 # Location of the ESP-IDF project template (relative to this file)
 _TEMPLATE_DIR = Path(__file__).parent / 'esp-idf-template'
@@ -46,9 +92,10 @@ _TEMPLATE_DIR = Path(__file__).parent / 'esp-idf-template'
 # is a stable anchor: ninja's incremental cache + ccache hits combine to bring
 # warm compiles down to ~5-30s.
 #
-# Concurrent compiles to the SAME target would corrupt the shared build dir;
-# they're serialised by the per-target asyncio.Lock in routes/compile.py.
-# Different targets get different subdirs and run in parallel.
+# Concurrent compiles in the SAME variant dir would corrupt it; they're
+# serialised by _variant_lock below (one lock per variant, or per replica of a
+# variant). Different variants of one target, and different targets, run in
+# parallel up to the build queue's slot count.
 #
 # Set VELXIO_PERSISTENT_BUILD_DIR=0 to fall back to the legacy tempfile flow
 # without rebuilding the image (escape hatch if the persistent dir misbehaves
@@ -157,6 +204,26 @@ class _RunResult:
     stderr: str
 
 
+def _nice_preexec(nice: int | None):
+    """preexec_fn that lowers the child's CPU priority. None = inherit.
+
+    The API and the simulation WebSockets share the box with the compilers;
+    a positive nice keeps them responsive under a full CPU, and a per-job
+    value lets the overlay rank a paid build's processes above an anonymous
+    one's (weights 1024 vs 110 between nice 0 and nice 10) without ever
+    stopping or interrupting anyone.
+    """
+    if not nice or os.name == 'nt':
+        return None
+
+    def _apply() -> None:
+        try:
+            os.nice(int(nice))
+        except OSError:
+            pass
+    return _apply
+
+
 def _run_with_streaming(
     cmd: list[str],
     *,
@@ -164,6 +231,7 @@ def _run_with_streaming(
     env: dict[str, str],
     timeout: float,
     progress_callback: Optional[ProgressCallback],
+    nice: int | None = None,
 ) -> _RunResult:
     """Run `cmd` synchronously and stream stdout + stderr line-by-line.
 
@@ -175,9 +243,11 @@ def _run_with_streaming(
 
     Raises subprocess.TimeoutExpired on timeout (matches the existing flow).
     """
+    preexec = _nice_preexec(nice)
     if progress_callback is None:
         cp = subprocess.run(
             cmd, cwd=cwd, env=env, capture_output=True, text=True, timeout=timeout,
+            preexec_fn=preexec,
         )
         return _RunResult(returncode=cp.returncode, stdout=cp.stdout, stderr=cp.stderr)
 
@@ -189,6 +259,7 @@ def _run_with_streaming(
         stderr=subprocess.PIPE,
         text=True,
         bufsize=1,  # line-buffered
+        preexec_fn=preexec,
     )
     stdout_lines: list[str] = []
     stderr_lines: list[str] = []
@@ -244,6 +315,87 @@ def _run_with_streaming(
 _MAX_BUILD_VARIANTS = 6
 
 
+def _max_build_variants(idf_target: str) -> int:
+    """Variant cap for one target: VELXIO_BUILD_VARIANTS_<TARGET> (e.g.
+    VELXIO_BUILD_VARIANTS_ESP32), else VELXIO_BUILD_VARIANTS, else the module
+    default. Per target because the hot target on velxio.dev rotates through
+    10 distinct variants in half an hour while the others idle at two."""
+    for name in (f'VELXIO_BUILD_VARIANTS_{idf_target.upper()}', 'VELXIO_BUILD_VARIANTS'):
+        raw = os.environ.get(name, '').strip()
+        if raw:
+            try:
+                return max(1, min(64, int(raw)))
+            except ValueError:
+                logger.warning(f'[espidf] {name}={raw!r} is not an integer; ignored')
+    return _MAX_BUILD_VARIANTS
+
+
+# ── Replicas of a hot variant ────────────────────────────────────────────────
+# Two compiles that hash to the SAME variant serialise on its lock, and on
+# velxio.dev the dominant configuration (the default esp32 blink, no
+# libraries) is 78% of all ESP-IDF builds: the second heavy slot spent its time
+# holding a slot while waiting for the first one's directory. A replica is a
+# second full copy of the variant (`v_<hash>_r1`), configured on first use and
+# then as warm as the original, with its own lock. A compile picks the first
+# replica whose lock is free. Replicas are only CREATED after the variant has
+# been found busy a few times in a short window, so a one-off library
+# combination never earns a second 400 MB tree.
+def _variant_replicas() -> int:
+    raw = os.environ.get('VELXIO_BUILD_VARIANT_REPLICAS', '').strip()
+    if not raw:
+        return 1
+    try:
+        return max(1, min(8, int(raw)))
+    except ValueError:
+        logger.warning(f'[espidf] VELXIO_BUILD_VARIANT_REPLICAS={raw!r} is not an integer; using 1')
+        return 1
+
+
+_REPLICA_COLLISION_THRESHOLD = 3     # busy hits before a new replica is created
+_REPLICA_COLLISION_WINDOW_S = 600.0  # ...within this many seconds
+_VARIANT_COLLISIONS: dict[str, deque] = {}
+#: Lock keys of replicas being built in the background right now. A replica
+#: is warmed by a background compile of the SAME sources (so its configure
+#: matches the variant) rather than by the user's job that hit the collision:
+#: a cold build is 30-75 s and that job would rather wait a few seconds for
+#: the original. While warming, the replica is neither picked nor re-created.
+_WARMING_REPLICAS: set[str] = set()
+_BACKGROUND_TASKS: set = set()
+
+
+def _note_variant_collision(base_key: str) -> bool:
+    """Record that every replica of `base_key` was busy. True when the streak
+    is long enough to justify creating the next replica."""
+    now = time.monotonic()
+    hits = _VARIANT_COLLISIONS.setdefault(base_key, deque())
+    hits.append(now)
+    while hits and now - hits[0] > _REPLICA_COLLISION_WINDOW_S:
+        hits.popleft()
+    return len(hits) >= _REPLICA_COLLISION_THRESHOLD
+
+
+def _variant_dir_name(variant_key: str, replica: int = 0) -> str:
+    safe = ''.join(c for c in variant_key if c.isalnum() or c in '-_')[:40] or 'default'
+    return 'v_' + safe + (f'_r{replica}' if replica else '')
+
+
+def _variant_lock_key(idf_target: str, variant_key: str, replica: int = 0) -> str:
+    base = f'{idf_target}/{variant_key}'
+    return base if not replica else f'{base}/r{replica}'
+
+
+_VARIANT_DIR_RE = re.compile(r'^v_(.+?)(?:_r(\d+))?$')
+
+
+def _lock_key_for_variant_dir(idf_target: str, dirname: str) -> str | None:
+    """Inverse of _variant_dir_name: the lock key a `v_*` directory is built
+    under, so eviction can tell whether someone is compiling in it."""
+    m = _VARIANT_DIR_RE.match(dirname)
+    if not m:
+        return None
+    return _variant_lock_key(idf_target, m.group(1), int(m.group(2) or 0))
+
+
 # One compile at a time per build variant. The build queue bounds how many
 # compiles run at once, not WHERE they run: two requests that hash to the same
 # variant (the deploy gate's smoke fired the S3 OLED example twice, 13 s
@@ -293,8 +445,15 @@ def _heal_corrupt_managed_components(project_dir: Path, build_dir: Path) -> bool
     return removed
 
 
-def _evict_cold_variants(target_dir: Path, keep: int) -> None:
-    """LRU-evict variant dirs (``v_*``) beyond ``keep``, coldest mtime first."""
+def _evict_cold_variants(target_dir: Path, keep: int, idf_target: str | None = None) -> None:
+    """LRU-evict variant dirs (``v_*``) beyond ``keep``, coldest mtime first.
+
+    Never evicts a variant whose lock is held: with two compiles of one target
+    running at once (different variants, or replicas of one), the coldest
+    sibling by mtime can be the one a long cold build is still writing into.
+    Its mtime is stamped at prepare time and again when its build finishes
+    (see _attempt), so a variant only looks cold once it has been idle.
+    """
     try:
         variants = [
             d for d in target_dir.iterdir()
@@ -304,10 +463,75 @@ def _evict_cold_variants(target_dir: Path, keep: int) -> None:
         return
     if len(variants) <= keep:
         return
+    target = idf_target or target_dir.name
+
+    def _busy(d: Path) -> bool:
+        key = _lock_key_for_variant_dir(target, d.name)
+        if key is None:
+            return False
+        with _VARIANT_LOCKS_GUARD:
+            lock = _VARIANT_LOCKS.get(key)
+        return bool(lock is not None and lock.locked())
+
     variants.sort(key=lambda d: d.stat().st_mtime if d.exists() else 0.0)
-    for d in variants[:len(variants) - keep]:
+    excess = len(variants) - keep
+    for d in variants:
+        if excess <= 0:
+            break
+        if _busy(d):
+            logger.info(f'[espidf] not evicting {d.name}: a compile holds its lock')
+            continue
         logger.info(f'[espidf] LRU-evicting cold build variant {d.name}')
         shutil.rmtree(d, ignore_errors=True)
+        excess -= 1
+
+
+def _ninja_parallelism_args() -> list[str]:
+    """`-j N` / `-l L` for ninja from VELXIO_NINJA_JOBS / VELXIO_NINJA_LOAD_LIMIT.
+
+    Unset (the OSS default) leaves ninja's own choice, nproc + 2. velxio.dev
+    runs two heavy slots on 6 vCPU, where two such ninjas plus the light lane
+    measured 34 runnable compiler threads at peak; the deployment caps them
+    in docker-compose.yml. `-l` throttles on the 1-minute load average, so a
+    build alone still gets the whole box.
+    """
+    args: list[str] = []
+    raw_jobs = os.environ.get('VELXIO_NINJA_JOBS', '').strip()
+    if raw_jobs:
+        try:
+            jobs = int(raw_jobs)
+            if jobs > 0:
+                args += ['-j', str(jobs)]
+        except ValueError:
+            logger.warning(f'[espidf] VELXIO_NINJA_JOBS={raw_jobs!r} is not an integer; ignored')
+    raw_load = os.environ.get('VELXIO_NINJA_LOAD_LIMIT', '').strip()
+    if raw_load:
+        try:
+            load = float(raw_load)
+            if load > 0:
+                args += ['-l', str(load)]
+        except ValueError:
+            logger.warning(f'[espidf] VELXIO_NINJA_LOAD_LIMIT={raw_load!r} is not a number; ignored')
+    return args
+
+
+_CONFIGURE_TROUBLE_MARKERS = (
+    'CMake Error',
+    'ninja: error',
+    'missing and no known rule to make it',
+    'error: loading \'build.ninja\'',
+)
+
+
+def _ninja_failure_wants_configure(result: _RunResult) -> bool:
+    """True when a failed ninja run on a warm dir looks like a configure
+    problem (cmake re-run failed, an input vanished, a manifest changed) rather
+    than a compiler error in the user's code. The fast path falls back to the
+    explicit configure exactly once on these."""
+    text = (result.stdout or '') + '\n' + (result.stderr or '')
+    if _corrupt_managed_component(text):
+        return True
+    return any(marker in text for marker in _CONFIGURE_TROUBLE_MARKERS)
 
 
 def _ninja_log_step_count(build_dir: 'str | Path') -> int:
@@ -462,9 +686,22 @@ def generate_ino_prototypes(source: str) -> str:
     return source[:first_pos] + block + source[first_pos:]
 
 
+# The toolchain-change wipe below removes EVERY variant of a target. It used
+# to be safe by construction (prepare ran on the event loop, so two compiles
+# could not interleave in it); now that prepare runs in a worker thread, two
+# first-after-restart compiles of one target must not both decide to wipe.
+_TARGET_SENTINEL_GUARD = threading.Lock()
+
+# Where prepare stashes the previous build's generated user_libs CMakeLists so
+# the merge can hand the regenerated file its old mtime when the bytes are
+# identical (it is a configure dependency; a fresh mtime re-runs cmake).
+_USERLIBS_CMAKE_STASH = '.velxio-userlibs-cmake.prev'
+
+
 def _prepare_persistent_project_dir(
     idf_target: str,
     variant_key: str = 'default',
+    replica: int = 0,
 ) -> Path:
     """Return a persistent project dir for (idf_target, variant_key), created
     from the template on first use and with the per-compile parts (main/,
@@ -485,13 +722,14 @@ def _prepare_persistent_project_dir(
 
     # Wipe ALL variants for this target if the toolchain changed (cached .o
     # files are no longer ABI-compatible).
-    sentinel = target_dir / '.idf_version'
-    current_signature = _idf_version_signature()
-    if sentinel.exists() and sentinel.read_text(encoding='utf-8').strip() != current_signature:
-        logger.info(f'[espidf] toolchain version changed; wiping {target_dir}')
-        shutil.rmtree(target_dir, ignore_errors=True)
-        target_dir.mkdir(parents=True, exist_ok=True)
-    sentinel.write_text(current_signature, encoding='utf-8')
+    with _TARGET_SENTINEL_GUARD:
+        sentinel = target_dir / '.idf_version'
+        current_signature = _idf_version_signature()
+        if sentinel.exists() and sentinel.read_text(encoding='utf-8').strip() != current_signature:
+            logger.info(f'[espidf] toolchain version changed; wiping {target_dir}')
+            shutil.rmtree(target_dir, ignore_errors=True)
+            target_dir.mkdir(parents=True, exist_ok=True)
+        sentinel.write_text(current_signature, encoding='utf-8')
 
     # One-time cleanup of the pre-variant layout (target_dir/project) so it
     # doesn't orphan ~240 MB after the upgrade to per-variant dirs.
@@ -500,8 +738,7 @@ def _prepare_persistent_project_dir(
         shutil.rmtree(legacy_project, ignore_errors=True)
         (target_dir / '.options_hash').unlink(missing_ok=True)
 
-    safe = ''.join(c for c in variant_key if c.isalnum() or c in '-_')[:40] or 'default'
-    variant_dir = target_dir / ('v_' + safe)
+    variant_dir = target_dir / _variant_dir_name(variant_key, replica)
     project_dir = variant_dir / 'project'
 
     if not project_dir.exists():
@@ -509,8 +746,17 @@ def _prepare_persistent_project_dir(
         shutil.copytree(_TEMPLATE_DIR, project_dir)
     else:
         # Reset per-compile parts only; keep build/ (warm for this variant).
+        # copytree preserves the template's mtimes, so main/CMakeLists.txt
+        # does NOT look new to ninja after this; the user's sources do, which
+        # is exactly what has to recompile.
         shutil.rmtree(project_dir / 'main', ignore_errors=True)
         shutil.copytree(_TEMPLATE_DIR / 'main', project_dir / 'main')
+        prev_cmake = project_dir / 'user_libs' / 'user_libs_all' / 'CMakeLists.txt'
+        stash = project_dir / _USERLIBS_CMAKE_STASH
+        if prev_cmake.is_file():
+            shutil.copy2(prev_cmake, stash)  # copy2 keeps the mtime
+        else:
+            stash.unlink(missing_ok=True)
         shutil.rmtree(project_dir / 'user_libs', ignore_errors=True)
 
     # Mark this variant most-recently-used, then LRU-evict the coldest.
@@ -518,7 +764,7 @@ def _prepare_persistent_project_dir(
         os.utime(variant_dir, None)
     except OSError:
         pass
-    _evict_cold_variants(target_dir, keep=_MAX_BUILD_VARIANTS)
+    _evict_cold_variants(target_dir, keep=_max_build_variants(idf_target), idf_target=idf_target)
 
     return project_dir
 
@@ -2503,7 +2749,22 @@ class ESPIDFCompiler:
             f'{defs_block}'
             f'{warns_block}'
         )
-        (comp_dir / 'CMakeLists.txt').write_text(cmake_content, encoding='utf-8')
+        cmake_path = comp_dir / 'CMakeLists.txt'
+        cmake_path.write_text(cmake_content, encoding='utf-8')
+        # The component's CMakeLists.txt is a configure dependency. The tree
+        # was wiped at prepare (a scan-all variant may resolve a different
+        # library set per sketch, so stale files must never survive), but the
+        # library files themselves come back through copy2 with their cache
+        # mtimes, and this file is the only one ninja would see as new. Give
+        # it back its previous mtime when the bytes did not change, so a warm
+        # variant with libraries skips the configure like a bare one does.
+        stash = comp_dir.parent.parent / _USERLIBS_CMAKE_STASH
+        try:
+            if stash.is_file() and stash.read_text(encoding='utf-8') == cmake_content:
+                st = stash.stat()
+                os.utime(cmake_path, (st.st_atime, st.st_mtime))
+        except OSError:
+            pass
         logger.info(
             f'[espidf] user_libs_all: {len(cpp_files)} source files, '
             f'{len(header_to_comp)} resolved headers'
@@ -4172,6 +4433,71 @@ class ESPIDFCompiler:
         )
         return merged_path
 
+    @staticmethod
+    def _pick_replica(idf_target: str, eff_hash: str) -> tuple[int, int | None]:
+        """(replica to build in, replica to warm in the background or None).
+
+        The first replica whose lock is free wins (0 first: it always exists).
+        When every existing copy is busy the compile queues on replica 0, and
+        after a short streak of such collisions (so a rare variant never gets
+        a second tree) the NEXT replica is created by a background build.
+        """
+        max_replicas = _variant_replicas()
+        target_dir = _BUILD_ROOT / idf_target
+        existing: list[int] = []
+        for n in range(max_replicas):
+            key = _variant_lock_key(idf_target, eff_hash, n)
+            if n == 0 or (
+                key not in _WARMING_REPLICAS
+                and (target_dir / _variant_dir_name(eff_hash, n)).is_dir()
+            ):
+                existing.append(n)
+        for n in existing:
+            if not _variant_lock(_variant_lock_key(idf_target, eff_hash, n)).locked():
+                return n, None
+        base_key = _variant_lock_key(idf_target, eff_hash)
+        nxt = len(existing)
+        warm = None
+        if (
+            nxt < max_replicas
+            and _variant_lock_key(idf_target, eff_hash, nxt) not in _WARMING_REPLICAS
+            and _note_variant_collision(base_key)
+        ):
+            warm = nxt
+        return 0, warm
+
+    def _warm_replica_in_background(
+        self, replica: int, idf_target: str, eff_hash: str,
+        files: list[dict], board_fqbn: str, **compile_kwargs,
+    ) -> None:
+        """Build replica `replica` of this variant from the same sources, off
+        to the side, at low CPU priority, so the next collision finds a warm
+        copy. Nothing waits on it; a failure only means no replica."""
+        key = _variant_lock_key(idf_target, eff_hash, replica)
+        if key in _WARMING_REPLICAS:
+            return
+        _WARMING_REPLICAS.add(key)
+        logger.info(f'[espidf] every replica of {idf_target}/{eff_hash} is busy; warming replica {replica} in the background')
+
+        async def _warm() -> None:
+            try:
+                result = await self.compile(
+                    files, board_fqbn, progress_callback=None,
+                    cpu_nice=10, _force_replica=replica, **compile_kwargs,
+                )
+                logger.info(
+                    f'[espidf] replica {replica} of {idf_target}/{eff_hash} warmed '
+                    f'(success={result.get("success")})'
+                )
+            except Exception:
+                logger.exception(f'[espidf] warming replica {replica} of {idf_target}/{eff_hash} failed')
+            finally:
+                _WARMING_REPLICAS.discard(key)
+
+        task = asyncio.create_task(_warm())
+        _BACKGROUND_TASKS.add(task)
+        task.add_done_callback(_BACKGROUND_TASKS.discard)
+
     async def compile(
         self,
         files: list[dict],
@@ -4183,6 +4509,8 @@ class ESPIDFCompiler:
         owner_id: str | None = None,
         pure_idf: bool = False,
         custom_wifi_ssids: list[str] | None = None,
+        cpu_nice: int | None = None,
+        _force_replica: int | None = None,
     ) -> dict:
         """
         Compile Arduino sketch using ESP-IDF.
@@ -4359,18 +4687,57 @@ class ESPIDFCompiler:
                     # Prepare AND build under the variant lock: prepare wipes main/ and
                     # user_libs, and the configure populates managed_components/ - neither
                     # survives a second compile landing in the same dir mid-way.
-                    async with _variant_lock(f'{idf_target}/{eff_hash}'):
-                        project_dir = _prepare_persistent_project_dir(idf_target, eff_hash)
-                        logger.info(f'[espidf] Using persistent build dir: {project_dir}')
-                        return await self._compile_in_dir(
-                            project_dir, files, idf_target,
-                            progress_callback, normalized_opts, spiffs_files,
-                            allowed_libraries=allowed, libraries_dir=scope_dir,
-                            arduino_mode=arduino_mode, use_idf5=use_idf5,
-                            pure_idf=pure_idf, board_fqbn=board_fqbn,
-                            custom_wifi_ssids=custom_wifi_ssids,
-                            denied_libraries=denied, speculative_out=speculative,
+                    if _force_replica is not None:
+                        replica = _force_replica
+                    else:
+                        replica, warm = self._pick_replica(idf_target, eff_hash)
+                        if warm is not None:
+                            self._warm_replica_in_background(
+                                warm, idf_target, eff_hash, files, board_fqbn,
+                                board_options=board_options,
+                                allowed_libraries=allowed, owner_id=owner_id,
+                                pure_idf=pure_idf, custom_wifi_ssids=custom_wifi_ssids,
+                            )
+                    lock_key = _variant_lock_key(idf_target, eff_hash, replica)
+                    wait_t0 = time.monotonic()
+                    async with _variant_lock(lock_key):
+                        waited = time.monotonic() - wait_t0
+                        _timing_note(
+                            variant_wait_ms=int(waited * 1000),
+                            replica=replica,
+                            variant=f'{idf_target}/{eff_hash}',
                         )
+                        if waited > 0.5:
+                            logger.info(
+                                f'[espidf] waited {waited:.1f}s for build dir '
+                                f'{lock_key} (replica {replica})'
+                            )
+                        # Prepare does rmtree + copytree on a 100-500 MB tree
+                        # and the LRU eviction: off the event loop, or every
+                        # WebSocket frame on the box stalls behind it.
+                        project_dir = await asyncio.to_thread(
+                            _prepare_persistent_project_dir, idf_target, eff_hash, replica,
+                        )
+                        logger.info(f'[espidf] Using persistent build dir: {project_dir}')
+                        try:
+                            return await self._compile_in_dir(
+                                project_dir, files, idf_target,
+                                progress_callback, normalized_opts, spiffs_files,
+                                allowed_libraries=allowed, libraries_dir=scope_dir,
+                                arduino_mode=arduino_mode, use_idf5=use_idf5,
+                                pure_idf=pure_idf, board_fqbn=board_fqbn,
+                                custom_wifi_ssids=custom_wifi_ssids,
+                                denied_libraries=denied, speculative_out=speculative,
+                                cpu_nice=cpu_nice,
+                            )
+                        finally:
+                            # Re-stamp at the END of the build too: eviction
+                            # sorts by this, and a long build must not be the
+                            # coldest sibling because it started long ago.
+                            try:
+                                os.utime(project_dir.parent, None)
+                            except OSError:
+                                pass
                 with tempfile.TemporaryDirectory(prefix='espidf_') as temp_dir:
                     project_dir = Path(temp_dir) / 'project'
                     shutil.copytree(_TEMPLATE_DIR, project_dir)
@@ -4382,6 +4749,7 @@ class ESPIDFCompiler:
                         arduino_mode=arduino_mode, use_idf5=use_idf5,
                         pure_idf=pure_idf, board_fqbn=board_fqbn,
                         custom_wifi_ssids=custom_wifi_ssids,
+                        cpu_nice=cpu_nice,
                     )
             finally:
                 if scope_dir is not None:
@@ -4517,6 +4885,7 @@ class ESPIDFCompiler:
         custom_wifi_ssids: list[str] | None = None,
         denied_libraries: set[str] | None = None,
         speculative_out: set[str] | None = None,
+        cpu_nice: int | None = None,
     ) -> dict:
         """Inner compile body: writes sketch + libs into `project_dir`,
         runs cmake + ninja, merges binaries. Caller is responsible for
@@ -4561,7 +4930,13 @@ class ESPIDFCompiler:
         prev_defaults = (
             defaults_path.read_text(encoding='utf-8') if defaults_path.exists() else None
         )
-        defaults_path.write_text(rendered_sdkconfig, encoding='utf-8')
+        if prev_defaults != rendered_sdkconfig:
+            defaults_path.write_text(rendered_sdkconfig, encoding='utf-8')
+        # A defaults change drops the generated sdkconfig below, and a missing
+        # sdkconfig is a missing configure input: ninja refuses to regenerate
+        # ("needed by build.ninja, missing"), so that case must run cmake
+        # explicitly. First build of a variant has no build.ninja anyway.
+        force_configure = prev_defaults is not None and prev_defaults != rendered_sdkconfig
 
 
         # ESP-IDF only SEEDS sdkconfig from sdkconfig.defaults when sdkconfig is
@@ -4610,7 +4985,7 @@ class ESPIDFCompiler:
 
         # Generate partitions.csv per the selected scheme.
         partition_csv = self._render_partition_csv(board_options['partitionScheme'])
-        (project_dir / 'partitions.csv').write_text(partition_csv, encoding='utf-8')
+        _write_if_changed(project_dir / 'partitions.csv', partition_csv)
 
         # Get sketch content — Arduino tab semantics: EVERY .ino is part of
         # the sketch. The main file (literal sketch.ino, else the first .ino
@@ -4937,6 +5312,54 @@ class ESPIDFCompiler:
         build_dir = project_dir / 'build'
         build_dir.mkdir(exist_ok=True)
 
+        # The template's main/CMakeLists.txt globs main/*.c and *.cpp without
+        # CONFIGURE_DEPENDS (ESP-IDF evaluates component CMakeLists in script
+        # mode, where it is rejected), so cmake only re-globs on a configure.
+        # Record the set of compilable sources per build; when it differs from
+        # the last build's, bump main/CMakeLists.txt so ninja's RERUN_CMAKE
+        # rule re-runs cmake and the new (or removed) file reaches the graph.
+        main_dir = project_dir / 'main'
+        try:
+            source_set = '\n'.join(sorted(
+                p.name for p in main_dir.iterdir() if p.suffix in ('.c', '.cpp')
+            ))
+        except OSError:
+            source_set = ''
+        source_marker = project_dir / '.velxio-sources'
+        prev_source_set = (
+            source_marker.read_text(encoding='utf-8') if source_marker.exists() else None
+        )
+        if prev_source_set != source_set:
+            source_marker.write_text(source_set, encoding='utf-8')
+            if prev_source_set is not None:
+                try:
+                    os.utime(main_dir / 'CMakeLists.txt', None)
+                except OSError:
+                    pass
+                logger.info('[espidf] source set changed; cmake will re-glob main/')
+
+        # A warm build dir skips the explicit configure: ninja re-runs cmake by
+        # itself when any configure input changed (partitions.csv,
+        # velxio_board.cmake, sdkconfig, every CMakeLists.txt, the managed
+        # components' manifests). Measured 2026-09-04: the configure was 18 of
+        # the 25 s of a warm esp32 build under load, and ninja then ran ~10
+        # steps. VELXIO_ESPIDF_ALWAYS_CONFIGURE=1 restores the old behaviour.
+        configure_skipped = (
+            not _ALWAYS_CONFIGURE
+            and not force_configure
+            and (build_dir / 'build.ninja').is_file()
+            and (build_dir / 'CMakeCache.txt').is_file()
+        )
+        if (
+            configure_skipped and idf_target == 'esp32p4' and arduino_mode
+            and (project_dir / 'managed_components' / 'espressif__esp_hosted').is_dir()
+            and not (project_dir / 'components' / 'espressif__esp_hosted').is_dir()
+        ):
+            # The first configure fetched esp_hosted but the patched override
+            # was never adopted (an earlier attempt died in between): only the
+            # explicit path below creates and reconfigures it.
+            configure_skipped = False
+
         env = self._build_env(
             idf_target, use_idf5=use_idf5, arduino_mode=arduino_mode,
             pure_idf=pure_idf,
@@ -4966,8 +5389,6 @@ class ESPIDFCompiler:
         if os.environ.get('IDF_CCACHE_ENABLE', '1') not in ('0', 'false', 'False', ''):
             cmake_cmd.append('-DCCACHE_ENABLE=1')
 
-        logger.info(f'[espidf] cmake: {" ".join(cmake_cmd)}')
-
         # IDF 5.x configure does more work per cold run (component manager,
         # per-target tool checks) — give it more headroom than the 4.4 flow.
         cmake_timeout = 300 if use_idf5 else 120
@@ -4979,82 +5400,105 @@ class ESPIDFCompiler:
                 env=env,
                 timeout=cmake_timeout,
                 progress_callback=progress_callback,
+                nice=cpu_nice,
             )
 
-        try:
-            cmake_result = await asyncio.to_thread(_run_cmake)
-        except subprocess.TimeoutExpired:
-            logger.error(
-                f'[espidf] cmake configure timed out after {cmake_timeout}s '
-                f'in {build_dir}'
-            )
-            return {
-                'success': False,
-                'error': f'ESP-IDF cmake configure timed out ({cmake_timeout}s)',
-                'stdout': '',
-                'stderr': '',
-            }
+        cmake_result = _RunResult(returncode=0, stdout='', stderr='')
 
-        if cmake_result.returncode != 0:
-            # A managed component left half-copied by an interrupted or
-            # concurrent configure makes the component manager refuse the
-            # whole variant for good ("is corrupted"). The copy in its own
-            # cache is intact, so drop the variant's copies and configure
-            # once more instead of failing every compile of this variant
-            # until the dir is deleted by hand.
-            corrupt = _corrupt_managed_component(cmake_result.stderr)
-            if corrupt and _heal_corrupt_managed_components(project_dir, build_dir):
-                logger.warning(
-                    f'[espidf] managed component "{corrupt}" corrupted in '
-                    f'{project_dir}; dropped managed_components/ and reconfiguring'
+        async def _configure() -> dict | None:
+            """The explicit cmake configure. Returns an error result, or None."""
+            nonlocal cmake_result
+            logger.info(f'[espidf] cmake: {" ".join(cmake_cmd)}')
+            configure_t0 = time.monotonic()
+            try:
+                cmake_result = await asyncio.to_thread(_run_cmake)
+            except subprocess.TimeoutExpired:
+                logger.error(
+                    f'[espidf] cmake configure timed out after {cmake_timeout}s '
+                    f'in {build_dir}'
                 )
-                try:
-                    cmake_result = await asyncio.to_thread(_run_cmake)
-                except subprocess.TimeoutExpired:
-                    return {
-                        'success': False,
-                        'error': f'ESP-IDF cmake reconfigure timed out ({cmake_timeout}s)',
-                        'stdout': '',
-                        'stderr': '',
-                    }
-        if cmake_result.returncode != 0:
-            logger.error(f'[espidf] cmake failed:\n{cmake_result.stderr}')
-            return {
-                'success': False,
-                'error': 'ESP-IDF cmake configure failed',
-                'stdout': cmake_result.stdout,
-                'stderr': cmake_result.stderr,
-            }
+                return {
+                    'success': False,
+                    'error': f'ESP-IDF cmake configure timed out ({cmake_timeout}s)',
+                    'stdout': '',
+                    'stderr': '',
+                }
 
-        # The configure above fetched managed components; give esp32p4 its
-        # patched esp_hosted override, and reconfigure once when it appears
-        # so the build system adopts the components/ dir.
-        if idf_target == 'esp32p4' and arduino_mode:
-            if self._override_esp_hosted_with_race_fix(project_dir):
-                try:
-                    cmake_result = await asyncio.to_thread(_run_cmake)
-                except subprocess.TimeoutExpired:
-                    return {
-                        'success': False,
-                        'error': f'ESP-IDF cmake reconfigure timed out ({cmake_timeout}s)',
-                        'stdout': '',
-                        'stderr': '',
-                    }
-                if cmake_result.returncode != 0:
-                    logger.error(
-                        f'[espidf] reconfigure after esp_hosted override failed:\n'
-                        f'{cmake_result.stderr}'
+            if cmake_result.returncode != 0:
+                # A managed component left half-copied by an interrupted or
+                # concurrent configure makes the component manager refuse the
+                # whole variant for good ("is corrupted"). The copy in its own
+                # cache is intact, so drop the variant's copies and configure
+                # once more instead of failing every compile of this variant
+                # until the dir is deleted by hand.
+                corrupt = _corrupt_managed_component(cmake_result.stderr)
+                if corrupt and _heal_corrupt_managed_components(project_dir, build_dir):
+                    logger.warning(
+                        f'[espidf] managed component "{corrupt}" corrupted in '
+                        f'{project_dir}; dropped managed_components/ and reconfiguring'
                     )
-                    return {
-                        'success': False,
-                        'error': 'ESP-IDF reconfigure after esp_hosted override failed',
-                        'stdout': cmake_result.stdout,
-                        'stderr': cmake_result.stderr,
-                    }
+                    try:
+                        cmake_result = await asyncio.to_thread(_run_cmake)
+                    except subprocess.TimeoutExpired:
+                        return {
+                            'success': False,
+                            'error': f'ESP-IDF cmake reconfigure timed out ({cmake_timeout}s)',
+                            'stdout': '',
+                            'stderr': '',
+                        }
+            if cmake_result.returncode != 0:
+                logger.error(f'[espidf] cmake failed:\n{cmake_result.stderr}')
+                return {
+                    'success': False,
+                    'error': 'ESP-IDF cmake configure failed',
+                    'stdout': cmake_result.stdout,
+                    'stderr': cmake_result.stderr,
+                }
+
+            # The configure above fetched managed components; give esp32p4 its
+            # patched esp_hosted override, and reconfigure once when it appears
+            # so the build system adopts the components/ dir.
+            if idf_target == 'esp32p4' and arduino_mode:
+                if self._override_esp_hosted_with_race_fix(project_dir):
+                    try:
+                        cmake_result = await asyncio.to_thread(_run_cmake)
+                    except subprocess.TimeoutExpired:
+                        return {
+                            'success': False,
+                            'error': f'ESP-IDF cmake reconfigure timed out ({cmake_timeout}s)',
+                            'stdout': '',
+                            'stderr': '',
+                        }
+                    if cmake_result.returncode != 0:
+                        logger.error(
+                            f'[espidf] reconfigure after esp_hosted override failed:\n'
+                            f'{cmake_result.stderr}'
+                        )
+                        return {
+                            'success': False,
+                            'error': 'ESP-IDF reconfigure after esp_hosted override failed',
+                            'stdout': cmake_result.stdout,
+                            'stderr': cmake_result.stderr,
+                        }
+            _timing_note(configure_ms=int((time.monotonic() - configure_t0) * 1000))
+            return None
+
+        if configure_skipped:
+            logger.info('[espidf] warm build dir: skipping cmake configure')
+            if progress_callback is not None:
+                try:
+                    progress_callback('[velxio] build dir is warm; skipping cmake configure\n')
+                except Exception:
+                    pass
+        else:
+            configure_error = await _configure()
+            if configure_error is not None:
+                return configure_error
+        _timing_note(configure_skipped=configure_skipped)
 
         # Step 2: ninja build
-        ninja_cmd = ['ninja']
-        logger.info('[espidf] Building with ninja...')
+        ninja_cmd = ['ninja'] + _ninja_parallelism_args()
+        logger.info(f'[espidf] Building with {" ".join(ninja_cmd)}...')
 
         # Cold ESP-IDF builds with external Arduino libraries (e.g. Adafruit
         # BMP280 + BusIO + Unified Sensor → ~1480 build steps) regularly take
@@ -5070,10 +5514,30 @@ class ESPIDFCompiler:
                 env=env,
                 timeout=NINJA_TIMEOUT_S,
                 progress_callback=progress_callback,
+                nice=cpu_nice,
             )
 
+        ninja_t0 = time.monotonic()
         try:
             ninja_result = await asyncio.to_thread(_run_ninja)
+            if (
+                configure_skipped
+                and ninja_result.returncode != 0
+                and _ninja_failure_wants_configure(ninja_result)
+            ):
+                # The fast path trusted the warm dir and ninja's own cmake
+                # re-run could not cope (a deleted input, a corrupted managed
+                # component, a stale cache). Do what the slow path would have
+                # done from the start, once, then build again.
+                logger.warning(
+                    '[espidf] ninja could not regenerate the warm build dir; '
+                    'falling back to an explicit configure'
+                )
+                _timing_note(configure_fallback=True)
+                configure_error = await _configure()
+                if configure_error is not None:
+                    return configure_error
+                ninja_result = await asyncio.to_thread(_run_ninja)
         except subprocess.TimeoutExpired:
             # Silent before — a 600s failure left no server-side trace at all,
             # so a slow-box incident (2026-08-17: cold S3 variant, ccache
@@ -5097,6 +5561,7 @@ class ESPIDFCompiler:
                 'stderr': '',
             }
 
+        _timing_note(ninja_ms=int((time.monotonic() - ninja_t0) * 1000))
         all_stdout = cmake_result.stdout + '\n' + ninja_result.stdout
         all_stderr = cmake_result.stderr + '\n' + ninja_result.stderr
 

--- a/test/backend/unit/test_build_queue.py
+++ b/test/backend/unit/test_build_queue.py
@@ -297,3 +297,146 @@ class LoadLevelTests(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class PriorityBurstTests(unittest.IsolatedAsyncioTestCase):
+    """`priority_burst`: a paid build starts at once on a full lane.
+
+    Ordering alone cannot do that — a full lane has nothing to hand over
+    until a build finishes. The burst lets a priority job run ABOVE capacity,
+    bounded, and never a standard one. Off (0) unless the deployment asks.
+    """
+
+    async def test_priority_job_starts_immediately_on_a_full_lane(self) -> None:
+        queue = BuildQueue('test', capacity=2, priority_burst=1)
+        admitted: list[str] = []
+        gate = asyncio.Event()
+
+        async def standard(idx: int) -> None:
+            async with queue.slot(priority=PRIORITY_STANDARD):
+                admitted.append(f'free-{idx}')
+                await gate.wait()
+
+        async def paid() -> None:
+            async with queue.slot(priority=PRIORITY_HIGH):
+                admitted.append('pro')
+                await gate.wait()
+
+        frees = [asyncio.create_task(standard(i)) for i in range(5)]
+        await asyncio.sleep(0)  # two run, three wait
+        pro = asyncio.create_task(paid())
+        await asyncio.sleep(0)
+
+        self.assertEqual(admitted, ['free-0', 'free-1', 'pro'])
+        self.assertEqual(queue.active, 3)
+        self.assertEqual(queue.burst_active, 1)
+
+        gate.set()
+        await asyncio.wait_for(asyncio.gather(pro, *frees), timeout=2)
+        self.assertEqual(queue.active, 0)
+        self.assertEqual(len(admitted), 6)
+
+    async def test_standard_jobs_never_use_the_burst(self) -> None:
+        queue = BuildQueue('test', capacity=1, priority_burst=2)
+        admitted: list[str] = []
+        gate = asyncio.Event()
+
+        async def standard(idx: int) -> None:
+            async with queue.slot(priority=PRIORITY_STANDARD):
+                admitted.append(f'free-{idx}')
+                await gate.wait()
+
+        tasks = [asyncio.create_task(standard(i)) for i in range(4)]
+        await asyncio.sleep(0)
+        self.assertEqual(admitted, ['free-0'])
+        self.assertEqual(queue.burst_active, 0)
+        gate.set()
+        await asyncio.wait_for(asyncio.gather(*tasks), timeout=2)
+
+    async def test_the_burst_is_bounded(self) -> None:
+        queue = BuildQueue('test', capacity=1, priority_burst=1)
+        admitted: list[str] = []
+        gate = asyncio.Event()
+
+        async def job(label: str, priority: int) -> None:
+            async with queue.slot(priority=priority):
+                admitted.append(label)
+                await gate.wait()
+
+        free = asyncio.create_task(job('free', PRIORITY_STANDARD))
+        await asyncio.sleep(0)
+        pros = [asyncio.create_task(job(f'pro-{i}', PRIORITY_HIGH)) for i in range(3)]
+        await asyncio.sleep(0)
+        # One burst admission, the other two priority jobs wait for a slot.
+        self.assertEqual(admitted, ['free', 'pro-0'])
+        self.assertEqual(queue.waiting, 2)
+        gate.set()
+        await asyncio.wait_for(asyncio.gather(free, *pros), timeout=2)
+        self.assertEqual(len(admitted), 4)
+
+    async def test_reserved_standard_slot_survives_the_burst(self) -> None:
+        """A free build still advances under a flood of paid ones with burst on."""
+        queue = BuildQueue('test', capacity=2, priority_burst=1)
+        admitted: list[str] = []
+        gate = asyncio.Event()
+
+        async def paid(idx: int) -> None:
+            async with queue.slot(priority=PRIORITY_HIGH):
+                admitted.append(f'pro-{idx}')
+                await gate.wait()
+
+        async def standard() -> None:
+            async with queue.slot(priority=PRIORITY_STANDARD):
+                admitted.append('free')
+
+        pros = [asyncio.create_task(paid(i)) for i in range(12)]
+        await asyncio.sleep(0)  # 2 regular + 1 burst run, nine wait
+        free = asyncio.create_task(standard())
+        await asyncio.sleep(0)
+        gate.set()
+        await asyncio.wait_for(asyncio.gather(free, *pros), timeout=2)
+        self.assertLessEqual(
+            admitted.index('free'), 4,
+            f'free build waited behind too many paid builds: {admitted}',
+        )
+
+    async def test_a_lifted_job_takes_the_burst(self) -> None:
+        """Dedup lifts a queued standard job to paid; it must burst in at once."""
+        queue = BuildQueue('test', capacity=1, priority_burst=1)
+        admitted: list[str] = []
+        gate = asyncio.Event()
+
+        async def job(label: str, priority: int, key: str | None = None) -> None:
+            async with queue.slot(priority=priority, key=key):
+                admitted.append(label)
+                await gate.wait()
+
+        blocker = asyncio.create_task(job('free-0', PRIORITY_STANDARD))
+        await asyncio.sleep(0)
+        shared = asyncio.create_task(job('shared', PRIORITY_STANDARD, key='shared'))
+        await asyncio.sleep(0)
+        self.assertEqual(admitted, ['free-0'])
+        self.assertTrue(queue.reprioritize('shared', PRIORITY_HIGH))
+        await asyncio.sleep(0)
+        self.assertEqual(admitted, ['free-0', 'shared'])
+        gate.set()
+        await asyncio.wait_for(asyncio.gather(blocker, shared), timeout=2)
+
+    async def test_burst_off_by_default(self) -> None:
+        queue = BuildQueue('test', capacity=1)
+        self.assertEqual(queue.priority_burst, 0)
+        gate = asyncio.Event()
+        admitted: list[str] = []
+
+        async def job(label: str, priority: int) -> None:
+            async with queue.slot(priority=priority):
+                admitted.append(label)
+                await gate.wait()
+
+        free = asyncio.create_task(job('free', PRIORITY_STANDARD))
+        await asyncio.sleep(0)
+        pro = asyncio.create_task(job('pro', PRIORITY_HIGH))
+        await asyncio.sleep(0)
+        self.assertEqual(admitted, ['free'])
+        gate.set()
+        await asyncio.wait_for(asyncio.gather(free, pro), timeout=2)

--- a/test/backend/unit/test_compile_build_lock.py
+++ b/test/backend/unit/test_compile_build_lock.py
@@ -1,25 +1,24 @@
 """
-The compile lock must protect the BUILD DIRECTORY, not the FQBN.
+The compile route holds NO build lock of its own; the compiler does.
 
-`_prepare_persistent_project_dir` keys the persistent build dir on
-(idf_target, variant). arduino-esp32's boards.txt gives several boards the same
-variant — `esp32` and `esp32cam` are both `build.variant=esp32` — so those FQBNs
-share one directory. The lock used to be keyed on the FQBN, which left them free
-to build in it at the same time.
+Until 2026-09 `routes/compile.py` took a per-target `asyncio.Lock` keyed on
+(idf_target, arduino variant) INSIDE the lane slot. The compiler has since
+grown its own lock per persistent build dir (`_variant_lock`, one per variant
+or replica), which protects exactly the shared resource. Keeping the coarser
+route lock on top cost velxio.dev its second heavy slot: 78% of ESP-IDF builds
+are esp32:esp32:esp32, so the second slot spent whole hours holding a slot
+while blocked on the lock (2026-09-02 12:00: one slot 3647 s of build time,
+the other 943 s, queue p50 43 minutes).
 
-That is not a theoretical race. Measured against staging: compiling
-`esp32:esp32:esp32` and `esp32:esp32:esp32cam` concurrently returned
-BYTE-IDENTICAL firmware (same sha256, 285504 bytes) and the esp32cam caller got
-the other sketch's binary — verified by embedding a unique marker string in each
-sketch and finding the wrong one in the returned image. In the product that
-surfaced as a gallery example running someone else's program: open two ESP32
-examples in two tabs, and the first tab shows the second's serial log and does
-nothing itself.
+`_build_identity` stays: the duration estimate is keyed on it, and it still
+has to name the build DIRECTORY (esp32 and esp32cam share one) rather than the
+FQBN.
 
 Run from the repo root:
     python -m pytest test/backend/unit/test_compile_build_lock.py -v
 """
 
+import inspect
 import sys
 import unittest
 from pathlib import Path
@@ -29,80 +28,48 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / 'backend'))
 from app.api.routes import compile as compile_module
 
 
+class RouteHoldsNoBuildLockTests(unittest.TestCase):
+    def test_the_route_level_target_lock_is_gone(self):
+        self.assertFalse(
+            hasattr(compile_module, '_target_lock'),
+            'the per-target lock is back in the route; it serialises every '
+            'esp32 build and wastes the second heavy slot (see module docstring)',
+        )
+        self.assertFalse(hasattr(compile_module, '_TARGET_LOCKS'))
+
+    def test_the_job_runner_does_not_lock_inside_the_slot(self):
+        source = inspect.getsource(compile_module._compile_job)
+        self.assertNotIn('_target_lock', source)
+        self.assertIn('lane.slot(', source)
+
+    def test_the_sync_route_does_not_lock_inside_the_slot(self):
+        source = inspect.getsource(compile_module.compile_sketch)
+        self.assertNotIn('_target_lock', source)
+
+
 class BuildIdentityTests(unittest.TestCase):
-    def test_boards_sharing_a_variant_share_one_lock(self):
-        """esp32 and esp32cam build in the same dir, so they must serialise."""
-        plain = compile_module._target_lock('esp32:esp32:esp32')
-        cam = compile_module._target_lock('esp32:esp32:esp32cam')
-        self.assertIs(
-            plain,
-            cam,
-            'esp32 and esp32cam share one persistent build dir (both are '
-            'build.variant=esp32); handing them different locks lets them '
-            'corrupt each other and swap binaries.',
+    def test_boards_sharing_a_variant_share_one_identity(self):
+        """esp32 and esp32cam build in the same dir (both build.variant=esp32)."""
+        self.assertEqual(
+            compile_module._build_identity('esp32:esp32:esp32'),
+            compile_module._build_identity('esp32:esp32:esp32cam'),
         )
 
-    def test_the_same_board_still_serialises(self):
-        self.assertIs(
-            compile_module._target_lock('esp32:esp32:esp32'),
-            compile_module._target_lock('esp32:esp32:esp32'),
-        )
-
-    def test_different_chips_still_run_in_parallel(self):
-        """The lock must not become a global one — that would halve throughput."""
-        xtensa = compile_module._target_lock('esp32:esp32:esp32')
-        riscv = compile_module._target_lock('esp32:esp32:esp32c3')
-        self.assertIsNot(
-            xtensa,
-            riscv,
-            'different IDF targets have separate build dirs and should still '
-            'compile concurrently up to the semaphore cap.',
-        )
-
-    def test_non_esp32_boards_never_share_a_lock(self):
-        """Only the ESP-IDF lane has a shared persistent build dir.
-
-        This assertion was inverted until now: it required every unrecognised
-        FQBN to collapse onto the default (esp32, esp32) pair, on the reasoning
-        that over-serialising is the safe direction. `_build_identity` stopped
-        doing that deliberately — `_idf_target` defaults ANY unknown board to
-        'esp32', so an AVR / RP2040 / STM32 compile inherited the ESP32 key and
-        queued behind unrelated ESP-IDF builds it shares nothing with. There is
-        no correctness argument for that wait: those boards go through
-        arduino-cli, which has no shared build dir to corrupt.
-        """
-        a = compile_module._build_identity('definitely:not:a:board')
-        b = compile_module._build_identity('also:not:a:board')
+    def test_different_chips_have_different_identities(self):
         self.assertNotEqual(
-            a,
-            b,
-            'non-ESP32 FQBNs have no shared build dir, so each keeps its own '
-            'identity instead of collapsing onto the ESP32 default.',
-        )
-        self.assertIsNot(
-            compile_module._target_lock('arduino:avr:uno'),
-            compile_module._target_lock('rp2040:rp2040:rpipico'),
-            'an AVR build must not queue behind an ESP-IDF one.',
+            compile_module._build_identity('esp32:esp32:esp32'),
+            compile_module._build_identity('esp32:esp32:esp32c3'),
         )
 
-    def test_a_non_esp32_board_still_serialises_with_itself(self):
-        """Dropping the shared key must not drop the per-board lock too."""
-        self.assertIs(
-            compile_module._target_lock('arduino:avr:uno'),
-            compile_module._target_lock('arduino:avr:uno'),
+    def test_non_esp32_boards_keep_their_own_identity(self):
+        """`_idf_target` defaults unknown boards to esp32; a non-ESP32 FQBN
+        must not collapse onto that pair (it would share the esp32 estimate)."""
+        self.assertNotEqual(
+            compile_module._build_identity('definitely:not:a:board'),
+            compile_module._build_identity('also:not:a:board'),
         )
-
-    def test_unknown_esp32_boards_still_share_the_default_pair(self):
-        """The over-serialising fallback stays where it protects something.
-
-        An unrecognised `esp32:` FQBN still resolves through _idf_target to the
-        default pair and lands in that build dir, so it must keep sharing the
-        lock — serialising more than necessary costs throughput, serialising
-        less corrupts a build.
-        """
-        self.assertIs(
-            compile_module._target_lock('esp32:esp32:definitely-not-a-board'),
-            compile_module._target_lock('esp32:esp32:also-not-a-board'),
+        self.assertEqual(
+            compile_module._build_identity('arduino:avr:uno'), 'arduino:avr:uno',
         )
 
 

--- a/test/backend/unit/test_espidf_compile_speed.py
+++ b/test/backend/unit/test_espidf_compile_speed.py
@@ -1,0 +1,238 @@
+"""Compile-speed mechanics in espidf_compiler (2026-09).
+
+Three things a warm ESP-IDF build depends on, none of which the toolchain is
+needed to check:
+
+  1. Generated configure inputs are written only when their bytes change, so
+     ninja's RERUN_CMAKE rule does not fire for a file that is the same.
+  2. Variant eviction never removes a directory whose lock is held, and
+     replicas of a variant are named / keyed consistently in both directions.
+  3. A failed ninja run on a warm dir is told apart as "configure trouble"
+     (fall back to an explicit cmake) vs. an error in the user's code.
+
+Run from the repo root:
+    python -m pytest test/backend/unit/test_espidf_compile_speed.py -v
+"""
+
+import asyncio
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / 'backend'))
+
+from app.services import espidf_compiler as ec  # noqa: E402
+
+
+class WriteIfChangedTests(unittest.TestCase):
+    def test_identical_bytes_keep_the_mtime(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / 'partitions.csv'
+            p.write_text('a,b,c\n')
+            old = time.time() - 3600
+            os.utime(p, (old, old))
+            self.assertFalse(ec._write_if_changed(p, 'a,b,c\n'))
+            self.assertAlmostEqual(p.stat().st_mtime, old, delta=1)
+
+    def test_different_bytes_are_written(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / 'partitions.csv'
+            p.write_text('a,b,c\n')
+            self.assertTrue(ec._write_if_changed(p, 'x\n'))
+            self.assertEqual(p.read_text(), 'x\n')
+
+    def test_missing_file_is_created(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / 'new.cmake'
+            self.assertTrue(ec._write_if_changed(p, 'hi\n'))
+            self.assertEqual(p.read_text(), 'hi\n')
+
+
+class VariantNamingTests(unittest.TestCase):
+    def test_dir_name_and_lock_key_round_trip(self):
+        for replica in (0, 1, 3):
+            name = ec._variant_dir_name('b6ef22a62ee4', replica)
+            self.assertEqual(
+                ec._lock_key_for_variant_dir('esp32', name),
+                ec._variant_lock_key('esp32', 'b6ef22a62ee4', replica),
+            )
+
+    def test_replica_zero_keeps_the_legacy_name_and_key(self):
+        self.assertEqual(ec._variant_dir_name('abc'), 'v_abc')
+        self.assertEqual(ec._variant_lock_key('esp32s3', 'abc'), 'esp32s3/abc')
+        self.assertEqual(ec._variant_dir_name('abc', 2), 'v_abc_r2')
+        self.assertEqual(ec._variant_lock_key('esp32s3', 'abc', 2), 'esp32s3/abc/r2')
+
+    def test_unrelated_dirs_have_no_key(self):
+        self.assertIsNone(ec._lock_key_for_variant_dir('esp32', 'project'))
+
+
+class EvictionTests(unittest.TestCase):
+    def _make(self, root: Path, names: list[str]) -> None:
+        for i, n in enumerate(names):
+            d = root / n
+            d.mkdir()
+            stamp = time.time() - 1000 + i  # later names are warmer
+            os.utime(d, (stamp, stamp))
+
+    def test_locked_variant_is_never_evicted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / 'esp32'
+            root.mkdir()
+            # v_old is the coldest by mtime AND locked: eviction must skip it
+            self._make(root, ['v_old', 'v_mid', 'v_new'])
+            lock = ec._variant_lock(ec._variant_lock_key('esp32', 'old'))
+
+            async def run() -> None:
+                async with lock:
+                    ec._evict_cold_variants(root, keep=2, idf_target='esp32')
+
+            asyncio.run(run())
+            self.assertTrue((root / 'v_old').exists(), 'evicted a variant under lock')
+            self.assertFalse((root / 'v_mid').exists(), 'the next-coldest free one goes')
+            self.assertTrue((root / 'v_new').exists())
+
+    def test_replica_dirs_are_checked_against_their_own_lock(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / 'esp32'
+            root.mkdir()
+            self._make(root, ['v_hot_r1', 'v_hot', 'v_other'])
+            lock = ec._variant_lock(ec._variant_lock_key('esp32', 'hot', 1))
+
+            async def run() -> None:
+                async with lock:
+                    ec._evict_cold_variants(root, keep=2, idf_target='esp32')
+
+            asyncio.run(run())
+            self.assertTrue((root / 'v_hot_r1').exists())
+            self.assertFalse((root / 'v_hot').exists())
+
+    def test_nothing_happens_under_the_cap(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / 'esp32'
+            root.mkdir()
+            self._make(root, ['v_a', 'v_b'])
+            ec._evict_cold_variants(root, keep=6, idf_target='esp32')
+            self.assertEqual(sorted(p.name for p in root.iterdir()), ['v_a', 'v_b'])
+
+    def test_per_target_cap_from_env(self):
+        with mock.patch.dict(os.environ, {'VELXIO_BUILD_VARIANTS_ESP32': '12'}):
+            self.assertEqual(ec._max_build_variants('esp32'), 12)
+            self.assertEqual(ec._max_build_variants('esp32s3'), ec._MAX_BUILD_VARIANTS)
+        with mock.patch.dict(os.environ, {'VELXIO_BUILD_VARIANTS': '9'}):
+            self.assertEqual(ec._max_build_variants('esp32c3'), 9)
+
+
+class ReplicaPickTests(unittest.TestCase):
+    def setUp(self) -> None:
+        ec._VARIANT_COLLISIONS.clear()
+        ec._WARMING_REPLICAS.clear()
+
+    def test_free_base_replica_wins(self):
+        with tempfile.TemporaryDirectory() as tmp, \
+                mock.patch.object(ec, '_BUILD_ROOT', Path(tmp)), \
+                mock.patch.dict(os.environ, {'VELXIO_BUILD_VARIANT_REPLICAS': '2'}):
+            self.assertEqual(ec.ESPIDFCompiler._pick_replica('esp32', 'h1'), (0, None))
+
+    def test_busy_base_goes_to_an_existing_free_replica(self):
+        with tempfile.TemporaryDirectory() as tmp, \
+                mock.patch.object(ec, '_BUILD_ROOT', Path(tmp)), \
+                mock.patch.dict(os.environ, {'VELXIO_BUILD_VARIANT_REPLICAS': '2'}):
+            (Path(tmp) / 'esp32' / 'v_h2_r1').mkdir(parents=True)
+            lock = ec._variant_lock(ec._variant_lock_key('esp32', 'h2'))
+
+            async def run() -> int:
+                async with lock:
+                    return ec.ESPIDFCompiler._pick_replica('esp32', 'h2')
+
+            self.assertEqual(asyncio.run(run()), (1, None))
+
+    def test_replica_is_warmed_only_after_a_collision_streak(self):
+        """A busy variant queues on replica 0; the streak asks for r1 to be
+        warmed in the background, and the job itself still builds in r0."""
+        with tempfile.TemporaryDirectory() as tmp, \
+                mock.patch.object(ec, '_BUILD_ROOT', Path(tmp)), \
+                mock.patch.dict(os.environ, {'VELXIO_BUILD_VARIANT_REPLICAS': '2'}):
+            lock = ec._variant_lock(ec._variant_lock_key('esp32', 'h3'))
+
+            async def run() -> list:
+                picks = []
+                async with lock:
+                    for _ in range(ec._REPLICA_COLLISION_THRESHOLD):
+                        picks.append(ec.ESPIDFCompiler._pick_replica('esp32', 'h3'))
+                return picks
+
+            picks = asyncio.run(run())
+            self.assertEqual(picks[:-1], [(0, None)] * (ec._REPLICA_COLLISION_THRESHOLD - 1))
+            self.assertEqual(picks[-1], (0, 1))
+
+    def test_a_replica_being_warmed_is_neither_picked_nor_recreated(self):
+        with tempfile.TemporaryDirectory() as tmp, \
+                mock.patch.object(ec, '_BUILD_ROOT', Path(tmp)), \
+                mock.patch.dict(os.environ, {'VELXIO_BUILD_VARIANT_REPLICAS': '2'}):
+            (Path(tmp) / 'esp32' / 'v_h5_r1').mkdir(parents=True)
+            ec._WARMING_REPLICAS.add(ec._variant_lock_key('esp32', 'h5', 1))
+            lock = ec._variant_lock(ec._variant_lock_key('esp32', 'h5'))
+
+            async def run() -> list:
+                async with lock:
+                    return [ec.ESPIDFCompiler._pick_replica('esp32', 'h5') for _ in range(5)]
+
+            self.assertEqual(asyncio.run(run()), [(0, None)] * 5)
+
+    def test_replicas_off_means_always_zero(self):
+        with tempfile.TemporaryDirectory() as tmp, \
+                mock.patch.object(ec, '_BUILD_ROOT', Path(tmp)), \
+                mock.patch.dict(os.environ, {'VELXIO_BUILD_VARIANT_REPLICAS': '1'}):
+            lock = ec._variant_lock(ec._variant_lock_key('esp32', 'h4'))
+
+            async def run() -> list[int]:
+                async with lock:
+                    return [ec.ESPIDFCompiler._pick_replica('esp32', 'h4') for _ in range(5)]
+
+            self.assertEqual(asyncio.run(run()), [(0, None)] * 5)
+
+
+class NinjaArgsAndFallbackTests(unittest.TestCase):
+    def test_no_env_means_ninjas_own_defaults(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop('VELXIO_NINJA_JOBS', None)
+            os.environ.pop('VELXIO_NINJA_LOAD_LIMIT', None)
+            self.assertEqual(ec._ninja_parallelism_args(), [])
+
+    def test_jobs_and_load_limit_from_env(self):
+        with mock.patch.dict(os.environ, {'VELXIO_NINJA_JOBS': '4', 'VELXIO_NINJA_LOAD_LIMIT': '6'}):
+            self.assertEqual(ec._ninja_parallelism_args(), ['-j', '4', '-l', '6.0'])
+
+    def test_user_code_error_does_not_trigger_a_reconfigure(self):
+        r = ec._RunResult(1, 'FAILED: esp-idf/main/sketch.ino.cpp.obj\n'
+                             'sketch.ino.cpp:5:3: error: expected ; before }\n', '')
+        self.assertFalse(ec._ninja_failure_wants_configure(r))
+
+    def test_configure_trouble_triggers_a_reconfigure(self):
+        for text in (
+            'ninja: error: loading \'build.ninja\': No such file or directory',
+            "ninja: error: 'sdkconfig', needed by 'build.ninja', missing and no known rule to make it",
+            'CMake Error at /opt/esp-idf-v5/tools/cmake/build.cmake:123 (message):',
+            'The downloaded component "espressif/mdns" is corrupted',
+        ):
+            r = ec._RunResult(1, text, '')
+            self.assertTrue(ec._ninja_failure_wants_configure(r), text)
+
+
+class NicePreexecTests(unittest.TestCase):
+    def test_none_and_zero_inherit(self):
+        self.assertIsNone(ec._nice_preexec(None))
+        self.assertIsNone(ec._nice_preexec(0))
+
+    def test_positive_nice_yields_a_callable(self):
+        fn = ec._nice_preexec(10)
+        self.assertTrue(callable(fn))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Measured on velxio.dev 2026-09-01..04: a warm esp32 build was 25 s under load, 18 s of it a cmake configure with nothing changed, and the heavy lane ran as one slot because the route took a per-target lock inside the lane slot while 78% of builds were `esp32:esp32:esp32`.

What changes:

- **Warm build dirs skip the explicit configure.** ninja re-runs cmake itself when a configure input changed (`RERUN_CMAKE`). Generated inputs are written only when their bytes change; the set of compilable sources is recorded per build and `main/CMakeLists.txt` is touched when it changes (the glob has no `CONFIGURE_DEPENDS`). Ninja failures that look like configure trouble fall back to the explicit configure once. `VELXIO_ESPIDF_ALWAYS_CONFIGURE=1` restores the old behaviour. Measured against the production toolchain: warm build 25 s -> 4.5 s; a file added or removed still re-runs cmake (22 s).
- **Replicas of hot variants** (`v_<hash>_r<N>`, `VELXIO_BUILD_VARIANT_REPLICAS`): a compile picks the first copy whose lock is free; after three collisions in ten minutes the next copy is warmed by a background build at nice 10. Two compiles of the dominant configuration then run at once (5.8 s wall for a pair).
- **Eviction is lock-aware** and per target (`VELXIO_BUILD_VARIANTS_<TARGET>`); prepare runs off the event loop.
- **The route-level per-target lock is removed**; the compiler's per-variant lock protects the shared directory. The metric carries `slot_ms` and `variant_wait_ms` separately, plus configure/ninja timing.
- **`priority_burst`** in `BuildQueue` (env `VELXIO_{HEAVY,LIGHT}_PRIORITY_BURST`, default 0): admissions above capacity that only priority jobs may use; the reserved standard slot still holds.
- `cpu_nice` from the `compile_priority` hook applied to cmake/ninja subprocesses; `ninja -j` from env.
- Artifact cache count/byte caps from env, prune off the loop, bypass header for a nightly smoke.
- arduino-cli: the never-reused per-sketch build cache dir is removed after each compile (15 GB in 15 days). Light builds are otherwise unchanged.

480 backend unit tests green (new: `test_espidf_compile_speed.py`, six burst tests, `test_compile_build_lock.py` rewritten).
