### PR TITLE
fix(spice): a dead solve says so instead of reading 0 V

### DIFF
--- a/frontend/src/__tests__/probe-no-solution.test.ts
+++ b/frontend/src/__tests__/probe-no-solution.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Regression: a probe whose nets the solver did not report must not print
+ * "0.00 µV" as if it had measured something.
+ *
+ * Reported on velxio.dev 2026-09-05: a 9 V cell wired straight to a
+ * voltmeter "read 0 V". The pair was fine; elsewhere on the canvas a 7805's
+ * VOUT was wired into the board's 5V pin, two ideal sources on one node,
+ * ngspice answered "singular matrix", the worker published an EMPTY
+ * nodeVoltages map, and `?? 0` turned that into a reading.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  readVoltmeter,
+  readAmmeter,
+  SOLVER_ERROR_DISPLAY,
+  NO_READING_DISPLAY,
+} from '../simulation/spice/probes';
+import type { ElectricalSolveResult } from '../simulation/spice/types';
+
+const vm = { id: 'vm', metadataId: 'instr-voltmeter', properties: {} };
+const am = { id: 'am', metadataId: 'instr-ammeter', properties: {} };
+const lookup = (_c: string, pin: string) => (pin === 'V+' ? 'n0' : pin === 'V-' ? 'n1' : null);
+
+function solve(partial: Partial<ElectricalSolveResult>): ElectricalSolveResult {
+  return {
+    nodeVoltages: {},
+    branchCurrents: {},
+    converged: true,
+    error: null,
+    solveMs: 0,
+    submittedNetlist: '',
+    pinNetMap: new Map(),
+    analysisMode: 'op',
+    ...partial,
+  };
+}
+
+describe('probes with no operating point', () => {
+  it('voltmeter: empty nodeVoltages after a solver error is "solver error", not 0 V', () => {
+    const r = readVoltmeter(vm, lookup, solve({
+      converged: false,
+      error: 'Warning: singular matrix:  check node v_vcc_rail#branch',
+    }));
+    expect(r.display).toBe(SOLVER_ERROR_DISPLAY);
+    expect(r.unit).toBe('—');
+    expect(r.stale).toBe(true);
+  });
+
+  it('voltmeter: a probe net missing from a clean snapshot is "no reading"', () => {
+    const r = readVoltmeter(vm, lookup, solve({ nodeVoltages: { n0: 4.5 } }));
+    expect(r.display).toBe(NO_READING_DISPLAY);
+    expect(r.stale).toBe(true);
+  });
+
+  it('voltmeter: both nets reported still reads the difference', () => {
+    const r = readVoltmeter(vm, lookup, solve({ nodeVoltages: { n0: 4.5, n1: -4.5 } }));
+    expect(r.display).toBe('9.000 V');
+    expect(r.stale).toBe(false);
+  });
+
+  it('voltmeter: ground is a reported 0 V, not a missing net', () => {
+    const gnd = (_c: string, pin: string) => (pin === 'V+' ? 'n0' : '0');
+    const r = readVoltmeter(vm, gnd, solve({ nodeVoltages: { n0: 3.3 } }));
+    expect(r.display).toBe('3.300 V');
+  });
+
+  it('ammeter: missing sense branch after a solver error is "solver error"', () => {
+    const r = readAmmeter(am, solve({ converged: false, error: 'singular matrix' }));
+    expect(r.display).toBe(SOLVER_ERROR_DISPLAY);
+    expect(r.stale).toBe(true);
+  });
+
+  it('ammeter: missing sense branch without an error keeps the wiring hint', () => {
+    const r = readAmmeter(am, solve({}));
+    expect(r.display).toBe('— no sense reading');
+  });
+});

