### PR TITLE
fix(spice): pro boards keep their logic voltage on GPIO sources; no rebuild per serial line

### DIFF
--- a/frontend/src/__tests__/circuit-simulation-service.test.ts
+++ b/frontend/src/__tests__/circuit-simulation-service.test.ts
@@ -202,6 +202,41 @@ describe('CircuitSimulationService — orchestration', () => {
     expect(fake.calls.solve.length).toBe(1);
   });
 
+  it('does NOT re-solve when a board only appended serial output', async () => {
+    // The serial batcher rewrites `boards` once per frame with a longer
+    // serialOutput. An ESP32 printing a line per GPIO write used to pay one
+    // full rebuild+solve per edge for that (rebuildCount climbing in step with
+    // edgeCount on velxio.dev, 2026-09-05).
+    const fake = new FakeSolverAdapter({ vectors: { 'v(vcc_rail)': 5 } });
+    __setSchedulerSolverFactoryForTests(() => fake);
+    const sim = makeSimStore(simpleBoardWithBoard);
+    const elec = makeElectricalStore();
+    const service = new CircuitSimulationService(
+      sim.port,
+      elec.port,
+      getMixedModeScheduler() as unknown as MixedModeSchedulerPort,
+      { collectBoardPinStates: () => ({}) },
+    );
+    startTracked(service);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(service.rebuildCount).toBe(1);
+
+    sim.set({ boards: [{ id: 'uno', boardKind: 'arduino-uno', serialOutput: 'H\n' } as never] });
+    sim.set({ boards: [{ id: 'uno', boardKind: 'arduino-uno', serialOutput: 'H\nL\n' } as never] });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(fake.calls.solve.length).toBe(1);
+    expect(service.rebuildCount).toBe(1);
+
+    // Stop resets every pin, so a running flip must still rebuild.
+    sim.set({ boards: [{ id: 'uno', boardKind: 'arduino-uno', running: true } as never] });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(service.rebuildCount).toBe(2);
+    // A kind change rebuilds too.
+    sim.set({ boards: [{ id: 'uno', boardKind: 'arduino-nano', running: true } as never] });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(service.rebuildCount).toBe(3);
+  });
+
   it('coalesces solves when one is in flight', async () => {
     const fake = new FakeSolverAdapter({
       vectors: { 'v(vcc_rail)': 5 },

--- a/frontend/src/__tests__/collect-pin-states-pro-board.test.ts
+++ b/frontend/src/__tests__/collect-pin-states-pro-board.test.ts
@@ -1,0 +1,51 @@
+/**
+ * A GPIO V-source for a board the OSS pin-group table does not know (an
+ * overlay board registered through proBoardRegistry, e.g. a pro XIAO) must be
+ * stamped at THAT board's logic voltage. collectPinStates indexed
+ * BOARD_PIN_GROUPS directly and fell back to the 5 V default, so a 3.3 V pro
+ * board's HIGH pin read 5.000 V on a voltmeter and over-drove its LED after
+ * every netlist rebuild, while the edge path altered the same source at 3.3 V
+ * (velxio.dev, XIAO ESP32S3 Sense, 2026-09-05).
+ */
+import { describe, it, expect } from 'vitest';
+import { registerProBoards } from '../lib/proBoardRegistry';
+import { boardPinGroupFor } from '../simulation/spice/boardPinGroups';
+import { collectPinStates, pinNameToArduinoPin } from '../simulation/spice/collectPinStates';
+import { useSimulatorStore, getBoardPinManager } from '../store/useSimulatorStore';
+import type { BoardKind } from '../types/board';
+
+const KIND = 'test-pro-3v3-board';
+
+registerProBoards([
+  {
+    kind: KIND,
+    label: 'Test 3V3',
+    fqbn: 'x:y:z',
+    description: '',
+    tag: 'velxio-test-board',
+    size: { w: 10, h: 10 },
+    render: () => null as never,
+    pinToNumber: (p: string) => (p === 'D7' ? 44 : p === 'GND' || p === '3V3' || p === '5V' ? -1 : null),
+    power: { vcc: 3.3, gnd: ['GND'], vcc_pins: ['3V3'], aux: { volts: 5, pins: ['5V'] } },
+  } as never,
+]);
+
+describe('collectPinStates on a pro board with its own rails', () => {
+  it('resolves the registry power, not the 5 V default', () => {
+    expect(boardPinGroupFor(KIND).vcc).toBe(3.3);
+    expect(pinNameToArduinoPin('D7', KIND as BoardKind)).toBe(44);
+    expect(pinNameToArduinoPin('3V3', KIND as BoardKind)).toBe(-1);
+  });
+
+  it('stamps a HIGH GPIO at 3.3 V', () => {
+    const boardId = 'xiao-test';
+    useSimulatorStore.getState().addBoard(KIND as BoardKind, 0, 0, boardId);
+    const pm = getBoardPinManager(boardId)!;
+    pm.triggerPinChange(44, true, 'mcu');
+    const states = collectPinStates(boardId, KIND as BoardKind, [
+      { start: { componentId: boardId, pinName: 'D7' }, end: { componentId: 'led', pinName: 'A' } },
+    ]);
+    expect(states['D7']).toEqual({ type: 'digital', v: 3.3 });
+    useSimulatorStore.getState().removeBoard(boardId);
+  });
+});

--- a/frontend/src/components/DynamicComponent.tsx
+++ b/frontend/src/components/DynamicComponent.tsx
@@ -33,7 +33,7 @@ import {
   configFromLogicFamily,
   type PinResolver,
 } from '../simulation/PinResolver';
-import { BOARD_PIN_GROUPS } from '../simulation/spice/boardPinGroups';
+import { boardPinGroupFor } from '../simulation/spice/boardPinGroups';
 import { traceDetailed } from '../simulation/PinTrace';
 import { withPartPinOwnership, releasePartPins } from '../simulation/partPinOwnership';
 import { getMixedModeScheduler } from '../simulation/spice/MixedModeScheduler';
@@ -610,7 +610,7 @@ export const DynamicComponent: React.FC<DynamicComponentProps> = ({
       const ownerBoard =
         simState.boards.find((b) => b.id === simState.activeBoardId) ?? null;
       const ownerBoardVcc =
-        (ownerBoard && BOARD_PIN_GROUPS[ownerBoard.boardKind as keyof typeof BOARD_PIN_GROUPS]?.vcc) ?? 5;
+        (ownerBoard && boardPinGroupFor(ownerBoard.boardKind).vcc) ?? 5;
       const getPinResolver = (componentPinName: string): PinResolver | null => {
         const state = useSimulatorStore.getState();
         const pinManager = (stubSimulator as {

--- a/frontend/src/components/components-instruments/Voltmeter.tsx
+++ b/frontend/src/components/components-instruments/Voltmeter.tsx
@@ -12,7 +12,7 @@ import { InstrumentScreen } from './InstrumentScreen';
 import { useElectricalStore } from '../../store/useElectricalStore';
 import { useSimulatorStore } from '../../store/useSimulatorStore';
 import { buildPinNetLookup, readVoltmeter } from '../../simulation/spice/probes';
-import { BOARD_PIN_GROUPS } from '../../simulation/spice/boardPinGroups';
+import { boardPinGroupFor } from '../../simulation/spice/boardPinGroups';
 
 /** Instrument tint. Amber for volts, cyan for amps: the same pairing the
  *  canvas legend and the picker thumbnails use. */
@@ -33,13 +33,13 @@ export function Voltmeter({ id }: VoltmeterProps) {
 
   const reading = useMemo(() => {
     const groundPins = boards.flatMap((b) =>
-      (BOARD_PIN_GROUPS[b.boardKind] ?? BOARD_PIN_GROUPS.default).gnd.map((pin) => ({
+      boardPinGroupFor(b.boardKind).gnd.map((pin) => ({
         componentId: b.id,
         pinName: pin,
       })),
     );
     const vccPins = boards.flatMap((b) =>
-      (BOARD_PIN_GROUPS[b.boardKind] ?? BOARD_PIN_GROUPS.default).vcc_pins.map((pin) => ({
+      boardPinGroupFor(b.boardKind).vcc_pins.map((pin) => ({
         componentId: b.id,
         pinName: pin,
       })),
@@ -47,7 +47,7 @@ export function Voltmeter({ id }: VoltmeterProps) {
     // Aux-rail pins (VIN / 5V / off-voltage 3V3) so probing them reads the
     // rail's own voltage — and so the n0/n1 numbering matches the solver's.
     const auxPins = boards.flatMap((b) => {
-      const aux = (BOARD_PIN_GROUPS[b.boardKind] ?? BOARD_PIN_GROUPS.default).aux;
+      const aux = boardPinGroupFor(b.boardKind).aux;
       if (!aux) return [];
       return aux.pins.map((pin) => ({ componentId: b.id, pinName: pin, volts: aux.volts }));
     });

--- a/frontend/src/simulation/probeResolve.ts
+++ b/frontend/src/simulation/probeResolve.ts
@@ -27,7 +27,7 @@
 import type { Wire, WireEndpoint } from '../types/wire';
 import type { BoardInstance } from '../types/board';
 import { boardPinToNumber } from '../utils/boardPinMapping';
-import { BOARD_PIN_GROUPS } from './spice/boardPinGroups';
+import { boardPinGroupFor } from './spice/boardPinGroups';
 import { traceDetailed, type TraceState } from './PinTrace';
 import { ADC_PIN_MAP } from './spice/connectAnalogInputsToMcu';
 
@@ -68,7 +68,7 @@ function boardOf(ctx: ProbeContext, componentId: string): BoardInstance | undefi
 }
 
 function vccOf(board: BoardInstance): number {
-  return (BOARD_PIN_GROUPS[board.boardKind] ?? BOARD_PIN_GROUPS.default).vcc;
+  return boardPinGroupFor(board.boardKind).vcc;
 }
 
 /**

--- a/frontend/src/simulation/spice/CircuitSimulationService.ts
+++ b/frontend/src/simulation/spice/CircuitSimulationService.ts
@@ -39,7 +39,7 @@ export interface SimulatorStorePort {
       start: { componentId: string; pinName: string };
       end: { componentId: string; pinName: string };
     }>;
-    boards: Array<{ id: string; boardKind: string; pinStates?: Record<string, unknown> }>;
+    boards: Array<{ id: string; boardKind: string; running?: boolean; pinStates?: Record<string, unknown> }>;
     /** Components destroyed at runtime (P4) — excluded from the netlist so a
      *  burnt part actually goes open. Optional for non-store ports. */
     burntComponents?: Set<string>;
@@ -110,6 +110,32 @@ export interface ServiceOptions {
   ) => Record<string, unknown>;
 }
 
+/**
+ * The netlist reads three things from a board: its id, its kind, and its
+ * pin states, and the last are collected from the PinManager at solve time,
+ * not from the store slice. So a new `boards` array only warrants a rebuild
+ * when a board was added, removed, changed kind, or started/stopped (Stop
+ * resets every pin, so the V-sources must go). Everything else that rewrites
+ * the slice, above all the per-frame serial batcher appending `serialOutput`
+ * to the board object, must NOT: on an ESP32 printing a line per GPIO write
+ * that was one full rebuild+solve per edge, measured at rebuildCount climbing
+ * in step with edgeCount, and each rebuild re-stamped the sources from
+ * scratch instead of the cheap in-place alter.
+ */
+export function boardsChangedForNetlist(
+  next: ReadonlyArray<{ id: string; boardKind: string; running?: boolean }>,
+  prev: ReadonlyArray<{ id: string; boardKind: string; running?: boolean }>,
+): boolean {
+  if (next === prev) return false;
+  if (next.length !== prev.length) return true;
+  for (let i = 0; i < next.length; i++) {
+    const a = next[i]!;
+    const b = prev[i]!;
+    if (a.id !== b.id || a.boardKind !== b.boardKind || !!a.running !== !!b.running) return true;
+  }
+  return false;
+}
+
 export class CircuitSimulationService {
   /**
    * The last REAL transient capture published, kept so a DC re-solve on a
@@ -147,6 +173,14 @@ export class CircuitSimulationService {
     analysisKind: 'op' | 'tran' | 'ac';
     sourcedNets: Set<string>;
   } | null = null;
+
+  /** Diagnostics read by `__spiceDebug()`: how many full netlist rebuilds
+   *  and how many in-place source alters this service has run. A meter that
+   *  flips between two supply voltages, or a pin that seems to ignore its
+   *  edges, is usually one of these counters climbing when it should not. */
+  rebuildCount = 0;
+  edgeCount = 0;
+  lastRebuildAt = 0;
 
   /** Set by `stop()`. Once true, `tick()` and `handleMcuEdge()`
    *  short-circuit so a service whose owner has unsubscribed can't
@@ -340,6 +374,7 @@ export class CircuitSimulationService {
       // alter + resolveDc internally; the scheduler's
       // onMcuPinChange covers both steps.
       await this.scheduler.onMcuPinChange(boardId, pinName, state, vcc);
+      this.edgeCount++;
       this.publishFromLastResult();
     } catch (err) {
       // eslint-disable-next-line no-console
@@ -356,6 +391,8 @@ export class CircuitSimulationService {
   }
 
   private async runSolve(): Promise<void> {
+    this.rebuildCount++;
+    this.lastRebuildAt = Date.now();
     const state = this.simStore.getState();
     // P4: a runtime-destroyed part is excluded from the netlist so it actually
     // goes open — its current stops and anything it fed loses power (cascading
@@ -492,7 +529,7 @@ export class CircuitSimulationService {
       if (
         n.components !== p.components ||
         n.wires !== p.wires ||
-        n.boards !== p.boards ||
+        boardsChangedForNetlist(n.boards, p.boards) ||
         // P4: a part burning out (or a Reset un-burning it) changes which
         // components are in the netlist, so re-solve to apply the open.
         n.burntComponents !== p.burntComponents

--- a/frontend/src/simulation/spice/collectPinStates.ts
+++ b/frontend/src/simulation/spice/collectPinStates.ts
@@ -12,7 +12,7 @@ import type { PinSourceState } from './types';
 import type { BoardKind } from '../../types/board';
 import { isStm32BoardKind } from '../../types/board';
 import { stm32PinNameToLinear } from '../Stm32Bridge';
-import { BOARD_PIN_GROUPS } from './boardPinGroups';
+import { boardPinGroupFor } from './boardPinGroups';
 import { boardPinToNumber } from '../../utils/boardPinMapping';
 
 /**
@@ -26,7 +26,13 @@ import { boardPinToNumber } from '../../utils/boardPinMapping';
  * detaches every listener on resubscription and freezes LEDs mid-run.
  */
 export function pinNameToArduinoPin(pinName: string, boardKind: BoardKind): number {
-  const group = BOARD_PIN_GROUPS[boardKind] ?? BOARD_PIN_GROUPS.default;
+  // boardPinGroupFor, not BOARD_PIN_GROUPS[kind]: an overlay board (a pro XIAO)
+  // is not in that table and declares its rails through the registry instead.
+  // Indexing the table directly fell back to the 5 V default, so every GPIO
+  // V-source the netlist stamped for a 3.3 V pro board read 5 V on a meter
+  // and over-drove its LEDs (velxio.dev 2026-09-05), while the edge path
+  // (connectMcuEdgesToService) altered the same source at 3.3 V.
+  const group = boardPinGroupFor(boardKind);
   if (group.gnd.includes(pinName) || group.vcc_pins.includes(pinName)) return -1;
   // Aux-rail supply pins (VIN / 5V / off-voltage 3V3) are not GPIOs either.
   if (group.aux?.pins.includes(pinName)) return -1;
@@ -86,7 +92,7 @@ export function collectPinStates(
 ): Record<string, PinSourceState> {
   const pm = getBoardPinManager(boardId);
   if (!pm) return {};
-  const group = BOARD_PIN_GROUPS[boardKind] ?? BOARD_PIN_GROUPS.default;
+  const group = boardPinGroupFor(boardKind);
   const vcc = group.vcc;
 
   const result: Record<string, PinSourceState> = {};

--- a/frontend/src/simulation/spice/start.ts
+++ b/frontend/src/simulation/spice/start.ts
@@ -157,6 +157,9 @@ export function startSimulation(): () => void {
       hasTimeWaveforms: !!electrical.timeWaveforms,
       paused: electrical.paused,
       outputPinsByBoard,
+      rebuildCount: service.rebuildCount,
+      edgeCount: service.edgeCount,
+      lastRebuildAt: service.lastRebuildAt,
     };
     (window as unknown as { __lastSpice?: unknown }).__lastSpice = snapshot;
     // eslint-disable-next-line no-console


### PR DESCRIPTION
Follow-up to #292, from tracing a toggling GPIO with a voltmeter and an LED on velxio.dev.

**GPIO sources of overlay boards were stamped at 5 V on every rebuild.** The XIAO ESP32S3 Sense (3.3 V) read 3.300 V after an edge and 5.000 V after any netlist rebuild, LED brightness doubling with it. `collectPinStates` indexed `BOARD_PIN_GROUPS[kind]` and fell back to the 5 V default for a kind that table does not know, while the edge path altered the same source at 3.3 V through `boardPinGroupFor`. Every direct table lookup now goes through `boardPinGroupFor` (collectPinStates, probeResolve, DynamicComponent, Voltmeter).

**One full rebuild per serial line.** `rebuildCount` climbed in step with `edgeCount`: the per-frame serial batcher rewrites `boards` with a longer `serialOutput`, and the service re-solved on any new boards array. The netlist reads only id, kind and the pin states it collects at solve time, so the service now rebuilds on add/remove/kind change/running flip and ignores the rest.

`__spiceDebug()` now reports `rebuildCount`, `edgeCount`, `lastRebuildAt`.

Verified on a local build against the production backend: XIAO D7 reads 3.3/0 V across edges with the rebuild counter flat; ESP32 devkit pad 2 the same. Tests: `collect-pin-states-pro-board`, a new case in `circuit-simulation-service`; full suite green (2848 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)