### PR TITLE
fix(spice): voltmeter on ground still says "solver error" during a dead solve

### DIFF
--- a/frontend/src/__tests__/probe-no-solution.test.ts
+++ b/frontend/src/__tests__/probe-no-solution.test.ts
@@ -58,6 +58,16 @@ describe('probes with no operating point', () => {
     expect(r.stale).toBe(false);
   });
 
+  it('voltmeter: both leads on ground during a dead solve is still "solver error"', () => {
+    const gnd = () => '0';
+    const r = readVoltmeter(vm, gnd, solve({
+      converged: false,
+      error: 'Fatal error: instance v_sg is a shorted VSRC',
+    }));
+    expect(r.display).toBe(SOLVER_ERROR_DISPLAY);
+    expect(r.stale).toBe(true);
+  });
+
   it('voltmeter: ground is a reported 0 V, not a missing net', () => {
     const gnd = (_c: string, pin: string) => (pin === 'V+' ? 'n0' : '0');
     const r = readVoltmeter(vm, gnd, solve({ nodeVoltages: { n0: 3.3 } }));

--- a/frontend/src/simulation/spice/probes.ts
+++ b/frontend/src/simulation/spice/probes.ts
@@ -205,6 +205,15 @@ export function readVoltmeter(
   // yet. Printing "0.00 µV" there looks like a measurement — the 2026-09-05
   // report was a 9 V cell "reading 0 V" while the whole canvas was unsolved
   // because a regulator output was wired into the board's 5V pin.
+  // Both probe nets on ground still "read 0 V" through nodeVoltageOf, and on a
+  // dead solve that is the one net the solver does not have to report. A
+  // signal generator wired onto its own GND (ngspice: "shorted VSRC") put the
+  // meter on ground with an error in the store and it printed 0.00 uV again
+  // (velxio.dev, 2026-09-06). No voltages at all plus an error is a dead
+  // solve whatever the probe touches.
+  if (solve.error && Object.keys(solve.nodeVoltages).length === 0) {
+    return noReading('voltmeter', solve);
+  }
   const vp = nodeVoltageOf(solve, plusNet);
   const vm = nodeVoltageOf(solve, minusNet);
   if (vp === undefined || vm === undefined) return noReading('voltmeter', solve);


### PR DESCRIPTION
Found while checking #295 on velxio.dev: a signal generator wired onto its own GND gives ngspice's `instance v_sg is a shorted VSRC`, the console shows the new message, but a voltmeter across that net still printed `0.00 uV`. Both leads sat on ground, the one net `nodeVoltageOf` answers without the solver. An error in the store with no node voltages at all is a dead solve whatever the probe touches, so the meter now shows `— solver error` first. One test added.