--- a/frontend/src/__tests__/solver-fault-reporter.test.ts
+++ b/frontend/src/__tests__/solver-fault-reporter.test.ts
@@ -1,0 +1,66 @@
+/**
+ * The solver's error used to live only in useElectricalStore.error, read by
+ * the two meters and the hover overlay. A rejected deck (singular matrix)
+ * therefore looked like "everything reads 0 V". The reporter turns each new
+ * hard error into one circuit-fault event, and stays quiet on repeats and on
+ * convergence chatter that still produced voltages.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useElectricalStore } from '../store/useElectricalStore';
+import {
+  describeSolverError,
+  isDeadSolve,
+  startSolverFaultReporter,
+} from '../simulation/spice/solverFaultReporter';
+
+function publish(partial: { error: string | null; nodeVoltages?: Record<string, number>; pins?: number }) {
+  const pinNetMap = new Map<string, string>();
+  for (let i = 0; i < (partial.pins ?? 2); i++) pinNetMap.set(`c${i}:p`, `n${i}`);
+  useElectricalStore.getState().setSolveResult({
+    nodeVoltages: partial.nodeVoltages ?? {},
+    branchCurrents: {},
+    pinNetMap,
+    analysisMode: 'op',
+    timeWaveforms: undefined,
+    converged: partial.error === null,
+    error: partial.error,
+    lastSolveMs: 0,
+    submittedNetlist: '',
+    sourcedNets: new Set(),
+  });
+}
+
+describe('solverFaultReporter', () => {
+  beforeEach(() => useElectricalStore.getState().reset());
+
+  it('names the rail in the singular-matrix message', () => {
+    const msg = describeSolverError('Warning: singular matrix:  check node v_vcc_rail#branch');
+    expect(msg).toContain('two voltage sources drive the same net');
+    expect(msg).toContain('main supply rail');
+    expect(msg).toContain('regulator or battery output');
+  });
+
+  it('a rejected deck is dead; a noisy transient with voltages is not', () => {
+    expect(isDeadSolve({ error: 'singular matrix', nodeVoltages: {}, pinNetMap: new Map() })).toBe(true);
+    const pins = new Map([['a:1', 'n0']]);
+    expect(isDeadSolve({ error: 'Warning: timestep too small', nodeVoltages: { n0: 1 }, pinNetMap: pins })).toBe(false);
+    expect(isDeadSolve({ error: 'Warning: something', nodeVoltages: {}, pinNetMap: pins })).toBe(true);
+    expect(isDeadSolve({ error: null, nodeVoltages: {}, pinNetMap: pins })).toBe(false);
+  });
+
+  it('reports one event per new error, re-arms after a clean solve', () => {
+    const reported: string[] = [];
+    const stop = startSolverFaultReporter((m) => reported.push(m));
+    publish({ error: 'Warning: singular matrix:  check node v_vcc_rail#branch' });
+    publish({ error: 'Warning: singular matrix:  check node v_vcc_rail#branch' });
+    expect(reported).toHaveLength(1);
+    publish({ error: null, nodeVoltages: { n0: 5 } });
+    publish({ error: 'Warning: singular matrix:  check node v_vcc_rail#branch' });
+    expect(reported).toHaveLength(2);
+    publish({ error: 'Warning: timestep too small', nodeVoltages: { n0: 1 } });
+    expect(reported).toHaveLength(2);
+    stop();
+    publish({ error: 'Warning: singular matrix:  check node v_bat#branch' });
+    expect(reported).toHaveLength(2);
+  });
+});

--- a/frontend/src/__tests__/source-conflict.test.ts
+++ b/frontend/src/__tests__/source-conflict.test.ts
@@ -1,0 +1,84 @@
+/**
+ * The 2026-09-05 canvas: a 9 V cell into a 7805 whose VOUT is wired into the
+ * board's 5V pin. The board's 5V pin is the ideal V_VCC_RAIL source and the
+ * 7805 is an ideal B-source, two sources on one node -> ngspice "singular
+ * matrix" -> the live solver published no voltages and a voltmeter across a
+ * second, perfectly wired battery read "0 V". The pre-flight said nothing.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildNetlist } from '../simulation/spice/NetlistBuilder';
+import { findSourceConflicts, verifyCircuit } from '../simulation/verify/circuitVerifier';
+import type { BuildNetlistInput } from '../simulation/spice/types';
+
+const wire = (id: string, a: [string, string], b: [string, string]) => ({
+  id,
+  start: { componentId: a[0], pinName: a[1] },
+  end: { componentId: b[0], pinName: b[1] },
+});
+
+function incident(voutToRail: boolean): BuildNetlistInput {
+  const wires = [
+    wire('w1', ['bat', '+'], ['reg', 'VIN']),
+    wire('w2', ['bat', '−'], ['reg', 'GND']),
+    wire('w3', ['reg', 'GND'], ['uno', 'GND.1']),
+  ];
+  if (voutToRail) wires.push(wire('w4', ['reg', 'VOUT'], ['uno', '5V']));
+  return {
+    components: [
+      { id: 'bat', metadataId: 'battery-9v', properties: {} },
+      { id: 'reg', metadataId: 'reg-7805', properties: {} },
+    ],
+    wires,
+    boards: [
+      {
+        id: 'uno',
+        boardKind: 'arduino-uno',
+        vcc: 5,
+        groundPinNames: ['GND.1', 'GND.2'],
+        vccPinNames: ['5V'],
+        pins: {},
+      } as BuildNetlistInput['boards'][number],
+    ],
+    analysis: { kind: 'op' },
+  };
+}
+
+describe('source-conflict pre-flight rule', () => {
+  it('names the regulator and the rail when VOUT is wired into the 5V pin', () => {
+    const input = incident(true);
+    const { netlist } = buildNetlist(input);
+    const found = findSourceConflicts(netlist, input);
+    expect(found).toHaveLength(1);
+    expect(found[0]!.code).toBe('source-conflict');
+    expect(found[0]!.severity).toBe('error');
+    expect(found[0]!.componentId).toBe('reg');
+    expect(found[0]!.message).toContain('reg-7805 reg output (VOUT)');
+    expect(found[0]!.message).toContain('main supply rail');
+  });
+
+  it('is silent for the same circuit without that wire', () => {
+    const input = incident(false);
+    const { netlist } = buildNetlist(input);
+    expect(findSourceConflicts(netlist, input)).toEqual([]);
+  });
+
+  it('flags a source shorted onto its own reference', () => {
+    const input = incident(false);
+    const found = findSourceConflicts('B_reg 0 0 V = min(V(n0)-2, 5)\n.op\n.end', input);
+    expect(found).toHaveLength(1);
+    expect(found[0]!.message).toContain('reg-7805 reg output (VOUT)');
+  });
+
+  it('verifyCircuit blocks the incident circuit and never reports it as clean', { timeout: 30_000 }, async () => {
+    const result = await verifyCircuit(incident(true));
+    const codes = result.errors.map((e) => e.code);
+    expect(codes).toContain('source-conflict');
+    expect(result.warnings.map((w) => w.code)).not.toContain('solver-failed');
+  });
+
+  it('verifyCircuit passes the corrected circuit', { timeout: 30_000 }, async () => {
+    const result = await verifyCircuit(incident(false));
+    expect(result.errors.map((e) => e.code)).not.toContain('source-conflict');
+    expect(result.errors.map((e) => e.code)).not.toContain('solver-failed');
+  });
+});

--- a/frontend/src/components/simulator/PinOverlay.tsx
+++ b/frontend/src/components/simulator/PinOverlay.tsx
@@ -126,6 +126,23 @@ export const PinOverlay: React.FC<PinOverlayProps> = ({
   const subtle = !wiring;
   const baseBackground = subtle ? 'transparent' : 'rgba(0, 200, 255, 0.8)';
   const baseBorder = subtle ? '1.5px solid transparent' : '1.5px solid white';
+  // Some elements expose one pad under two names at the same coordinates
+  // (a XIAO's "D8" and its GPIO "7", a DevKit's "TX" and "16"). Only the
+  // top-most square is hoverable, so its tooltip carries every name of that
+  // pad — a user reading "7" on a pad silk-screened D8 wired an RGB LED one
+  // pin off (2026-09-05) because the alias was the only name they could see.
+  const namesAtPad = new Map<string, string[]>();
+  for (const p of pins) {
+    const key = `${p.x},${p.y}`;
+    const names = namesAtPad.get(key) ?? [];
+    names.push(p.name);
+    namesAtPad.set(key, names);
+  }
+  const titleFor = (pin: PinInfo): string => {
+    const names = namesAtPad.get(`${pin.x},${pin.y}`) ?? [pin.name];
+    const others = names.filter((n) => n !== pin.name);
+    return others.length ? `${pin.name} (${others.join(', ')})` : pin.name;
+  };
 
   return (
     <div
@@ -209,7 +226,7 @@ export const PinOverlay: React.FC<PinOverlayProps> = ({
               e.currentTarget.style.border = baseBorder;
               e.currentTarget.style.transform = 'scale(1)';
             }}
-            title={pin.name}
+            title={titleFor(pin)}
           />
         );
       })}

--- a/frontend/src/simulation/spice/boardPinGroups.ts
+++ b/frontend/src/simulation/spice/boardPinGroups.ts
@@ -177,3 +177,13 @@ export function boardPinGroupFor(kind: string): BoardPinGroup {
   if (pro) return pro;
   return BOARD_PIN_GROUPS.default;
 }
+
+/**
+ * Human form of an aux-rail tag: "5" -> "5 V", "3v3" -> "3.3 V" (the net name
+ * spells the dot as "v"). Used by the messages that name a rail to the user.
+ */
+export function railVolts(tag: string): string {
+  const m = /^(\d+)(?:v(\d+))?$/.exec(tag);
+  if (!m) return `${tag} V`;
+  return m[2] ? `${m[1]}.${m[2]} V` : `${m[1]} V`;
+}

