### PR TITLE
fix(esp32-qemu): DHT22 answers the open-drain release, and MicroPython can time it

### DIFF
--- a/backend/app/services/esp32_dht22.py
+++ b/backend/app/services/esp32_dht22.py
@@ -1,0 +1,242 @@
+"""DHT22 reply for the QEMU ESP32 worker: the sensor's waveform, paced in guest
+time, armed by either way a driver releases the line.
+
+Why this module exists. `esp32_worker.py` used to answer a DHT22 only when the
+firmware switched the pin to INPUT after holding it LOW: the push-pull idiom of
+Adafruit's DHT.h (`pinMode(INPUT_PULLUP)`). It paced the reply by counting the
+guest's GPIO_IN reads, because that library measures a pulse by counting
+`digitalRead()` iterations. MicroPython's `dht` driver does neither. Its pin is
+open-drain for the whole transaction and the release is `gpio_set_level(pin, 1)`,
+so the worker saw the start LOW and then nothing, and `measure()` raised
+ETIMEDOUT forever (issue #291). That driver also measures pulses in
+microseconds (`machine_time_pulse_us`, 100 us timeout per phase, a bit is a HIGH
+longer than 48 us), which read counting cannot satisfy: 70 counted reads are
+20 us on a fast host and 200 us on a slow one.
+
+So the model here follows the browser one (`simulation/line/models/dht22.ts`):
+
+- The reply is armed by the RELEASE of a line the guest held LOW, in both
+  idioms: direction OUTPUT -> INPUT, or a write of 1 while the pad is still an
+  output (QEMU only reports level writes on output-enabled pads, so a reported
+  write of 1 IS the open-drain release).
+- Phases are guest microseconds read off QEMU's virtual clock at every GPIO_IN
+  read, the only instant the guest can observe the pad.
+- Between two reads the phase clock is credited at most `stall_cap_us` (2 us).
+  That one rule serves the two regimes this worker runs in:
+
+    * Under `-icount` (the worker turns it on for a MicroPython run with a
+      line sensor) a guest read costs ~0.5-0.9 us of guest time, under the
+      cap, so the phase clock IS guest time and a driver that times pulses
+      measures 80/26/70 us exactly (checked with `machine.time_pulse_us`).
+      A hiccup between two reads (one ~20 us event per frame was measured at
+      shift 4) is credited as 2 us, so it moves a phase boundary by nothing
+      the guest can notice beyond the hiccup itself.
+    * Without `-icount` the guest's clock is host time and a read costs
+      40-90 us of it (the read exits into a Python callback), so a phase
+      can only be a number of READS. Every gap hits the cap and each read
+      credits 2 us: the frame becomes 40/40/25/11/35 reads, which is what a
+      read-counting driver (Adafruit's DHT.h compares the reads it made in
+      the 50 us LOW against the reads in the HIGH) decodes correctly, and
+      which no host stall can disturb. A pulse-timing driver cannot work in
+      this regime whatever we do: it would see one read per 40-90 us.
+
+The first edge is placed at the first read after the release rather than inside
+the release callback: QEMU copies GPIO_OUT into GPIO_IN after it has run the
+write callback, so a level driven from inside that callback is overwritten
+before the guest can see it.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+# AM2302 datasheet figures. The '0' HIGH sits at the short end of its 22-30 us
+# range on purpose: MicroPython calls a HIGH longer than 48 us a '1', and the
+# ~20 us hiccup measured once per frame under -icount shift 4 would push a
+# 26 us pulse to 46. Every DHT library thresholds the '0' between 30 and 50.
+RESPONSE_LOW_US = 80
+RESPONSE_HIGH_US = 80
+BIT_LOW_US = 50
+BIT0_HIGH_US = 22
+BIT1_HIGH_US = 70
+TAIL_LOW_US = 50
+
+# Longest gap between two guest reads that is credited to the phase clock; see
+# the module docstring for the two regimes it serves. Above the ~0.9 us a read
+# costs under -icount shift 4, below anything a host stall produces.
+STALL_CAP_US = 2.0
+
+Level = int
+Phase = tuple[Level, int]  # (level, duration_us)
+
+
+def coerce_number(value: object, default: float) -> float:
+    """A finite number off a sensor property, else the default. The canvas
+    serialises property values as strings ("28"), the frontend usually converts
+    them, and a payload built from a str would raise inside a QEMU callback."""
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except ValueError:
+            return default
+    return default
+
+
+def dht22_payload(temperature_c: float, humidity_pct: float) -> list[int]:
+    """The 5 bytes an AM2302 sends: [hum_H, hum_L, temp_H, temp_L, checksum].
+    Humidity in 0.1 %RH, temperature in 0.1 C with the sign in bit 15."""
+    hum = round(humidity_pct * 10)
+    tmp = round(temperature_c * 10)
+    h_H = (hum >> 8) & 0xFF
+    h_L = hum & 0xFF
+    raw_t = ((-tmp) & 0x7FFF) | 0x8000 if tmp < 0 else tmp & 0x7FFF
+    t_H = (raw_t >> 8) & 0xFF
+    t_L = raw_t & 0xFF
+    chk = (h_H + h_L + t_H + t_L) & 0xFF
+    return [h_H, h_L, t_H, t_L, chk]
+
+
+def dht22_phases(payload: list[int]) -> list[Phase]:
+    """The frame as (level, duration_us) phases, first phase first. After the
+    last one the sensor lets go and the pull-up idles the line HIGH."""
+    phases: list[Phase] = [(0, RESPONSE_LOW_US), (1, RESPONSE_HIGH_US)]
+    for byte in payload:
+        for b in range(7, -1, -1):
+            bit = (byte >> b) & 1
+            phases.append((0, BIT_LOW_US))
+            phases.append((1, BIT1_HIGH_US if bit else BIT0_HIGH_US))
+    phases.append((0, TAIL_LOW_US))
+    return phases
+
+
+class Dht22Trigger:
+    """When to answer: the release of a line the guest held LOW, either idiom.
+
+    Fed with what QEMU reports about the pad. `on_write(level)` is a level the
+    guest wrote while the pad is an output; `on_direction(is_output)` is the pad
+    changing direction. Both return True exactly when a reply should start.
+    """
+
+    def __init__(self) -> None:
+        self.saw_low = False
+
+    def on_write(self, level: int) -> bool:
+        if level == 0:
+            self.saw_low = True
+            return False
+        if self.saw_low:            # open-drain release: a 1 after the LOW
+            self.saw_low = False
+            return True
+        return False
+
+    def on_direction(self, is_output: bool) -> bool:
+        if is_output:
+            return False
+        if self.saw_low:            # push-pull release: INPUT after the LOW
+            self.saw_low = False
+            return True
+        return False
+
+
+class Dht22Reply:
+    """One frame on one pad, advanced by the guest's GPIO_IN reads.
+
+    `set_level(level)` drives the pad (QEMU's GPIO_IN bit); `now_us()` is the
+    guest clock in microseconds. `step()` is called once per read and returns
+    True once the frame is out and the line is idle again.
+    """
+
+    def __init__(
+        self,
+        phases: list[Phase],
+        set_level: Callable[[int], None],
+        now_us: Callable[[], float],
+        stall_cap_us: float = STALL_CAP_US,
+    ) -> None:
+        if not phases:
+            raise ValueError('a DHT22 frame has at least one phase')
+        self._phases = phases
+        self._set = set_level
+        self._now = now_us
+        self._cap = float(stall_cap_us)
+        self._idx = -1              # -1: nothing driven yet
+        self._elapsed = 0.0         # guest us credited to the current phase
+        self._last: float | None = None
+        self.done = False
+        # Diagnostics.
+        self.reads = 0
+        self.stalls = 0
+        self.gaps_us: list[float] = []
+        self.started_at_us: float | None = None
+        self.finished_at_us: float | None = None
+
+    @property
+    def phase(self) -> int:
+        """Index of the phase on the wire, -1 before the first read."""
+        return self._idx
+
+    def step(self) -> bool:
+        if self.done:
+            return True
+        t = self._now()
+        self.reads += 1
+        if self._idx < 0:
+            self._idx = 0
+            self._last = t
+            self.started_at_us = t
+            self._set(self._phases[0][0])
+            return False
+        assert self._last is not None
+        gap = t - self._last
+        self._last = t
+        if gap < 0:                 # the guest clock went backwards: a reboot
+            gap = 0.0
+        self.gaps_us.append(gap)
+        if gap > self._cap:
+            self.stalls += 1
+            gap = self._cap
+        self._elapsed += gap
+        # The cap keeps one step under the shortest phase, so this crosses at
+        # most one boundary per read in practice; the loop is for correctness.
+        while self._elapsed >= self._phases[self._idx][1]:
+            self._elapsed -= self._phases[self._idx][1]
+            self._idx += 1
+            if self._idx >= len(self._phases):
+                self._settle(t)
+                return True
+            self._set(self._phases[self._idx][0])
+        return False
+
+    def settle(self) -> bool:
+        """Release the line if the frame is over but the guest stopped reading
+        before the tail ran out (a read-counting driver returns on the last
+        falling edge and never looks again). Returns True when it acted."""
+        if self.done or self._idx < 0:
+            return False
+        self._settle(self._now())
+        return True
+
+    def _settle(self, t: float) -> None:
+        self._set(1)                # released: the pull-up idles it HIGH
+        self.done = True
+        self.finished_at_us = t
+
+    def diag(self) -> dict:
+        gaps = sorted(self.gaps_us)
+        n = len(gaps)
+        return {
+            'reads': self.reads,
+            'stalls': self.stalls,
+            'gap_p50_us': round(gaps[n // 2], 2) if n else None,
+            'gap_p95_us': round(gaps[min(n - 1, (n * 95) // 100)], 2) if n else None,
+            'gap_max_us': round(gaps[-1], 2) if n else None,
+            'frame_us': (
+                round(self.finished_at_us - self.started_at_us, 1)
+                if self.started_at_us is not None and self.finished_at_us is not None
+                else None
+            ),
+        }

--- a/backend/app/services/esp32_flash_image.py
+++ b/backend/app/services/esp32_flash_image.py
@@ -17,6 +17,8 @@ image byte-for-byte.
 
 from __future__ import annotations
 
+import re
+
 # Sizes QEMU's esp32-picsimlab MTD layer accepts. ESP32 / S3 / C3 builds
 # all default to 4 MB (CONFIG_ESPTOOLPY_FLASHSIZE_4MB). We only ever
 # round UP — never down.
@@ -42,3 +44,19 @@ def pad_to_flash_size(fw_bytes: bytes) -> bytes:
     if len(fw_bytes) >= target:
         return fw_bytes
     return fw_bytes + b'\xff' * (target - len(fw_bytes))
+
+
+_MICROPYTHON_BANNER = re.compile(rb'MicroPython v\d+\.\d+')
+
+
+def firmware_is_micropython(image: bytes) -> bool:
+    """True when a flash image carries a MicroPython app.
+
+    The REPL banner ("MicroPython v1.28.0 on 2026-04-06; ...") is a string
+    literal in every build's .rodata, so its prefix is the signature. The
+    `esp_app_desc_t` every ESP-IDF app carries would be the principled place
+    to look, but MicroPython builds leave its `version` and `project_name`
+    fields all zeros (checked against ESP32_GENERIC v1.28.0: only `time`,
+    `date` and `idf_ver` are filled in), so it says nothing there.
+    """
+    return _MICROPYTHON_BANNER.search(image) is not None

--- a/backend/app/services/esp32_worker.py
+++ b/backend/app/services/esp32_worker.py
@@ -46,6 +46,29 @@ import tempfile
 import threading
 import time
 
+# DHT22 reply model: what arms it and how the frame is paced on the guest's
+# clock (issue #291). Same fallback dance as the slave modules below.
+try:
+    from app.services.esp32_dht22 import (
+        Dht22Reply as _Dht22Reply,
+        Dht22Trigger as _Dht22Trigger,
+        coerce_number as _dht22_num,
+        dht22_payload as _dht22_payload_bytes,
+        dht22_phases as _dht22_phases,
+    )
+except ImportError:
+    import importlib.util as _ilu_dht, pathlib as _pl_dht, sys as _sys_dht
+    _spec_dht = _ilu_dht.spec_from_file_location(
+        'esp32_dht22', _pl_dht.Path(__file__).parent / 'esp32_dht22.py')
+    _mod_dht = _ilu_dht.module_from_spec(_spec_dht)  # type: ignore[arg-type]
+    _sys_dht.modules['esp32_dht22'] = _mod_dht
+    _spec_dht.loader.exec_module(_mod_dht)  # type: ignore[union-attr]
+    _Dht22Reply = _mod_dht.Dht22Reply            # type: ignore[assignment]
+    _Dht22Trigger = _mod_dht.Dht22Trigger        # type: ignore[assignment]
+    _dht22_num = _mod_dht.coerce_number          # type: ignore[assignment]
+    _dht22_payload_bytes = _mod_dht.dht22_payload  # type: ignore[assignment]
+    _dht22_phases = _mod_dht.dht22_phases        # type: ignore[assignment]
+
 # I2C slave state machines — extracted to a standalone module for testability
 try:
     from app.services.esp32_i2c_slaves import (
@@ -353,6 +376,37 @@ class _RmtDecoder:
 
 # ─── Main ─────────────────────────────────────────────────────────────────────
 
+# ── -icount policy ────────────────────────────────────────────────────────────
+# Instruction-driven guest time on the Xtensa machines is opt-in per run,
+# because it makes the boot ~3x slower (MicroPython banner at 20 s with
+# shift 4, 35 s with shift 3, 7 s without). What needs it: a MicroPython
+# single-wire sensor driver times its pulses in microseconds with 100 us
+# timeouts, and without -icount this guest reads a GPIO only every 40-90 us of
+# host time (each read exits into a Python callback), so a 26 us pulse cannot
+# be observed at all. Under -icount shift 4 a read costs ~0.9 us of guest time
+# and the DHT22 decoded 21/21 frames over 75 s (issue #291). Shift 5 halves the
+# boot again but its ~40 us per-frame hiccup flipped a '0' bit (checksum error).
+#
+# Arduino runs keep the fast boot: Adafruit's DHT.h counts reads and the
+# HC-SR04 echo is timed on the guest clock, both fine at host time. WiFi keeps
+# -icount off: the AP beacon timer runs on QEMU_CLOCK_REALTIME (issue #260).
+ICOUNT_SHIFT_C3 = 3
+ICOUNT_SHIFT_LINE_SENSORS = 4
+LINE_SENSOR_TYPES = ('dht22', 'hc-sr04')
+
+
+def icount_shift_for_run(machine: str, wifi_enabled: bool, sensors: list,
+                         firmware_is_upy: bool) -> int | None:
+    """The `-icount` shift for this run, or None to leave guest time on host time."""
+    if 'c3' in machine:
+        return ICOUNT_SHIFT_C3
+    if wifi_enabled or not firmware_is_upy:
+        return None
+    if not any(str(s.get('sensor_type', '')) in LINE_SENSOR_TYPES for s in sensors):
+        return None
+    return ICOUNT_SHIFT_LINE_SENSORS
+
+
 def main() -> None:  # noqa: C901  (complexity OK for inline worker)
     # ── 1. Read config from stdin ─────────────────────────────────────────────
     raw_cfg = sys.stdin.readline()
@@ -506,7 +560,8 @@ def main() -> None:  # noqa: C901  (complexity OK for inline worker)
         # `app.*` is not on sys.path; mirrors the esp32_i2c_slaves pattern
         # at the top of the file.
         try:
-            from app.services.esp32_flash_image import pad_to_flash_size  # type: ignore[import-not-found]
+            from app.services.esp32_flash_image import (  # type: ignore[import-not-found]
+                firmware_is_micropython, pad_to_flash_size)
         except ImportError:
             import importlib.util as _ilu, pathlib as _pl
             _spec = _ilu.spec_from_file_location(
@@ -516,7 +571,9 @@ def main() -> None:  # noqa: C901  (complexity OK for inline worker)
             _mod = _ilu.module_from_spec(_spec)  # type: ignore[arg-type]
             _spec.loader.exec_module(_mod)  # type: ignore[union-attr]
             pad_to_flash_size = _mod.pad_to_flash_size
+            firmware_is_micropython = _mod.firmware_is_micropython
         fw_bytes = pad_to_flash_size(base64.b64decode(firmware_b64))
+        firmware_is_upy = firmware_is_micropython(fw_bytes)
         tmp = tempfile.NamedTemporaryFile(suffix='.bin', delete=False)
         tmp.write(fw_bytes)
         tmp.close()
@@ -534,13 +591,19 @@ def main() -> None:  # noqa: C901  (complexity OK for inline worker)
         b'-drive', f'file={firmware_path},if=mtd,format=raw'.encode(),
     ]
 
-    # Deterministic instruction counting for stable timers.
-    # Required for ESP32-C3 boot (RISC-V needs deterministic timing).
-    # For ESP32 (Xtensa), -icount is NOT used: the WiFi AP beacon timer
-    # runs on QEMU_CLOCK_REALTIME, so decoupling virtual time from real
-    # time can cause beacon delivery issues on slow/virtualized hosts.
-    if 'c3' in machine:
-        args_list.extend([b'-icount', b'3'])
+    # Deterministic instruction counting for stable timers. Always on for the
+    # ESP32-C3 (RISC-V needs deterministic timing to boot); on the Xtensa
+    # machines only for the runs that need it, see icount_shift_for_run().
+    icount_shift = icount_shift_for_run(machine, wifi_enabled, initial_sensors, firmware_is_upy)
+    if icount_shift is not None:
+        args_list.extend([b'-icount', str(icount_shift).encode()])
+        if 'c3' not in machine:
+            _log(f'-icount {icount_shift}: MicroPython run with a line sensor, '
+                 'guest time is instruction-driven (boot takes ~3x longer)')
+    elif firmware_is_upy and wifi_enabled and any(
+            str(s.get('sensor_type', '')) in LINE_SENSOR_TYPES for s in initial_sensors):
+        _log('line sensor on a MicroPython run that uses WiFi: -icount stays off '
+             '(issue #260), so a pulse-timing driver will time out on it')
 
     # ── WiFi NIC (slirp user-mode networking) ──────────────────────────────
     # Always present on machines that model a radio — see wifi_nic_arg().
@@ -812,87 +875,121 @@ def main() -> None:  # noqa: C901  (complexity OK for inline worker)
     #   3. No changes to the dispatcher are needed
     _sync_handlers: list = []
 
-    def _dht22_build_payload(temperature: float, humidity: float) -> list[int]:
-        """Build 5-byte DHT22 data payload: [hum_H, hum_L, temp_H, temp_L, checksum]."""
-        hum = round(humidity * 10)
-        tmp = round(temperature * 10)
-        h_H = (hum >> 8) & 0xFF
-        h_L = hum & 0xFF
-        raw_t = ((-tmp) & 0x7FFF) | 0x8000 if tmp < 0 else tmp & 0x7FFF
-        t_H = (raw_t >> 8) & 0xFF
-        t_L = raw_t & 0xFF
-        chk = (h_H + h_L + t_H + t_L) & 0xFF
-        return [h_H, h_L, t_H, t_L, chk]
+    # ── DHT22 ────────────────────────────────────────────────────────────────
+    # The model is esp32_dht22.py (trigger, phases, guest-time pacing). This is
+    # the glue: the guest clock, the pad, the sync-handler shape, and a settle
+    # timer for drivers that stop reading before the tail of the frame is out.
+    try:
+        _qemu_clock_get_ns = lib.qemu_clock_get_ns
+        _qemu_clock_get_ns.restype = ctypes.c_int64
+        _qemu_clock_get_ns.argtypes = [ctypes.c_int]
+        _QEMU_CLOCK_VIRTUAL = 1  # enum QEMUClockType, qemu/timer.h
 
-    def _dht22_build_sync_phases(payload: list[int]) -> list[tuple[int, int]]:
-        """Build list of (sync_count, pin_value) phase transitions for DHT22.
+        def _guest_now_us() -> float:
+            """The guest's own clock, in us: what esp_timer / micros() count.
+            Instruction-driven under -icount (the C3, and the runs picked by
+            icount_shift_for_run), host time while the VM runs otherwise;
+            either way it is the clock the guest measures our pulses with."""
+            return _qemu_clock_get_ns(_QEMU_CLOCK_VIRTUAL) / 1000.0
+    except AttributeError:
+        _log('libqemu does not export qemu_clock_get_ns; DHT22 pacing uses host time')
 
-        Each entry means: after sync_count digitalRead() calls in this phase,
-        drive the pin to pin_value and advance to the next phase.
+        def _guest_now_us() -> float:
+            return time.perf_counter_ns() / 1000.0
 
-        The Adafruit DHT library decodes bits by comparing
-        highCycles > lowCycles — only RATIOS matter, not absolute values.
-        We use the raw µs values as sync counts to preserve correct ratios.
+    class _Dht22Handler:
+        """Sync-handler shape over a Dht22Reply: one step per GPIO_IN read."""
 
-        After the last data bit (40th bit HIGH→LOW), the firmware's
-        expectPulse() loop ends — no more syncs will arrive.  So we do
-        NOT add a trailing phase; cleanup happens immediately after the
-        last phase transition fires.
-        """
-        phases: list[tuple[int, int]] = []
-        # Preamble: LOW 80 syncs → drive HIGH
-        phases.append((80, 1))
-        # Preamble: HIGH 80 syncs → drive LOW
-        phases.append((80, 0))
-        # 40 data bits: LOW 50 syncs → HIGH, then HIGH (26 or 70) → LOW
-        for byte_val in payload:
-            for b in range(7, -1, -1):
-                bit = (byte_val >> b) & 1
-                phases.append((50, 1))              # LOW phase → drive HIGH
-                phases.append((70 if bit else 26, 0))  # HIGH phase → drive LOW
-        return phases
-
-    class DHT22SyncHandler:
-        """Drives the DHT22 waveform synchronously, one GPIO_IN read sync at a time.
-
-        Uses phase-based counting: each phase defines how many syncs to wait before
-        driving the pin to a new value.  The Adafruit DHT library decodes bits by
-        comparing highCycles vs lowCycles — only RATIOS matter, so raw µs values used
-        as sync counts preserve the correct bit decoding.
-        """
-        def __init__(self, gpio: int, slot: int, phases: list[tuple[int, int]]) -> None:
-            self._gpio        = gpio
-            self._slot        = slot
-            self._phases      = phases
-            self._phase_idx   = 0
-            self._count       = 0
-            self._total_syncs = 0
+        def __init__(self, reply, gpio: int, sensor: dict, how: str) -> None:
+            self.reply = reply
+            self._gpio = gpio
+            self._sensor = sensor
+            self._how = how
 
         def step(self) -> bool:
-            """Advance one sync tick.  Returns True when the handler is done."""
-            self._count += 1
-            if self._phase_idx >= len(self._phases):
-                return self._finish()
-            target, pin_value = self._phases[self._phase_idx]
-            if self._count >= target:
-                lib.qemu_picsimlab_set_pin(self._slot, pin_value)
-                self._total_syncs += self._count
-                self._count       = 0
-                self._phase_idx  += 1
-                if self._phase_idx >= len(self._phases):
-                    return self._finish()
+            if self.reply.done:
+                return True
+            if self.reply.step():
+                self._finish()
+                return True
             return False
 
-        def _finish(self) -> bool:
+        def _finish(self) -> None:
             with _sensors_lock:
-                sensor = _sensors.get(self._gpio)
-                if sensor:
-                    sensor['responding'] = False
-            _log(f'DHT22 sync respond done gpio={self._gpio} '
-                 f'total_syncs={self._total_syncs} phases={len(self._phases)}')
+                if self._sensor.get('_dht22_reply') is self.reply:
+                    self._sensor['responding'] = False
+            d = self.reply.diag()
+            _log(f'DHT22 frame done gpio={self._gpio} ({self._how}) {d}')
             _emit({'type': 'system', 'event': 'dht22_diag', 'gpio': self._gpio,
-                   'status': 'ok', 'total_syncs': self._total_syncs})
-            return True
+                   'status': 'ok', 'release': self._how, **d})
+
+    def _dht22_settle_later(reply, sensor: dict, gpio: int) -> None:
+        """A read-counting driver returns on the last falling edge and never
+        reads again, so the tail LOW would sit on the pad until the next start.
+        Once the guest has gone quiet, release the line from a host thread
+        under the BQL (which also keeps step() from running concurrently)."""
+        if _lock_iothread is None or _unlock_iothread is None:
+            return
+
+        def _settle(last_reads: int) -> None:
+            if _stopped.is_set() or reply.done:
+                return
+            with _sensors_lock:
+                if sensor.get('_dht22_reply') is not reply:
+                    return
+            if reply.reads != last_reads:
+                # The guest is still polling: the frame is in progress. Under
+                # -icount a frame is ~3000 reads at ~90 us of host time each,
+                # so "quiet" is measured in reads, never in host time.
+                _later(reply.reads)
+                return
+            _lock_iothread(b'esp32_worker.py:dht22_settle', 0)
+            try:
+                acted = reply.settle()
+            finally:
+                _unlock_iothread()
+            if acted:
+                with _sensors_lock:
+                    if sensor.get('_dht22_reply') is reply:
+                        sensor['responding'] = False
+                _log(f'DHT22 line released by the settle timer gpio={gpio} '
+                     f'phase={reply.phase} {reply.diag()}')
+
+        def _later(last_reads: int) -> None:
+            t = threading.Timer(0.03, _settle, args=(last_reads,))
+            t.daemon = True
+            t.start()
+
+        _later(reply.reads)
+
+    def _dht22_trigger(sensor: dict):
+        trig = sensor.get('_dht22_trigger')
+        if trig is None:
+            trig = sensor['_dht22_trigger'] = _Dht22Trigger()
+        return trig
+
+    def _dht22_arm(gpio: int, slot: int, sensor: dict, how: str) -> None:
+        """Start a frame on `slot`. A frame still in flight is replaced: the
+        guest can only issue a new start after abandoning the previous read."""
+        temp = _dht22_num(sensor.get('temperature'), 25.0)
+        hum = _dht22_num(sensor.get('humidity'), 50.0)
+        payload = _dht22_payload_bytes(temp, hum)
+        old = sensor.get('_dht22_reply')
+        if old is not None and not old.done:
+            _sync_handlers[:] = [h for h in _sync_handlers
+                                 if getattr(h, 'reply', None) is not old]
+            _log(f'DHT22 frame restarted gpio={gpio} at phase {old.phase}')
+        reply = _Dht22Reply(
+            _dht22_phases(payload),
+            lambda level: lib.qemu_picsimlab_set_pin(slot, level),
+            _guest_now_us,
+        )
+        with _sensors_lock:
+            sensor['_dht22_reply'] = reply
+            sensor['responding'] = True
+        _sync_handlers.append(_Dht22Handler(reply, gpio, sensor, how))
+        _dht22_settle_later(reply, sensor, gpio)
+        _log(f'DHT22 armed ({how}) gpio={gpio} temp={temp} hum={hum} payload={payload}')
 
     class HCSR04SyncHandler:
         """Drives HC-SR04 ECHO pin synchronously from the QEMU GPIO_IN read callback.
@@ -911,12 +1008,12 @@ def main() -> None:  # noqa: C901  (complexity OK for inline worker)
 
           Phase 3 of pulseIn() (measure HIGH duration):
             Subsequent gpio_get_level() calls fire step().  We hold ECHO HIGH
-            until echo_us wall-clock µs have elapsed (perf_counter_ns), then
-            set LOW.  Virtual time ≈ wall-clock time (confirmed: 30 000 µs
-            pulseIn timeout = 30 ms wall-clock), so pulseIn() measures ≈ echo_us
-            virtual µs → correct distance.
+            until echo_us of GUEST time have elapsed (_guest_now_us: QEMU's
+            virtual clock, the one micros() / time_pulse_us read), then set
+            LOW.  Without -icount that clock is host time; under -icount it is
+            instruction-driven and host time would be off by 100x.
 
-        Guard: wall-clock timeouts replace step-count limits.  A step-count
+        Guard: guest-clock timeouts replace step-count limits.  A step-count
         guard is wrong because steps fire at rates that vary with QEMU load;
         using a fixed count would cut the pulse short for longer distances
         (100 cm = 5 800 µs, 200 cm = 11 600 µs) before elapsed_us is reached.
@@ -931,8 +1028,8 @@ def main() -> None:  # noqa: C901  (complexity OK for inline worker)
             self._echo_us       = echo_us
             self._state         = 'armed'
             self._total_steps   = 0
-            self._arm_start_ns  = time.perf_counter_ns()
-            self._echo_start_ns = 0
+            self._arm_start_us  = _guest_now_us()
+            self._echo_start_us = 0.0
 
         def step(self) -> bool:
             self._total_steps += 1
@@ -941,7 +1038,7 @@ def main() -> None:  # noqa: C901  (complexity OK for inline worker)
                 if self._total_steps <= self._SKIP_COUNT:
                     return False
                 # Check armed timeout (handler never entered 'high')
-                arm_us = (time.perf_counter_ns() - self._arm_start_ns) // 1000
+                arm_us = int(_guest_now_us() - self._arm_start_us)
                 if arm_us > self._ARMED_TIMEOUT_US:
                     _log(f'HCSR04 armed timeout trig={self._trig_gpio} '
                          f'arm_us={arm_us} steps={self._total_steps} — releasing')
@@ -957,12 +1054,12 @@ def main() -> None:  # noqa: C901  (complexity OK for inline worker)
                 _log(f'HCSR04 ECHO HIGH (sync) trig={self._trig_gpio} '
                      f'slot={self._echo_slot} echo_us={self._echo_us} '
                      f'armed_us={arm_us} skip={self._total_steps - 1}')
-                self._echo_start_ns = time.perf_counter_ns()
+                self._echo_start_us = _guest_now_us()
                 self._state = 'high'
                 return False
 
             elif self._state == 'high':
-                elapsed_us = (time.perf_counter_ns() - self._echo_start_ns) // 1000
+                elapsed_us = int(_guest_now_us() - self._echo_start_us)
                 if elapsed_us >= self._echo_us:
                     return self._finish(elapsed_us)
                 # Safety: don't hold ECHO past pulseIn() timeout
@@ -1056,11 +1153,13 @@ def main() -> None:  # noqa: C901  (complexity OK for inline worker)
         stype = sensor.get('type', '')
 
         if stype == 'dht22':
-            # Record that the firmware drove the pin LOW (start signal).
-            # The actual response is triggered from _on_dir_change when the
-            # firmware switches the pin to INPUT mode.
-            if value == 0 and not sensor.get('responding', False):
-                sensor['saw_low'] = True
+            # A level the guest wrote while the pad is an output (QEMU reports
+            # no others). The LOW is the start signal; a 1 after it is the
+            # open-drain release, how MicroPython's dht driver lets go of the
+            # line (issue #291). The push-pull release, pinMode(INPUT), arrives
+            # in _on_dir_change instead.
+            if _dht22_trigger(sensor).on_write(value & 1):
+                _dht22_arm(gpio, slot, sensor, 'open-drain release')
 
         elif stype == 'hc-sr04':
             # HC-SR04 trigger:
@@ -1125,7 +1224,7 @@ def main() -> None:  # noqa: C901  (complexity OK for inline worker)
                        'duty_pct': intensity})
             return
 