--- a/frontend/src/simulation/spice/probes.ts
+++ b/frontend/src/simulation/spice/probes.ts
@@ -160,6 +160,28 @@ function buildAcStatsI(samples: readonly number[]): ProbeAcStats {
   };
 }
 
+/** Shown when the solver rejected the circuit (ngspice error in the store). */
+export const SOLVER_ERROR_DISPLAY = '— solver error';
+/** Shown when the probe's nets exist but no solve has reported them yet. */
+export const NO_READING_DISPLAY = '— no reading';
+
+/** Node "0" is ground by definition and never appears in nodeVoltages. */
+function nodeVoltageOf(solve: ElectricalSolveResult, net: string): number | undefined {
+  if (net === '0') return 0;
+  const v = solve.nodeVoltages[net];
+  return typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+}
+
+function noReading(kind: ProbeKind, solve: ElectricalSolveResult): ProbeReading {
+  return {
+    kind,
+    value: 0,
+    unit: '—',
+    display: solve.error ? SOLVER_ERROR_DISPLAY : NO_READING_DISPLAY,
+    stale: true,
+  };
+}
+
 export function readVoltmeter(
   comp: ComponentForSpice,
   netLookup: (componentId: string, pinName: string) => string | null,
@@ -177,8 +199,15 @@ export function readVoltmeter(
       stale: true,
     };
   }