-        # ── DHT22: track direction changes + trigger sync response ───────
+        # ── DHT22: the push-pull release arrives as a direction change ───
         if slot >= 1:
             gpio = int(_PINMAP[slot]) if slot <= _GPIO_COUNT else slot
             # Matrix keypad: rows toggle OUTPUT(scan)/INPUT(idle) every pass,
@@ -1146,31 +1245,10 @@ def main() -> None:  # noqa: C901  (complexity OK for inline worker)
                     _keypad_recompute(_kp)
             with _sensors_lock:
                 sensor = _sensors.get(gpio)
-            if sensor is not None and sensor.get('type') == 'dht22':
-                if direction == 1:
-                    # OUTPUT mode — record timestamp for diagnostics
-                    sensor['dir_out_ns'] = time.perf_counter_ns()
-                elif direction == 0:
-                    # INPUT mode — trigger DHT22 sync-based response
-                    if sensor.get('saw_low', False) and not sensor.get('responding', False):
-                        sensor['saw_low'] = False
-                        sensor['responding'] = True
-
-                        # Build the response waveform phases
-                        temp = sensor.get('temperature', 25.0)
-                        hum = sensor.get('humidity', 50.0)
-                        payload = _dht22_build_payload(temp, hum)
-                        phases = _dht22_build_sync_phases(payload)
-
-                        # Drive pin LOW synchronously — firmware sees LOW
-                        # at its first digitalRead() in expectPulse().
-                        lib.qemu_picsimlab_set_pin(slot, 0)
-
-                        # Arm the sync-based response state machine
-                        _sync_handlers.append(DHT22SyncHandler(gpio, slot, phases))
-                        _log(f'DHT22 sync armed gpio={gpio} '
-                             f'temp={temp} hum={hum} '
-                             f'phases={len(phases)} payload={payload}')
+            if sensor is not None and sensor.get('type') == 'dht22' and direction in (0, 1):
+                # The push-pull release: the pad went INPUT after the LOW.
+                if _dht22_trigger(sensor).on_direction(direction == 1):
+                    _dht22_arm(gpio, slot, sensor, 'input release')
         gpio = int(_PINMAP[slot]) if 1 <= slot <= _GPIO_COUNT else slot
         _emit({'type': 'gpio_dir', 'pin': gpio, 'dir': direction})
 

--- a/test/backend/unit/test_dht22_worker.py
+++ b/test/backend/unit/test_dht22_worker.py
@@ -1,692 +1,372 @@
 """
-test_dht22_worker.py — Diagnostic tests for the ESP32 DHT22 response mechanism.
+test_dht22_worker.py — the DHT22 reply the QEMU ESP32 worker drives
+(`app.services.esp32_dht22`), and the run policy around it.
 
-Tests the core algorithm extracted from esp32_worker.py:
-  1. Payload encoding (_dht22_build_payload)
-  2. Callback state machine (pin_change → saw_low, dir_change → response trigger)
-  3. Response pin-drive sequence (preamble + 40 data bits)
-  4. Timing analysis
+Two guests read the same frame here, the way the two driver families do on the
+real chip:
+
+  * MicroPython's `dht_readinto` (drivers/dht/dht.c, v1.28) times pulses with
+    `machine_time_pulse_us`: 100 us per phase, a '1' is a HIGH over 48 us.
+  * Adafruit's DHT.h counts `digitalRead()` iterations per pulse and compares
+    the HIGH count against the preceding 50 us LOW count.
+
+The reply must decode under both, at read spacings from the ~0.5 us a guest
+gets under `-icount` to the 40-90 us it gets without (issue #291).
 """
 