-  const vp = solve.nodeVoltages[plusNet] ?? 0;
-  const vm = solve.nodeVoltages[minusNet] ?? 0;
+  // A net the solver did not report is NOT 0 V. It means there is no
+  // operating point to read: ngspice rejected the deck (two ideal sources
+  // fighting over one node -> "singular matrix"), or no solve has landed
+  // yet. Printing "0.00 µV" there looks like a measurement — the 2026-09-05
+  // report was a 9 V cell "reading 0 V" while the whole canvas was unsolved
+  // because a regulator output was wired into the board's 5V pin.
+  const vp = nodeVoltageOf(solve, plusNet);
+  const vm = nodeVoltageOf(solve, minusNet);
+  if (vp === undefined || vm === undefined) return noReading('voltmeter', solve);
   const diff = vp - vm;
   const fmt = formatV(diff);
 
@@ -219,7 +248,11 @@ export function readAmmeter(
 ): ProbeReading {
   const key = `v_${comp.id}_sense`;
   const i = solve.branchCurrents[key];
-  if (i == null) {
+  if (i == null || !Number.isFinite(i)) {
+    // Same rule as the voltmeter: a missing branch after a solver error is
+    // "no solution", not 0 A. Without an error it is the sense source that
+    // never made it into the netlist (probe not wired into a loop).
+    if (solve.error) return noReading('ammeter', solve);
     return { kind: 'ammeter', value: 0, unit: '—', display: '— no sense reading', stale: true };
   }
   // Sign convention: like a bench DMM with the red lead on A+, a positive

--- a/frontend/src/simulation/spice/runNetlist.ts
+++ b/frontend/src/simulation/spice/runNetlist.ts
@@ -21,6 +21,8 @@ export interface SpiceResult {
   dcValue(name: string): number;
   vAtLast(name: string): VectorValue;
   findVar(name: string): number;
+  /** ngspice stderr from the analysis (convergence warnings, rejected deck). */
+  warnings: string[];
 }
 
 let singleton: SolverPort | null = null;
@@ -160,7 +162,7 @@ export async function runNetlist(netlist: string): Promise<SpiceResult> {
         ? mergedVectors.get('time')?.real ?? new Float64Array(0)
         : new Float64Array(0),
     solveMs: 0,
-    warnings: [] as string[],
+    warnings: (solved.warnings ?? []) as string[],
   };
   const rawVecs = all.rawNames;
 
@@ -184,6 +186,7 @@ export async function runNetlist(netlist: string): Promise<SpiceResult> {
   };
   return {
     variableNames,
+    warnings: result.warnings,
     findVar(name) {
       const l = name.toLowerCase();
       let idx = variableNames.indexOf(l);

--- a/frontend/src/simulation/spice/solverFaultReporter.ts
+++ b/frontend/src/simulation/spice/solverFaultReporter.ts
@@ -1,0 +1,100 @@
+/**
+ * solverFaultReporter — a dead SPICE solve becomes something the user can read.
+ *
+ * When ngspice rejects the deck (the classic case: two ideal voltage sources on
+ * one node -> "singular matrix"), the worker publishes an EMPTY nodeVoltages
+ * map. Every meter then read 0 V, every LED went dark, and nothing said why:
+ * `useElectricalStore.error` was only ever read by the two meters and the
+ * hover overlay. Reported on velxio.dev 2026-09-05 as "my 9 V battery reads
+ * 0 V" — the battery was fine, a 7805 output wired into the board's 5V pin
+ * had killed the whole solve.
+ *
+ * This subscriber watches the store's `error` and, for each NEW hard error,
+ * dispatches the same `velxio-circuit-fault` event the burnout monitor uses,
+ * so the message lands in the output console under "Circuit check". One event
+ * per distinct message: the continuous solver re-runs on every canvas change
+ * and a still-broken circuit must not spam the log. Convergence chatter on a
+ * transient analysis is not reported here — only a solve that produced no
+ * voltages at all, or a message ngspice only prints for a rejected deck.
+ */
+import { useElectricalStore } from '../../store/useElectricalStore';
+import { railVolts } from './boardPinGroups';
+
+/** ngspice messages that mean "no operating point at all", not a warning. */
+const HARD_ERROR_RE = /singular matrix|no such vector|circuit not parsed|error on line|fatal/i;
+
+/** Name a V-source the way the user sees it on the canvas. */
+export function describeSourceName(src: string): string {
+  const s = src.toLowerCase();
+  if (s === 'v_vcc_rail') return "the board's main supply rail (5V / VCC / 3V3 pins)";
+  const aux = /^v_aux_rail_(.+)$/.exec(s);
+  if (aux) return `the board's ${railVolts(aux[1]!)} supply pin`;
+  return `source ${s}`;
+}
+
+/** Turn a raw ngspice line into a sentence with a likely fix. */
+export function describeSolverError(raw: string): string {
+  const text = raw.trim();
+  const singular = /singular matrix:?\s*check node\s+(\S+?)#branch/i.exec(text);
+  if (singular) {
+    return (
+      `The circuit has no solution: two voltage sources drive the same net ` +
+      `(${describeSourceName(singular[1]!)}). Typical cause: a regulator or battery ` +
+      `output wired straight into a board supply pin (5V / 3V3), or two supplies tied ` +
+      `together. Remove one of them. Every meter and LED stays dead until then. (ngspice: ${text})`
+    );
+  }
+  if (/singular matrix/i.test(text)) {
+    return (
+      `The circuit has no solution (ngspice: ${text}). Check for voltage sources wired ` +
+      `against each other, or a source shorted by a wire.`
+    );
+  }
+  return `Circuit solver problem: ${text}`;
+}
+
+function emitFault(message: string): void {
+  // eslint-disable-next-line no-console
+  console.warn(`[circuit-sim] ${message}`);
+  if (typeof window === 'undefined' || typeof window.dispatchEvent !== 'function') return;
+  try {
+    window.dispatchEvent(
+      new CustomEvent('velxio-circuit-fault', { detail: { kind: 'solver', message } }),
+    );
+  } catch {
+    /* CustomEvent unavailable — the console.warn is enough */
+  }
+}
+
+/** True when this snapshot is a rejected deck rather than a noisy success. */
+export function isDeadSolve(state: {
+  error: string | null;
+  nodeVoltages: Record<string, number>;
+  pinNetMap: Map<string, string>;
+}): boolean {
+  if (!state.error) return false;
+  if (HARD_ERROR_RE.test(state.error)) return true;
+  // A circuit with wired pins but not one solved voltage: nothing to read.
+  return state.pinNetMap.size > 0 && Object.keys(state.nodeVoltages).length === 0;
+}
+
+/**
+ * Subscribe to the electrical store; returns the unsubscribe handle.
+ * Exported separately from the mount so tests can drive it without a DOM.
+ */
+export function startSolverFaultReporter(
+  report: (message: string) => void = emitFault,
+): () => void {
+  let lastReported: string | null = null;
+  return useElectricalStore.subscribe((state, prev) => {
+    if (state.error === prev.error) return;
+    if (!isDeadSolve(state)) {
+      // A clean solve re-arms the reporter: the next failure is news again.
+      if (!state.error) lastReported = null;
+      return;
+    }
+    if (state.error === lastReported) return;
+    lastReported = state.error;
+    report(describeSolverError(state.error!));
+  });
+}

--- a/frontend/src/simulation/spice/start.ts
+++ b/frontend/src/simulation/spice/start.ts
@@ -35,6 +35,7 @@ import { connectChipInputsToSolve } from './connectChipInputsToSolve';
 import { connectMcuEdgesToService } from './connectMcuEdgesToService';
 import { setElectricalResolveHook } from './electricalResolveHook';
 import { startAnalogScopeFeed } from './analogScopeFeed';
+import { startSolverFaultReporter } from './solverFaultReporter';
 import { collectPinStates } from './collectPinStates';
 
 /** Adapt useElectricalStore to the ElectricalStorePort. */
@@ -92,6 +93,9 @@ export function startSimulation(): () => void {
   // nothing until the user actually probes a wire: with no analog channel it
   // forces no transient and runs no timer.
   const unsubAnalogScope = startAnalogScopeFeed();
+  // A rejected deck (singular matrix) used to leave every meter at 0 V with
+  // no message anywhere; this puts the ngspice error in the output console.
+  const unsubFault = startSolverFaultReporter();
 
   // Let custom chips / WS boards request a re-solve when they toggle an
   // output pin. Trailing-throttled: callers of this hook are PER-EDGE sites
@@ -163,6 +167,7 @@ export function startSimulation(): () => void {
   return () => {
     setElectricalResolveHook(null);
     unsubAnalogScope();
+    unsubFault();
     if (trailingResolve !== null) {
       clearTimeout(trailingResolve);
       trailingResolve = null;

--- a/frontend/src/simulation/verify/circuitVerifier.ts
+++ b/frontend/src/simulation/verify/circuitVerifier.ts
@@ -22,10 +22,10 @@
  * single solver-error warning and the rest of the rules are skipped.
  */
 import { lineGaps } from '../line/requestLine';
-import { buildNetlist } from '../spice/NetlistBuilder';
+import { buildNetlist, sanitizeSpiceId } from '../spice/NetlistBuilder';
 import { runNetlist as runSpice } from '../spice/runNetlist';
 import { UnionFind } from '../spice/unionFind';
-import { BOARD_PIN_GROUPS, auxRailNetName } from '../spice/boardPinGroups';
+import { BOARD_PIN_GROUPS, auxRailNetName, railVolts } from '../spice/boardPinGroups';
 import { isBreadboard } from '../../utils/breadboardNets';
 import type { BuildNetlistInput, ElectricalSolveResult } from '../spice/types';
 import { COMPONENT_RATINGS } from './componentRatings';
@@ -33,6 +33,7 @@ import { COMPONENT_RATINGS } from './componentRatings';
 export type WarningSeverity = 'error' | 'warning';
 export type WarningCode =
   | 'solver-failed'
+  | 'source-conflict'
   | 'unstable-solve'
   | 'short-circuit'
   | 'source-overload'
@@ -110,7 +111,16 @@ export async function verifyCircuit(
 
   // Run a forced .op solve so currents are scalar and deterministic.
   const opInput: BuildNetlistInput = { ...input, analysis: { kind: 'op' } };
-  const { netlist, pinNetMap } = buildNetlist(opInput);
+  const { netlist, pinNetMap, nets } = buildNetlist(opInput);
+
+  // ── Ideal sources fighting over one net (graph-based, no solve) ────────
+  // Two ideal voltage sources on the same pair of nodes make the .op matrix
+  // singular. ngspice then rejects the whole deck and the live solver publishes
+  // no voltages at all: every meter reads 0 V, every LED goes dark, and until
+  // 2026-09-05 nothing said why (a 7805's VOUT wired into a XIAO's 5V pin was
+  // reported as "my 9 V battery reads 0 V"). Detected from the netlist itself
+  // so both sides get named; blocking, because nothing on the canvas solves.
+  errors.push(...findSourceConflicts(netlist, input));
 
   // ── Line-owning sensors the wired board cannot host (no solve) ────────
   // A DHT22 or an HC-SR04 asks the board it is wired to for the line
@@ -646,6 +656,19 @@ export async function verifyCircuit(
   let solve: ElectricalSolveResult | undefined;
   try {
     const cooked = await runSpice(netlist);
+    // ngspice does not throw on a rejected deck: `source` returns 0, the
+    // analysis runs on nothing and the plot is empty. A circuit with nets but
+    // not one v(...) vector is that case — say so instead of waving it through
+    // with zero warnings (which is what the 2026-09-05 report saw in `[verify]`).
+    if (nets.length > 0 && !cooked.variableNames.some((n) => n.startsWith('v('))) {
+      const reason = cooked.warnings[0] ?? 'ngspice returned no node voltages';
+      errors.push({
+        severity: 'error',
+        code: 'solver-failed',
+        message: `The circuit solver rejected this circuit (${reason.trim()}). Nothing on the canvas will solve until it is fixed. Check for voltage sources wired against each other.`,
+      });
+      return { errors, warnings, componentsChecked: 0, solve };
+    }
     // Re-shape into the same flat dictionaries that the live store uses.
     const nodeVoltages: Record<string, number> = { '0': 0 };
     const branchCurrents: Record<string, number> = {};
@@ -984,4 +1007,95 @@ function parseResistance(raw: string): number {
   const mult =
     suffix === 'k' || suffix === 'K' ? 1e3 : suffix === 'M' ? 1e6 : suffix === 'g' || suffix === 'G' ? 1e9 : suffix === 'm' ? 1e-3 : 1;
   return base * mult;
+}
+
+/** Netlist source card: name plus its two nodes (V-sources and B-sources). */
+interface SourceCard {
+  name: string;
+  a: string;
+  b: string;
+}
+
+function parseSourceCards(netlist: string): SourceCard[] {
+  const out: SourceCard[] = [];
+  for (const raw of netlist.split('\n')) {
+    const line = raw.trim();
+    if (!line || line.startsWith('*') || line.startsWith('.')) continue;
+    const m = /^([VB]\S*)\s+(\S+)\s+(\S+)/.exec(line);
+    if (!m) continue;
+    out.push({ name: m[1]!, a: m[2]!, b: m[3]! });
+  }
+  return out;
+}
+
+/** Say which canvas item a netlist source card belongs to. */
+function describeSourceCard(card: SourceCard, input: BuildNetlistInput): { text: string; componentId?: string } {
+  const lower = card.name.toLowerCase();
+  if (lower === 'v_vcc_rail') return { text: "the board's main supply rail (5V / VCC / 3V3 pins)" };
+  const aux = /^v_aux_rail_(.+)$/.exec(lower);
+  if (aux) return { text: `the board's ${railVolts(aux[1]!)} supply pin` };
+  for (const board of input.boards) {
+    const prefix = `v_${sanitizeSpiceId(board.id)}_`.toLowerCase();
+    if (lower.startsWith(prefix)) {
+      const pin = Object.keys(board.pins ?? {}).find(
+        (p) => `${prefix}${sanitizeSpiceId(p)}`.toLowerCase() === lower,
+      );
+      return { text: `board ${board.id} pin ${pin ?? lower.slice(prefix.length)} (driven by the MCU)`, componentId: board.id };
+    }
+  }
+  const body = lower.slice(2); // drop "v_" / "b_"
+  for (const comp of input.components) {
+    const id = sanitizeSpiceId(comp.id).toLowerCase();
+    if (body === id || body.startsWith(`${id}_`)) {
+      const role = comp.metadataId.startsWith('reg-')
+        ? 'output (VOUT)'
+        : comp.metadataId.startsWith('battery') || comp.metadataId === 'power-supply' || comp.metadataId === 'signal-generator'
+          ? 'output'
+          : comp.metadataId.startsWith('instr-')
+            ? 'sense terminal'
+            : 'output';
+      return { text: `${comp.metadataId} ${comp.id} ${role}`, componentId: comp.id };
+    }
+  }
+  return { text: `source ${card.name}` };
+}
+
+/**
+ * Two ideal voltage sources across the same pair of nodes, or one source
+ * between a node and itself: the .op matrix is singular and ngspice rejects
+ * the deck. Exported for tests; `verifyCircuit` runs it before the solve.
+ */
+export function findSourceConflicts(netlist: string, input: BuildNetlistInput): CircuitWarning[] {
+  const cards = parseSourceCards(netlist);
+  const byPair = new Map<string, SourceCard[]>();
+  const out: CircuitWarning[] = [];
+  for (const card of cards) {
+    if (card.a === card.b) {
+      const who = describeSourceCard(card, input);
+      out.push({
+        severity: 'error',
+        code: 'source-conflict',
+        componentId: who.componentId,
+        message: `${who.text} is wired back onto its own reference (both terminals on net ${card.a}), so the circuit has no solution. Remove the wire that shorts it.`,
+      });
+      continue;
+    }
+    const key = [card.a, card.b].sort().join('|');
+    const list = byPair.get(key) ?? [];
+    list.push(card);
+    byPair.set(key, list);
+  }
+  for (const [, list] of byPair) {
+    if (list.length < 2) continue;
+    const parts = list.map((c) => describeSourceCard(c, input));
+    const names = parts.map((p) => p.text);
+    const last = names.pop()!;
+    out.push({
+      severity: 'error',
+      code: 'source-conflict',
+      componentId: parts.find((p) => p.componentId)?.componentId,
+      message: `${names.join(', ')} and ${last} are both driving the same net, so the circuit has no solution: the simulator cannot solve any voltage on the canvas until one of them is removed. Typical cause: a regulator or battery output wired straight into a board supply pin.`,
+    });
+  }
+  return out;
 }


### PR DESCRIPTION
A voltmeter across a healthy 9 V cell read "0 V" on velxio.dev (2026-09-05). The battery was fine: elsewhere on the canvas a 7805's VOUT was wired into the board's 5V pin, two ideal sources on one node, ngspice said "singular matrix", the worker published no voltages and every meter printed `0.00 uV` as if it had measured something. Nothing showed the error and the pre-flight passed the circuit.

What changes:

- `probes.ts`: a net the solver did not report is `— no reading`, or `— solver error` when the store carries an ngspice error. Ground stays a reported 0 V. Same rule for the ammeter's sense branch.
- `solverFaultReporter.ts` (mounted in `start.ts`): one `velxio-circuit-fault` per new hard error, so the ngspice message lands in the output console under "Circuit check". Quiet on repeats and on convergence chatter.
- `circuitVerifier.ts`: blocking `source-conflict` rule found from the netlist (two V/B sources on one node pair, or a source shorted onto itself) naming both sides; `solver-failed` when the .op returns no node voltages (ngspice never throws on a rejected deck). `runNetlist` surfaces the analysis stderr.
- `PinOverlay.tsx`: a pad with two names (XIAO `D8` / GPIO `7`) shows both in its tooltip.

Verified on a local build served against the production backend with the reporter's exact canvas: the meter shows `— solver error`, the console gets the message, and Run is blocked with the two named sides. Tests: `probe-no-solution`, `solver-fault-reporter`, `source-conflict`; full suite green (2844 passed, one Galaksija Z80 timing test flaked under load and passes alone).

The pro side (XIAO 3V3 rails, silk name on top of the GPIO alias, `solve_failed` telemetry) ships in velxio-prod.