-import threading
-import time
+from __future__ import annotations
+
 import unittest
 
-
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-#  Extracted logic from esp32_worker.py (closures inside main())
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-def dht22_build_payload(temperature: float, humidity: float) -> list[int]:
-    """Build 5-byte DHT22 data payload: [hum_H, hum_L, temp_H, temp_L, checksum]."""
-    hum = round(humidity * 10)
-    tmp = round(temperature * 10)
-    h_H = (hum >> 8) & 0xFF
-    h_L = hum & 0xFF
-    raw_t = ((-tmp) & 0x7FFF) | 0x8000 if tmp < 0 else tmp & 0x7FFF
-    t_H = (raw_t >> 8) & 0xFF
-    t_L = raw_t & 0xFF
-    chk = (h_H + h_L + t_H + t_L) & 0xFF
-    return [h_H, h_L, t_H, t_L, chk]
-
-
-def busy_wait_us(us: int) -> None:
-    """Busy-wait for the given number of microseconds using perf_counter_ns."""
-    end = time.perf_counter_ns() + us * 1000
-    while time.perf_counter_ns() < end:
-        pass
+from app.services.esp32_dht22 import (
+    BIT0_HIGH_US,
+    BIT1_HIGH_US,
+    BIT_LOW_US,
+    RESPONSE_HIGH_US,
+    RESPONSE_LOW_US,
+    STALL_CAP_US,
+    Dht22Reply,
+    Dht22Trigger,
+    coerce_number,
+    dht22_payload,
+    dht22_phases,
+)
+from app.services.esp32_flash_image import firmware_is_micropython
+from app.services.esp32_worker import (
+    ICOUNT_SHIFT_C3,
+    ICOUNT_SHIFT_LINE_SENSORS,
+    icount_shift_for_run,
+)
 
 
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-#  Mock QEMU environment
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# ── the two guests ───────────────────────────────────────────────────────────
 
-class MockLib:
-    """Mock for the ctypes QEMU library.  Records every set_pin call."""
+class Pad:
+    """The pad as QEMU holds it: the level the host last drove."""
 
-    def __init__(self):
-        self.pin_events: list[tuple[float, int, int]] = []  # (timestamp_ns, slot, value)
-        self._lock = threading.Lock()
+    def __init__(self) -> None:
+        self.level = 1
+        self.edges: list[tuple[float, int]] = []
 
-    def qemu_picsimlab_set_pin(self, slot: int, value: int) -> None:
-        ts = time.perf_counter_ns()
-        with self._lock:
-            self.pin_events.append((ts, slot, value))
+    def set(self, level: int) -> None:
+        self.level = level
 
 
-class DHT22SimulatorHarness:
-    """
-    Minimal simulation of the esp32_worker callback environment for DHT22.
+class GuestClock:
+    def __init__(self) -> None:
+        self.t = 0.0
 
-    Mirrors the exact logic from esp32_worker.py's _on_pin_change and
-    _on_dir_change closures, plus the _dht22_respond thread function.
-    """
-
-    def __init__(self, gpio_count: int = 40):
-        self.gpio_count = gpio_count
-        # Identity pinmap: slot i → GPIO (i-1)
-        self.pinmap = list(range(-1, gpio_count))  # pinmap[0]=count placeholder
-        self.pinmap[0] = gpio_count                 # pinmap[0] = count
-
-        self.sensors: dict[int, dict] = {}
-        self.sensors_lock = threading.Lock()
-        self.stopped = threading.Event()
-        self.lib = MockLib()
-
-        # Collect emitted events
-        self.emitted_events: list[dict] = []
-
-    def register_sensor(self, gpio: int, sensor_type: str, **kwargs):
-        with self.sensors_lock:
-            self.sensors[gpio] = {
-                'type': sensor_type,
-                'saw_low': False,
-                'responding': False,
-                **kwargs,
-            }
-
-    def _emit(self, obj: dict):
-        self.emitted_events.append(obj)
-
-    # ── Callback replicas (mirroring esp32_worker.py) ──
-
-    def on_pin_change(self, slot: int, value: int) -> None:
-        """Replica of _on_pin_change from esp32_worker.py."""
-        if self.stopped.is_set():
-            return
-        gpio = self.pinmap[slot] if 1 <= slot <= self.gpio_count else slot
-        self._emit({'type': 'gpio_change', 'pin': gpio, 'state': value})
-
-        with self.sensors_lock:
-            sensor = self.sensors.get(gpio)
-        if sensor is None:
-            return
-
-        stype = sensor.get('type', '')
-
-        if stype == 'dht22':
-            if value == 0 and not sensor.get('responding', False):
-                sensor['saw_low'] = True
-
-    def on_dir_change(self, slot: int, direction: int) -> None:
-        """Replica of _on_dir_change from esp32_worker.py (DHT22 portion)."""
-        if self.stopped.is_set():
-            return
-
-        if slot >= 1:
-            gpio = self.pinmap[slot] if slot <= self.gpio_count else slot
-            with self.sensors_lock:
-                sensor = self.sensors.get(gpio)
-            if sensor is not None and sensor.get('type') == 'dht22':
-                if direction == 1:
-                    sensor['dir_out_ns'] = time.perf_counter_ns()
-                elif direction == 0:
-                    if sensor.get('saw_low', False) and not sensor.get('responding', False):
-                        sensor['saw_low'] = False
-                        sensor['responding'] = True
-
-                        now_ns = time.perf_counter_ns()
-                        dir_out_ns = sensor.get('dir_out_ns', now_ns)
-                        wall_us = max(1.0, (now_ns - dir_out_ns) / 1000)
-                        qemu_us_signal = 1200.0
-                        ratio = wall_us / qemu_us_signal
-
-                        # Drive pin LOW synchronously
-                        self.lib.qemu_picsimlab_set_pin(slot, 0)
-
-                        threading.Thread(
-                            target=self._dht22_respond,
-                            args=(gpio, sensor.get('temperature', 25.0),
-                                  sensor.get('humidity', 50.0), ratio),
-                            daemon=True,
-                            name=f'dht22-gpio{gpio}',
-                        ).start()
-
-        # Emit gpio_dir event (like the real worker does after DHT22 handling)
-        if slot >= 1:
-            gpio = self.pinmap[slot] if 1 <= slot <= self.gpio_count else slot
-            self._emit({'type': 'gpio_dir', 'pin': gpio, 'dir': direction})
-
-    def _dht22_respond(self, gpio_pin: int, temperature: float, humidity: float,
-                       ratio: float) -> None:
-        """Replica of _dht22_respond from esp32_worker.py."""
-        slot = gpio_pin + 1
-        payload = dht22_build_payload(temperature, humidity)
-
-        def qemu_wait(qemu_us: float) -> None:
-            wall_us = max(1, int(qemu_us * ratio))
-            busy_wait_us(wall_us)
-
-        t0 = time.perf_counter_ns()
-        error_msg: str | None = None
-        try:
-            # Preamble: hold LOW 80 µs → drive HIGH 80 µs
-            qemu_wait(80)
-            self.lib.qemu_picsimlab_set_pin(slot, 1)
-            qemu_wait(80)
-
-            # 40 data bits
-            for byte_val in payload:
-                for b in range(7, -1, -1):
-                    bit = (byte_val >> b) & 1
-                    self.lib.qemu_picsimlab_set_pin(slot, 0)
-                    qemu_wait(50)
-                    self.lib.qemu_picsimlab_set_pin(slot, 1)
-                    qemu_wait(70 if bit else 26)
-
-            # Final release
-            self.lib.qemu_picsimlab_set_pin(slot, 0)
-            qemu_wait(50)
-            self.lib.qemu_picsimlab_set_pin(slot, 1)
-        except Exception as exc:
-            error_msg = str(exc)
-        finally:
-            elapsed_us = (time.perf_counter_ns() - t0) / 1000
-            with self.sensors_lock:
-                sensor = self.sensors.get(gpio_pin)
-                if sensor:
-                    sensor['responding'] = False
-            if error_msg:
-                print(f'  DHT22 respond ERROR gpio={gpio_pin}: {error_msg}')
-            else:
-                print(f'  DHT22 respond done gpio={gpio_pin} ratio={ratio:.4f} '
-                      f'elapsed={elapsed_us:.0f}µs')
+    def now(self) -> float:
+        return self.t
 
 
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-#  Test cases
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+def run_guest(reply: Dht22Reply, pad: Pad, clock: GuestClock, decoder,
+              first_read_delay_us: float, read_interval_us: float,
+              stall_at_read: int | None = None, stall_us: float = 0.0,
+              max_reads: int = 200_000):
+    """Drive `reply` the way QEMU does: one step per guest read, the guest
+    reading the pad right after. `decoder.sample(t, level)` returns None to keep
+    reading or a result."""
+    clock.t += first_read_delay_us
+    for n in range(max_reads):
+        if stall_at_read is not None and n == stall_at_read:
+            clock.t += stall_us
+        reply.step()
+        pad.edges.append((clock.t, pad.level))
+        r = decoder.sample(clock.t, pad.level)
+        if r is not None:
+            return r
+        clock.t += read_interval_us
+    raise AssertionError('the guest never finished')
 
-class TestDHT22Payload(unittest.TestCase):
-    """Test the 5-byte payload encoding."""
 
-    def test_positive_temperature(self):
-        payload = dht22_build_payload(28.0, 65.0)
-        self.assertEqual(len(payload), 5)
-        # Humidity: 65.0 → 650 → 0x028A → [0x02, 0x8A]
-        self.assertEqual(payload[0], 0x02)
-        self.assertEqual(payload[1], 0x8A)
-        # Temperature: 28.0 → 280 → 0x0118 → [0x01, 0x18]
-        self.assertEqual(payload[2], 0x01)
-        self.assertEqual(payload[3], 0x18)
-        # Checksum
-        expected_chk = (0x02 + 0x8A + 0x01 + 0x18) & 0xFF
-        self.assertEqual(payload[4], expected_chk)
+class MicroPythonDht:
+    """drivers/dht/dht.c after the release: wait for LOW (100 us), one pulse of
+    150 us budget, then 40 pulses of 100 us budget, bit = HIGH > 48 us.
+    `machine_time_pulse_us` samples the clock BEFORE each read, as the C does."""
 
-    def test_negative_temperature(self):
-        payload = dht22_build_payload(-5.0, 80.0)
-        # Temperature: -5.0 → -50 → (50 & 0x7FFF) | 0x8000 = 0x8032 → [0x80, 0x32]
-        self.assertEqual(payload[2], 0x80)
-        self.assertEqual(payload[3], 0x32)
+    def __init__(self) -> None:
+        self.state = 'wait_low'
+        self.t0 = None
+        self.pulse_level = 1
+        self.nchanges = 2
+        self.timeout = 150
+        self.bits: list[int] = []
 
-    def test_zero_values(self):
-        payload = dht22_build_payload(0.0, 0.0)
-        self.assertEqual(payload, [0, 0, 0, 0, 0])
+    def sample(self, t: float, level: int):
+        if self.state == 'wait_low':
+            if self.t0 is None:
+                self.t0 = t
+            if level == 0:
+                self._start_pulse(t, 150)
+                return None
+            return 'timeout' if t - self.t0 > 100 else None
+        # inside machine_time_pulse_us
+        if level == self.pulse_level:
+            self.pulse_level = 1 - self.pulse_level
+            self.nchanges -= 1
+            if self.nchanges == 0:
+                dur = t - self.t0
+                if self.state == 'preamble':
+                    self._start_pulse(t, 100)
+                    self.state = 'bits'
+                    return None
+                self.bits.append(1 if dur > 48 else 0)
+                if len(self.bits) == 40:
+                    out = bytes(int(''.join(map(str, self.bits[i:i + 8])), 2) for i in range(0, 40, 8))
+                    return out
+                self._start_pulse(t, 100)
+                return None
+            self.t0 = t
+            return None
+        if t - self.t0 >= self.timeout:
+            return 'timeout'
+        return None
+
+    def _start_pulse(self, t: float, timeout: int) -> None:
+        if self.state == 'wait_low':
+            self.state = 'preamble'
+        self.t0 = t
+        self.pulse_level = 1
+        self.nchanges = 2
+        self.timeout = timeout
+
+
+class AdafruitDht:
+    """DHT.h: expectPulse(LOW), expectPulse(HIGH), then 40 x (LOW count, HIGH
+    count); bit = highCount > lowCount. Counts reads, never the clock."""
+
+    MAXCYCLES = 240_000
+
+    def __init__(self) -> None:
+        self.expect = 0
+        self.count = 0
+        self.pulses: list[int] = []
+
+    def sample(self, t: float, level: int):
+        if level == self.expect:
+            self.count += 1
+            if self.count >= self.MAXCYCLES:
+                return 'timeout'
+            return None
+        self.pulses.append(self.count)
+        self.count = 0
+        self.expect = 1 - self.expect
+        if len(self.pulses) == 82:
+            data = self.pulses[2:]
+            bits = [1 if data[2 * i + 1] > data[2 * i] else 0 for i in range(40)]
+            return bytes(int(''.join(map(str, bits[i:i + 8])), 2) for i in range(0, 40, 8))
+        return None
+
+
+def make_reply(temp=28.0, hum=55.0):
+    pad, clock = Pad(), GuestClock()
+    reply = Dht22Reply(dht22_phases(dht22_payload(temp, hum)), pad.set, clock.now)
+    return reply, pad, clock
+
+
+EXPECTED = bytes(dht22_payload(28.0, 55.0))
+
+
+# ── payload ──────────────────────────────────────────────────────────────────
+
+class TestPayload(unittest.TestCase):
+    def test_positive(self):
+        self.assertEqual(dht22_payload(28.0, 55.0), [2, 38, 1, 24, 65])
+
+    def test_negative_temperature_sets_sign_bit(self):
+        p = dht22_payload(-10.5, 30.0)
+        self.assertEqual(p[2] & 0x80, 0x80)
+        self.assertEqual(((p[2] & 0x7F) << 8) | p[3], 105)
 
     def test_checksum_wraps(self):
-        payload = dht22_build_payload(25.5, 99.9)
-        chk = sum(payload[:4]) & 0xFF
-        self.assertEqual(payload[4], chk)
-
-
-class TestDHT22PinMapping(unittest.TestCase):
-    """Verify identity pinmap: slot i → GPIO (i-1)."""
-
-    def test_esp32_gpio4_slot5(self):
-        harness = DHT22SimulatorHarness(gpio_count=40)
-        # GPIO 4 → slot 5
-        self.assertEqual(harness.pinmap[5], 4)
-
-    def test_esp32_gpio_range(self):
-        harness = DHT22SimulatorHarness(gpio_count=40)
-        for gpio in range(40):
-            slot = gpio + 1
-            self.assertEqual(harness.pinmap[slot], gpio,
-                             f'pinmap[{slot}] should be {gpio}')
-
-    def test_esp32c3_gpio_range(self):
-        harness = DHT22SimulatorHarness(gpio_count=22)
-        for gpio in range(22):
-            slot = gpio + 1
-            self.assertEqual(harness.pinmap[slot], gpio,
-                             f'ESP32-C3: pinmap[{slot}] should be {gpio}')
-
-
-class TestDHT22StateMachine(unittest.TestCase):
-    """Test the saw_low / responding state machine."""
-
-    def setUp(self):
-        self.harness = DHT22SimulatorHarness()
-        self.harness.register_sensor(4, 'dht22', temperature=28.0, humidity=65.0)
-
-    def test_initial_state(self):
-        sensor = self.harness.sensors[4]
-        self.assertFalse(sensor['saw_low'])
-        self.assertFalse(sensor['responding'])
-
-    def test_pin_change_low_sets_saw_low(self):
-        self.harness.on_pin_change(5, 0)  # slot=5 → GPIO 4, value=0 (LOW)
-        sensor = self.harness.sensors[4]
-        self.assertTrue(sensor['saw_low'], 'saw_low should be True after LOW pin_change')
-
-    def test_pin_change_high_does_not_set_saw_low(self):
-        self.harness.on_pin_change(5, 1)  # HIGH
-        sensor = self.harness.sensors[4]
-        self.assertFalse(sensor['saw_low'])
-
-    def test_pin_change_low_blocked_when_responding(self):
-        sensor = self.harness.sensors[4]
-        sensor['responding'] = True
-        self.harness.on_pin_change(5, 0)  # LOW
-        self.assertFalse(sensor['saw_low'],
-                         'saw_low should remain False when responding=True')
-
-    def test_dir_change_output_records_timestamp(self):
-        self.harness.on_dir_change(5, 1)  # direction=1 → OUTPUT
-        sensor = self.harness.sensors[4]
-        self.assertIn('dir_out_ns', sensor)
-        self.assertIsInstance(sensor['dir_out_ns'], (int, float))
-
-    def test_dir_change_input_without_saw_low_does_not_trigger(self):
-        """If saw_low is False, dir_change(INPUT) should NOT trigger response."""
-        self.harness.on_dir_change(5, 1)  # OUTPUT
-        # Do NOT call pin_change(LOW) → saw_low stays False
-        self.harness.on_dir_change(5, 0)  # INPUT
-        sensor = self.harness.sensors[4]
-        self.assertFalse(sensor['responding'],
-                         'Should not trigger response without saw_low')
-        self.assertEqual(len(self.harness.lib.pin_events), 0,
-                         'No pin drives should happen without saw_low')
-
-    def test_full_sequence_triggers_response(self):
-        """Simulate the full firmware DHT22 start signal sequence."""
-        # 1. pinMode(OUTPUT) → dir_change(1)
-        self.harness.on_dir_change(5, 1)
-        # 2. digitalWrite(LOW) → pin_change(0)
-        self.harness.on_pin_change(5, 0)
-        sensor = self.harness.sensors[4]
-        self.assertTrue(sensor['saw_low'])
-
-        # 3. delayMicroseconds(1100) — simulate with small sleep
-        time.sleep(0.001)
-
-        # 4. digitalWrite(HIGH) → pin_change(1)
-        self.harness.on_pin_change(5, 1)
-
-        # 5. delayMicroseconds(55) — simulate
-        time.sleep(0.00005)
-
-        # 6. pinMode(INPUT_PULLUP) → dir_change(0) → TRIGGERS RESPONSE
-        self.harness.on_dir_change(5, 0)
-
-        # Wait for response thread to complete
-        time.sleep(1.0)
-
-        self.assertFalse(sensor['responding'],
-                         'responding should be False after response thread completes')
-
-        # Check pin events were recorded
-        events = self.harness.lib.pin_events
-        self.assertGreater(len(events), 0,
-                           'Response thread should have driven pins')
-
-        print(f'\n  Total pin events: {len(events)}')
-        # Expected: 1 (sync LOW) + 1 (HIGH preamble) + 40*2 (data bits) + 2 (final) = 84 drives
-        expected_drives = 1 + 1 + 40 * 2 + 2
-        self.assertEqual(len(events), expected_drives,
-                         f'Expected {expected_drives} pin drives, got {len(events)}')
-
-
-class TestDHT22ResponseWaveform(unittest.TestCase):
-    """Verify the exact pin-drive sequence of the DHT22 response."""
-
-    def test_response_sequence(self):
-        harness = DHT22SimulatorHarness()
-        harness.register_sensor(4, 'dht22', temperature=28.0, humidity=65.0)
-
-        # Trigger full sequence
-        harness.on_dir_change(5, 1)     # OUTPUT
-        harness.on_pin_change(5, 0)     # LOW (saw_low=True)
-        time.sleep(0.001)               # simulate delayMicroseconds(1100)
-        harness.on_pin_change(5, 1)     # HIGH
-        time.sleep(0.00005)
-        harness.on_dir_change(5, 0)     # INPUT → triggers response
-
-        time.sleep(1.0)  # wait for response thread
-
-        events = harness.lib.pin_events
-        if not events:
-            self.fail('No pin events recorded — response thread did not run!')
-
-        # Extract slot/value pairs (ignore timestamps)
-        drives = [(slot, value) for _, slot, value in events]
-        print(f'\n  Pin drives ({len(drives)} total):')
-
-        # 1. Synchronous LOW from on_dir_change
-        self.assertEqual(drives[0], (5, 0), 'First drive should be sync LOW on slot 5')
-
-        # 2. HIGH preamble
-        self.assertEqual(drives[1], (5, 1), 'Second drive should be HIGH preamble')
-
-        # 3. Data bits: alternating LOW/HIGH for 40 bits = 80 drives
-        payload = dht22_build_payload(28.0, 65.0)
-        data_drives = drives[2:82]  # 80 drives for 40 bits
-        self.assertEqual(len(data_drives), 80, f'Expected 80 data drives, got {len(data_drives)}')
-
-        # Verify data drives alternate LOW/HIGH
-        for i, (slot, value) in enumerate(data_drives):
-            self.assertEqual(slot, 5, f'Data drive {i}: wrong slot')
-            expected_value = 0 if i % 2 == 0 else 1
-            self.assertEqual(value, expected_value,
-                             f'Data drive {i}: expected {"LOW" if expected_value == 0 else "HIGH"}, '
-                             f'got {"LOW" if value == 0 else "HIGH"}')
-
-        # 4. Final: LOW then HIGH
-        self.assertEqual(drives[82], (5, 0), 'Final LOW')
-        self.assertEqual(drives[83], (5, 1), 'Final HIGH (release)')
-
-        print('  Waveform sequence: CORRECT ✓')
-
-    @unittest.skipIf(
-        __import__('os').environ.get('CI') == 'true',
-        'Timing-sensitive test (uses busy-wait + sleep) — skipped in CI'
-    )
-    def test_response_data_matches_payload(self):
-        """Verify that the HIGH pulse durations encode the correct bits."""
-        harness = DHT22SimulatorHarness()
-        harness.register_sensor(4, 'dht22', temperature=28.0, humidity=65.0)
-
-        # Trigger
-        harness.on_dir_change(5, 1)
-        harness.on_pin_change(5, 0)
-        time.sleep(0.001)
-        harness.on_pin_change(5, 1)
-        time.sleep(0.00005)
-        harness.on_dir_change(5, 0)
-        time.sleep(1.0)
-
-        events = harness.lib.pin_events
-        if len(events) < 84:
-            self.fail(f'Expected 84 pin events, got {len(events)}')
-
-        # Extract HIGH pulse durations (between set_pin(1) and set_pin(0))
-        # Data starts at event index 2
-        payload = dht22_build_payload(28.0, 65.0)
-        expected_bits = []
-        for byte_val in payload:
-            for b in range(7, -1, -1):
-                expected_bits.append((byte_val >> b) & 1)
-
-        # For each data bit, check HIGH duration relative to LOW duration
-        # bit=0: HIGH ≈ 26µs, bit=1: HIGH ≈ 70µs
-        # LOW phase always ≈ 50µs
-        decoded_bits = []
-        for i in range(40):
-            # Event index: 2 + i*2 = LOW drive, 2 + i*2 + 1 = HIGH drive
-            low_ts = events[2 + i * 2][0]    # timestamp of LOW
-            high_ts = events[2 + i * 2 + 1][0]  # timestamp of HIGH
-            # Next LOW (or final LOW) timestamp
-            next_low_ts = events[2 + (i + 1) * 2][0] if i < 39 else events[82][0]
-
-            low_dur_us = (high_ts - low_ts) / 1000
-            high_dur_us = (next_low_ts - high_ts) / 1000
-
-            # Decode: HIGH > LOW → bit 1, else bit 0
-            decoded_bit = 1 if high_dur_us > low_dur_us else 0
-            decoded_bits.append(decoded_bit)
-
-        self.assertEqual(decoded_bits, expected_bits,
-                         'Decoded bits from waveform do not match expected payload')
-
-        # Reconstruct bytes from decoded bits
-        decoded_bytes = []
-        for byte_idx in range(5):
-            val = 0
-            for bit_idx in range(8):
-                val = (val << 1) | decoded_bits[byte_idx * 8 + bit_idx]
-            decoded_bytes.append(val)
-
-        print(f'\n  Expected payload: {[hex(b) for b in payload]}')
-        print(f'  Decoded payload:  {[hex(b) for b in decoded_bytes]}')
-        self.assertEqual(decoded_bytes, payload, 'Decoded bytes do not match payload')
-        print('  Data encoding: CORRECT ✓')
-
-
-class TestDHT22ResponseTiming(unittest.TestCase):
-    """Analyze the timing of the response to check for issues."""
-
-    @unittest.skipIf(
-        __import__('os').environ.get('CI') == 'true',
-        'Timing-sensitive test (asserts microsecond accuracy of the '
-        'preamble LOW) — skipped in CI / deploy-gate runs because GIL '
-        'contention from concurrent docker build / zstd / npm easily '
-        'inflates the observed timing past the 1 ms threshold.'
-    )
-    def test_response_timing_analysis(self):
-        """Measure actual timing of the response with ratio=1.0 (real-time)."""
-        harness = DHT22SimulatorHarness()
-        harness.register_sensor(4, 'dht22', temperature=28.0, humidity=65.0)
-
-        # Use a fixed ratio of 1.0 for predictable timing
-        sensor = harness.sensors[4]
-        sensor['dir_out_ns'] = time.perf_counter_ns() - 1200000  # 1200µs ago
-
-        harness.on_dir_change(5, 1)     # OUTPUT (record dir_out_ns)
-        harness.on_pin_change(5, 0)     # LOW
-
-        # Simulate ~1200µs delay (the real firmware's start signal)
-        busy_wait_us(1200)
-
-        harness.on_pin_change(5, 1)     # HIGH
-        busy_wait_us(55)
-
-        t_dir_input = time.perf_counter_ns()
-        harness.on_dir_change(5, 0)     # INPUT → triggers
-        t_after_callback = time.perf_counter_ns()
-
-        callback_us = (t_after_callback - t_dir_input) / 1000
-        print(f'\n  dir_change(INPUT) callback duration: {callback_us:.0f}µs')
-
-        time.sleep(1.0)  # wait for response
-
-        events = harness.lib.pin_events
-        self.assertGreater(len(events), 0, 'No pin events!')
-
-        # Timing analysis
-        t_first_event = events[0][0]
-        t_last_event = events[-1][0]
-        total_us = (t_last_event - t_first_event) / 1000
-
-        # Time from callback to first pin drive (sync LOW in callback)
-        sync_low_delay_us = (events[0][0] - t_dir_input) / 1000
-
-        # Time from sync LOW to first HIGH (preamble HIGH)
-        preamble_low_us = 0.0
-        response_start_us = 0.0
-        if len(events) >= 2:
-            preamble_low_us = (events[1][0] - events[0][0]) / 1000
-            response_start_us = (events[1][0] - t_after_callback) / 1000
-
-        print(f'  Sync LOW delay from callback start: {sync_low_delay_us:.0f}µs')
-        print(f'  Preamble LOW duration (expected 80µs): {preamble_low_us:.0f}µs')
-        print(f'  Response thread first drive after callback return: {response_start_us:.0f}µs')
-        print(f'  Total response waveform duration: {total_us:.0f}µs')
-        print(f'  Total pin events: {len(events)}')
-
-        # The preamble LOW should be close to 80µs (± tolerance for busy-wait accuracy)
-        # At ratio ~1.0, we expect 80µs ± 50%
-        self.assertGreater(preamble_low_us, 30,
-                           f'Preamble LOW too short: {preamble_low_us:.0f}µs (expected ~80µs)')
-        # On busy systems / GIL contention, preamble can be up to ~500µs
-        self.assertLess(preamble_low_us, 1000,
-                        f'Preamble LOW too long: {preamble_low_us:.0f}µs (expected ~80µs)')
-
-
-class TestDHT22MultipleReads(unittest.TestCase):
-    """Test that multiple consecutive reads work correctly."""
-
-    def test_second_read_after_first_completes(self):
-        harness = DHT22SimulatorHarness()
-        harness.register_sensor(4, 'dht22', temperature=28.0, humidity=65.0)
-
-        for attempt in range(3):
-            # Reset events
-            harness.lib.pin_events.clear()
-
-            # Full sequence
-            harness.on_dir_change(5, 1)     # OUTPUT
-            harness.on_pin_change(5, 0)     # LOW
-            time.sleep(0.001)
-            harness.on_pin_change(5, 1)     # HIGH
-            time.sleep(0.00005)
-            harness.on_dir_change(5, 0)     # INPUT → triggers
-            time.sleep(0.5)                 # wait for response
-
-            sensor = harness.sensors[4]
-            self.assertFalse(sensor['responding'],
-                             f'Attempt {attempt+1}: responding should be False after completion')
-            self.assertGreater(len(harness.lib.pin_events), 0,
-                               f'Attempt {attempt+1}: no pin events!')
-            print(f'  Attempt {attempt+1}: {len(harness.lib.pin_events)} pin events ✓')
-
-    def test_sensor_reregistration_resets_state(self):
-        """Simulate what happens when sensor_attach command arrives mid-read."""
-        harness = DHT22SimulatorHarness()
-        harness.register_sensor(4, 'dht22', temperature=28.0, humidity=65.0)
-
-        # Start first read
-        harness.on_dir_change(5, 1)     # OUTPUT
-        harness.on_pin_change(5, 0)     # LOW → saw_low=True
-
-        # Simulate sensor_attach command arriving (re-registration)
-        harness.register_sensor(4, 'dht22', temperature=28.0, humidity=65.0)
-
-        sensor = harness.sensors[4]
-        self.assertFalse(sensor['saw_low'],
-                         'saw_low should be reset after re-registration')
-
-        # Continue the sequence
-        time.sleep(0.001)
-        harness.on_pin_change(5, 1)     # HIGH
-        time.sleep(0.00005)
-        harness.on_dir_change(5, 0)     # INPUT → should NOT trigger (saw_low was reset!)
-
-        time.sleep(0.1)
-        self.assertEqual(len(harness.lib.pin_events), 0,
-                         'Re-registration reset saw_low, so response should NOT trigger!')
-        print('  Sensor re-registration correctly prevents false trigger ✓')
-        print('  ⚠ WARNING: If sensor_attach arrives between pin_change(LOW) and '
-              'dir_change(INPUT), the read attempt will fail silently!')
-
-
-class TestDHT22EdgeCases(unittest.TestCase):
-    """Test edge cases that could cause the DHT22 to fail."""
-
-    def test_no_sensor_registered(self):
-        """pin_change/dir_change with no sensor should not crash."""
-        harness = DHT22SimulatorHarness()
-        harness.on_pin_change(5, 0)
-        harness.on_dir_change(5, 1)
-        harness.on_dir_change(5, 0)
-        self.assertEqual(len(harness.lib.pin_events), 0)
-
-    def test_wrong_gpio_pin(self):
-        """Sensor on GPIO 4 should not respond to events on GPIO 5."""
-        harness = DHT22SimulatorHarness()
-        harness.register_sensor(4, 'dht22', temperature=28.0, humidity=65.0)
-
-        # Trigger on slot 6 (GPIO 5) — wrong pin
-        harness.on_dir_change(6, 1)
-        harness.on_pin_change(6, 0)
-        time.sleep(0.001)
-        harness.on_dir_change(6, 0)
-        time.sleep(0.1)
-
-        sensor = harness.sensors[4]
-        self.assertFalse(sensor['saw_low'])
-        self.assertFalse(sensor['responding'])
-        self.assertEqual(len(harness.lib.pin_events), 0)
-
-    def test_dir_change_input_before_output(self):
-        """Dir change to INPUT before OUTPUT should be ignored (no dir_out_ns)."""
-        harness = DHT22SimulatorHarness()
-        harness.register_sensor(4, 'dht22', temperature=28.0, humidity=65.0)
-
-        # Skip OUTPUT, go straight to INPUT after a LOW
-        harness.on_pin_change(5, 0)     # LOW → saw_low=True
-        harness.on_dir_change(5, 0)     # INPUT → triggers (saw_low=True)
-
-        time.sleep(0.5)
-
-        sensor = harness.sensors[4]
-        # It should still trigger (saw_low was True)
-        events = harness.lib.pin_events
-        if events:
-            print(f'  Triggered without prior OUTPUT: {len(events)} pin events')
-            print('  ⚠ NOTE: Ratio will be near-zero because dir_out_ns is missing. '
-                  'This could produce invalid timing.')
-
-    def test_slot_to_gpio_consistency(self):
-        """Verify slot = gpio + 1 mapping in response matches on_dir_change."""
-        harness = DHT22SimulatorHarness()
-        harness.register_sensor(4, 'dht22', temperature=28.0, humidity=65.0)
-
-        harness.on_dir_change(5, 1)
-        harness.on_pin_change(5, 0)
-        time.sleep(0.001)
-        harness.on_pin_change(5, 1)
-        time.sleep(0.00005)
-        harness.on_dir_change(5, 0)
-        time.sleep(0.5)
-
-        events = harness.lib.pin_events
-        if events:
-            # All events should be on slot 5 (gpio 4 + 1)
-            slots = {e[1] for e in events}
-            self.assertEqual(slots, {5},
-                             f'All pin drives should be on slot 5, got slots: {slots}')
-            print(f'  All {len(events)} drives on slot 5 (GPIO 4): CONSISTENT ✓')
-
-
-class TestBusyWaitAccuracy(unittest.TestCase):
-    """Verify busy_wait_us accuracy on this system."""
-
-    @unittest.skipIf(
-        __import__('os').environ.get('CI') == 'true',
-        'Timing-sensitive test (busy-wait absolute duration) — skipped in CI'
-    )
-    def test_busy_wait_100us(self):
-        t0 = time.perf_counter_ns()
-        busy_wait_us(100)
-        elapsed_us = (time.perf_counter_ns() - t0) / 1000
-        print(f'\n  busy_wait_us(100): actual={elapsed_us:.0f}µs (expected ~100µs)')
-        self.assertGreater(elapsed_us, 50, 'Way too fast')
-        self.assertLess(elapsed_us, 500, 'Way too slow')
-
-    @unittest.skipIf(
-        __import__('os').environ.get('CI') == 'true',
-        'Timing-sensitive test (busy-wait absolute duration) — skipped in CI'
-    )
-    def test_busy_wait_1us(self):
-        t0 = time.perf_counter_ns()
-        busy_wait_us(1)
-        elapsed_us = (time.perf_counter_ns() - t0) / 1000
-        print(f'\n  busy_wait_us(1): actual={elapsed_us:.0f}µs')
-        self.assertLess(elapsed_us, 100, 'Way too slow for 1µs wait')
-
-    def test_perf_counter_resolution(self):
-        """Check time.perf_counter_ns() resolution."""
-        samples = []
-        for _ in range(100):
-            t0 = time.perf_counter_ns()
-            t1 = time.perf_counter_ns()
-            if t1 > t0:
-                samples.append(t1 - t0)
-        if samples:
-            avg_ns = sum(samples) / len(samples)
-            print(f'\n  perf_counter_ns resolution: ~{avg_ns:.0f}ns '
-                  f'(min={min(samples)}ns, max={max(samples)}ns)')
+        p = dht22_payload(99.9, 99.9)
+        self.assertEqual(p[4], sum(p[:4]) & 0xFF)
+
+    def test_phase_shape(self):
+        ph = dht22_phases(dht22_payload(28.0, 55.0))
+        self.assertEqual(len(ph), 2 + 80 + 1)
+        self.assertEqual(ph[0], (0, RESPONSE_LOW_US))
+        self.assertEqual(ph[1], (1, RESPONSE_HIGH_US))
+        self.assertEqual(ph[2], (0, BIT_LOW_US))
+        highs = {ph[i][1] for i in range(3, 83, 2)}
+        self.assertEqual(highs, {BIT0_HIGH_US, BIT1_HIGH_US})
+
+    def test_coerce_number(self):
+        self.assertEqual(coerce_number('28', 25.0), 28.0)
+        self.assertEqual(coerce_number(' 55.5 ', 50.0), 55.5)
+        self.assertEqual(coerce_number(None, 25.0), 25.0)
+        self.assertEqual(coerce_number('abc', 25.0), 25.0)
+        self.assertEqual(coerce_number(True, 25.0), 25.0)
+        self.assertEqual(coerce_number(30, 25.0), 30.0)
+
+
+# ── trigger: both release idioms ─────────────────────────────────────────────
+
+class TestTrigger(unittest.TestCase):
+    def test_open_drain_release_arms(self):
+        t = Dht22Trigger()
+        self.assertFalse(t.on_write(1))          # od_high before the start
+        self.assertFalse(t.on_write(0))          # start signal
+        self.assertTrue(t.on_write(1))           # release by writing a 1
+        self.assertFalse(t.on_write(1))          # armed once
+
+    def test_push_pull_release_arms(self):
+        t = Dht22Trigger()
+        self.assertFalse(t.on_direction(True))   # pinMode(OUTPUT)
+        self.assertFalse(t.on_write(0))
+        self.assertTrue(t.on_direction(False))   # pinMode(INPUT_PULLUP)
+        self.assertFalse(t.on_direction(False))
+
+    def test_write_high_then_input_arms_once(self):
+        """SimpleDHT-style: digitalWrite(HIGH) then pinMode(INPUT)."""
+        t = Dht22Trigger()
+        t.on_write(0)
+        self.assertTrue(t.on_write(1))
+        self.assertFalse(t.on_direction(False))
+
+    def test_input_without_low_does_not_arm(self):
+        t = Dht22Trigger()
+        self.assertFalse(t.on_direction(False))
+        self.assertFalse(t.on_write(1))
+
+
+# ── the reply under both drivers ─────────────────────────────────────────────
+
+class TestReplyDecodes(unittest.TestCase):
+    DENSE = (0.45, 0.9, 1.8)          # -icount shift 3, 4, 5: guest-time reads
+    SPARSE = (36.0, 70.0, 120.0)      # no -icount: host-time reads
+
+    def test_micropython_decodes_under_icount(self):
+        for gap in self.DENSE:
+            reply, pad, clock = make_reply()
+            got = run_guest(reply, pad, clock, MicroPythonDht(), 10.0, gap)
+            self.assertEqual(got, EXPECTED, f'gap {gap}')
+            self.assertEqual(reply.stalls, 0)
+
+    def test_adafruit_decodes_under_icount(self):
+        for gap in self.DENSE:
+            reply, pad, clock = make_reply()
+            got = run_guest(reply, pad, clock, AdafruitDht(), 55.0, gap)
+            self.assertEqual(got, EXPECTED, f'gap {gap}')
+
+    def test_adafruit_decodes_at_host_time_read_spacing(self):
+        """Without -icount every gap hits the cap: the frame is a fixed number
+        of reads per phase, whatever the host is doing."""
+        for gap in self.SPARSE:
+            reply, pad, clock = make_reply()
+            dec = AdafruitDht()
+            got = run_guest(reply, pad, clock, dec, 55.0, gap)
+            self.assertEqual(got, EXPECTED, f'gap {gap}')
+            # One read per credited cap: the counts are the phase lengths in
+            # caps (the guest sees the edge on the read that ends the phase).
+            lows = dec.pulses[2::2]
+            highs = dec.pulses[3::2]
+            self.assertEqual(len(set(lows)), 1, lows)
+            self.assertAlmostEqual(lows[0], BIT_LOW_US / STALL_CAP_US, delta=1)
+            for h in highs:
+                self.assertTrue(abs(h - BIT0_HIGH_US / STALL_CAP_US) <= 1
+                                or abs(h - BIT1_HIGH_US / STALL_CAP_US) <= 1, h)
+
+    def test_micropython_timing_is_the_datasheet(self):
+        reply, pad, clock = make_reply()
+        dec = MicroPythonDht()
+        run_guest(reply, pad, clock, dec, 10.0, 0.45)
+        # Reconstruct HIGH lengths off the recorded edges.
+        edges = pad.edges
+        highs, start = [], None
+        for t, lvl in edges:
+            if lvl == 1 and start is None:
+                start = t
+            elif lvl == 0 and start is not None:
+                highs.append(round(t - start, 1))
+                start = None
+        self.assertAlmostEqual(highs[0], RESPONSE_HIGH_US, delta=1.0)
+        for h in highs[1:41]:
+            self.assertTrue(abs(h - BIT0_HIGH_US) <= 1.0 or abs(h - BIT1_HIGH_US) <= 1.0, h)
+
+    def test_stall_is_credited_at_the_cap(self):
+        """A host stall between two reads moves the phase clock by the cap only,
+        so the read-counting driver still decodes; the timing driver sees the
+        stall on its own clock and times out, then decodes a fresh frame."""
+        reply, pad, clock = make_reply()
+        got = run_guest(reply, pad, clock, AdafruitDht(), 55.0, 36.0, stall_at_read=40, stall_us=3000.0)
+        self.assertEqual(got, EXPECTED)
+        self.assertEqual(reply.stalls, len(reply.gaps_us))   # every sparse gap is a "stall"
+
+        reply, pad, clock = make_reply()
+        got = run_guest(reply, pad, clock, MicroPythonDht(), 10.0, 0.45, stall_at_read=400, stall_us=150.0)
+        self.assertEqual(got, 'timeout')
+        self.assertEqual(reply.stalls, 1)
+        reply2, pad2, clock2 = make_reply()
+        self.assertEqual(run_guest(reply2, pad2, clock2, MicroPythonDht(), 10.0, 0.45), EXPECTED)
+
+    def test_first_edge_waits_for_the_first_read(self):
+        reply, pad, clock = make_reply()
+        self.assertEqual(pad.level, 1)
+        self.assertEqual(reply.phase, -1)
+        reply.step()
+        self.assertEqual(pad.level, 0)
+        self.assertEqual(reply.phase, 0)
+
+    def test_settle_releases_the_tail(self):
+        """Adafruit returns on the last falling edge and never reads again: the
+        tail LOW stays on the pad until the settle timer releases it."""
+        reply, pad, clock = make_reply()
+        run_guest(reply, pad, clock, AdafruitDht(), 55.0, 36.0)
+        self.assertFalse(reply.done)
+        self.assertEqual(pad.level, 0)
+        self.assertTrue(reply.settle())
+        self.assertTrue(reply.done)
+        self.assertEqual(pad.level, 1)
+        self.assertFalse(reply.settle())
+        self.assertTrue(reply.step())        # a late read changes nothing
+
+    def test_settle_before_any_read_is_a_no_op(self):
+        reply, pad, clock = make_reply()
+        self.assertFalse(reply.settle())
+        self.assertEqual(pad.level, 1)
+
+    def test_diag_reports_reads_and_gaps(self):
+        reply, pad, clock = make_reply()
+        run_guest(reply, pad, clock, MicroPythonDht(), 10.0, 0.9)
+        d = reply.diag()
+        self.assertGreater(d['reads'], 3000)
+        self.assertAlmostEqual(d['gap_p50_us'], 0.9, delta=0.01)
+        self.assertEqual(d['stalls'], 0)
+
+
+# ── run policy ───────────────────────────────────────────────────────────────
+
+class TestIcountPolicy(unittest.TestCase):
+    DHT = [{'sensor_type': 'dht22', 'pin': 15}]
+
+    def test_c3_always(self):
+        self.assertEqual(icount_shift_for_run('esp32c3-picsimlab', True, [], False), ICOUNT_SHIFT_C3)
+
+    def test_micropython_with_line_sensor(self):
+        self.assertEqual(icount_shift_for_run('esp32-picsimlab', False, self.DHT, True), ICOUNT_SHIFT_LINE_SENSORS)
+        self.assertEqual(icount_shift_for_run('esp32s3-picsimlab', False, [{'sensor_type': 'hc-sr04', 'pin': 5}], True), ICOUNT_SHIFT_LINE_SENSORS)
+
+    def test_arduino_keeps_host_time(self):
+        self.assertIsNone(icount_shift_for_run('esp32-picsimlab', False, self.DHT, False))
+
+    def test_wifi_keeps_host_time(self):
+        self.assertIsNone(icount_shift_for_run('esp32-picsimlab', True, self.DHT, True))
+
+    def test_no_line_sensor_keeps_host_time(self):
+        self.assertIsNone(icount_shift_for_run('esp32-picsimlab', False, [{'sensor_type': 'ssd1306', 'pin': 200}], True))
+        self.assertIsNone(icount_shift_for_run('esp32-picsimlab', False, [], True))
+
+
+class TestFirmwareIsMicroPython(unittest.TestCase):
+    def test_banner_string(self):
+        self.assertTrue(firmware_is_micropython(b'\xff' * 100 + b'MicroPython v1.28.0 on 2026-04-06; Generic ESP32 module with ESP32' + b'\x00' * 100))
+
+    def test_arduino_image(self):
+        self.assertFalse(firmware_is_micropython(b'\xe9\x06\x02\x20' + b'\x00' * 4096 + b'Failed to read from DHT sensor!'))
+        self.assertFalse(firmware_is_micropython(b''))
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main()


### PR DESCRIPTION
Fixes #291.

## What was wrong

The backend QEMU worker (the ESP32 path of every self-hosted image, and of `?esp32sim=qemu` on velxio.dev) armed a DHT22 reply only when the firmware switched the data pin to INPUT after holding it LOW. That is how Adafruit's DHT.h ends the start signal. MicroPython's `dht` driver never changes direction: the pin is open-drain for the whole transaction and the release is `gpio_set_level(pin, 1)`. The worker saw the LOW and then nothing, so `measure()` raised `ETIMEDOUT` on every call, exactly the log in the issue. velxio.dev runs MicroPython on the in-browser engine, whose line hub already knows both release idioms, which is why the same example works there.

Two more things stood in the way once the reply was armed:

- The frame was paced by counting the guest's GPIO reads, which is what DHT.h measures. MicroPython times each pulse in microseconds (`machine_time_pulse_us`, 100 us timeout per phase, a '1' is a HIGH over 48 us). Without `-icount` this guest reads a GPIO every 40 to 90 us of host time (each read exits into a Python callback), so a 26 us pulse cannot be observed at all, whatever the worker does.
- QEMU copies GPIO_OUT into GPIO_IN after it runs the write callback, so a level driven from inside that callback (the open-drain release) was overwritten before the guest could read it.

## What changes

- `esp32_dht22.py`: the reply as a model. `Dht22Trigger` accepts both release idioms. Phases are the datasheet figures in guest microseconds read off `qemu_clock_get_ns` at every guest read, with a 2 us credit cap per read: under `-icount` reads are ~0.9 us apart and the phase clock is guest time; on host time every gap hits the cap and the frame becomes a read-counted one (40/40/25/11/35 reads) that DHT.h decodes and no host stall can disturb. The first edge waits for the first read after the release.
- `-icount 4` for a MicroPython run with a line sensor (`dht22`, `hc-sr04`) and no WiFi, decided at launch from the flash image (the REPL banner string; MicroPython's app descriptor carries no project name). Arduino runs keep the fast boot and the count-paced frame. WiFi runs keep `-icount` off (#260) and the worker logs that a pulse-timing driver will time out.
- HC-SR04 echo timed on the guest clock instead of `perf_counter`, so it is right under `-icount` as well.
- A settle timer releases the tail LOW a read-counting driver leaves on the pad, keyed on the guest going quiet (reads), not on host time.
- `temperature` / `humidity` coerced with a default, so a string value cannot raise inside a QEMU callback.

## Measured on the real worker and libqemu (headless, same image as the GHCR one)

| run | before | after |
|---|---|---|
| MicroPython DHT22 example (`100d-temperature-based-led-indicator-micropython-esp32`) | ETIMEDOUT forever | 28.0 C / 55.0 %, 21/21 frames over 75 s |
| MicroPython HC-SR04 example (distance 40) | not tested | 39.86 to 39.88 cm |
| Arduino DHT.h DHT22 | works | works, 17/17 reads, boot unchanged (7 s) |
| Arduino `pulseIn` HC-SR04 (distance 40) | 32 to 42 cm | 32 to 42 cm (unchanged) |
| MicroPython boot with a line sensor | 7 s | 20 s (`-icount 4`; 35 s at shift 3, and shift 5 flipped a bit) |

`pytest test/backend/unit/` 488 passed. `test_dht22_worker.py` now tests the module with a MicroPython-style and an Adafruit-style guest instead of a copy of the old closures.

## Known limits

- A DHT22 wired onto a MicroPython board while it is already running gets no `-icount`; it is honoured at the next Run.
- MicroPython on the ESP32-S3 QEMU machine does not boot at all (the S3 firmware aborts on PSRAM init), before and after this change.
- A MicroPython run that also uses WiFi keeps host time, so its DHT22 still times out; the worker says so in its log.
