### PR TITLE
feat(sd-card): visible way into the SD panel, inspector opens while running

### DIFF
--- a/frontend/src/__tests__/sd-card-gate.test.ts
+++ b/frontend/src/__tests__/sd-card-gate.test.ts
@@ -56,4 +56,19 @@ describe('proSdCardGate', () => {
     expect(events[0].type).toBe('velxio-pro-upgrade-prompt');
     expect(events[0].detail.componentName).toContain('microSD');
   });
+
+  it('names the plan that unlocks it and the free path, so the modal answers', () => {
+    const events: Array<{ detail: { requiredPlan?: string; description?: string } }> = [];
+    vi.stubGlobal('window', {
+      dispatchEvent: (e: { detail: { requiredPlan?: string; description?: string } }) => {
+        events.push(e);
+        return true;
+      },
+    });
+    triggerSdCardUpgradePrompt();
+    // Any paid plan unlocks the upload: the modal must not claim the top tier.
+    expect(events[0].detail.requiredPlan).toBe('maker');
+    expect(events[0].detail.description).toMatch(/free plan/i);
+    expect(events[0].detail.description).toMatch(/copied onto the card automatically/);
+  });
 });

--- a/frontend/src/__tests__/sd-card-panel-copy.test.ts
+++ b/frontend/src/__tests__/sd-card-panel-copy.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+/**
+ * sd-card-panel-copy.test.ts — the SD panel says, BEFORE any click, whether
+ * this user can upload, and what the free path is when they cannot.
+ *
+ * Background: the panel showed a "Paid" tag and an "Add files" button to
+ * everyone; a free user only learned it was gated after clicking, and was
+ * never told that a data file in the project workspace reaches the card by
+ * itself. Server-rendered on purpose: the copy is a pure function of the
+ * gate, no effects or bridge needed.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { SdCardPanel } from '../components/simulator/SdCardPanel';
+import { installSdCardUploadGate } from '../lib/proSdCardGate';
+
+afterEach(() => installSdCardUploadGate(null));
+
+const render = () =>
+  renderToStaticMarkup(createElement(SdCardPanel, { files: [], onChange: () => {}, boardId: null }));
+
+describe('SdCardPanel copy vs the upload gate', () => {
+  it('OSS / paid: plain "Add files" and the upload hint', () => {
+    installSdCardUploadGate(() => true);
+    const html = render();
+    expect(html).toContain('+ Add files<');
+    expect(html).not.toContain('(paid)');
+    expect(html).toContain('Upload your own files');
+    expect(html).not.toContain('part of the paid plans');
+  });
+
+  it('gated: the button says paid, the hint names the free path', () => {
+    installSdCardUploadGate(() => false);
+    const html = render();
+    expect(html).toContain('+ Add files (paid)');
+    expect(html).toContain('part of the paid plans');
+    // The free alternative, in the same breath.
+    expect(html).toMatch(/copied onto the card\s+automatically/);
+  });
+});

--- a/frontend/src/components/DynamicComponent.tsx
+++ b/frontend/src/components/DynamicComponent.tsx
@@ -64,6 +64,9 @@ interface DynamicComponentProps {
   onMouseDown?: (e: React.MouseEvent) => void;
   /** Right click: the canvas opens the properties + pins dialog here. */
   onContextMenu?: (e: React.MouseEvent) => void;
+  /** The on-canvas shortcut some parts show (the microSD card's "SD files"
+   *  chip) asks the canvas to open the same inspector, left-click, any mode. */
+  onOpenInspector?: (e: React.MouseEvent) => void;
   onDoubleClick?: (e: React.MouseEvent) => void;
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
@@ -80,6 +83,7 @@ export const DynamicComponent: React.FC<DynamicComponentProps> = ({
   isHovered = false,
   onMouseDown,
   onContextMenu,
+  onOpenInspector,
   onDoubleClick,
   onMouseEnter,
   onMouseLeave,
@@ -145,6 +149,11 @@ export const DynamicComponent: React.FC<DynamicComponentProps> = ({
     const t = setTimeout(bumpControlHint, 150);
     return () => clearTimeout(t);
   }, [interactionRunning, metadata.id, chipWasmFingerprint]);
+  // Parts with a file store the inspector manages (metadata.sdSlot marks a
+  // part with its own TF slot, the Round Display; the standalone card is
+  // keyed by id like everywhere else in the SD path).
+  const hasSdShortcut =
+    Boolean(onOpenInspector) && (metadata.id === 'microsd-card' || metadata.sdSlot === true);
   const showControlHint =
     interactionRunning &&
     metadata.id === 'custom-chip' &&
@@ -376,6 +385,12 @@ export const DynamicComponent: React.FC<DynamicComponentProps> = ({
       // the user needs to reach. If a new interactive part is added,
       // append its tag here.
       const target = e.target as HTMLElement;
+      // The part's own shortcut chip (SD files) is a button: it must neither
+      // start a drag nor reach the canvas selection logic.
+      if (target.closest?.('.velxio-part-shortcut')) {
+        e.stopPropagation();
+        return;
+      }
       const tag = target.tagName?.toLowerCase() ?? '';
       const ownsPointer =
         interactionRunning &&
@@ -842,11 +857,45 @@ export const DynamicComponent: React.FC<DynamicComponentProps> = ({
           alignItems: 'center',
           justifyContent: 'center',
           gap: '4px',
-          opacity: isHovered || isSelected ? 1 : 0,
+          opacity: isHovered || isSelected || hasSdShortcut ? 1 : 0,
           transition: 'opacity 120ms ease-out',
         }}
       >
         {properties.pin !== undefined ? `Pin ${properties.pin}` : metadata.name}
+        {/* The card's files live in the inspector, which only a right-click
+            reached: nobody found the upload there. This chip is the visible
+            way in, and it stays up while the simulation runs too (the live
+            "Card contents" listing is most useful then). */}
+        {hasSdShortcut && (
+          <button
+            type="button"
+            className="velxio-part-shortcut"
+            title="Files on the SD card: upload your own, download what the sketch wrote"
+            onClick={onOpenInspector}
+            style={{
+              pointerEvents: 'auto',
+              cursor: 'pointer',
+              fontSize: '10px',
+              fontWeight: 600,
+              lineHeight: '1.2',
+              padding: '2px 7px',
+              borderRadius: '10px',
+              border: '1px solid #0071e3',
+              background: '#0071e3',
+              color: '#fff',
+              whiteSpace: 'nowrap',
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '4px',
+            }}
+          >
+            <svg width="9" height="11" viewBox="0 0 9 11" fill="none" aria-hidden="true">
+              <path d="M3 0.5h5.5v10h-8v-7.5z" stroke="#fff" strokeWidth="1" strokeLinejoin="round" />
+              <path d="M2.5 2.5v2M4.5 2.5v2M6.5 2.5v2" stroke="#fff" strokeWidth="1" />
+            </svg>
+            SD files
+          </button>
+        )}
         {isKeyBindable(metadata.id) && typeof properties.key === 'string' && properties.key && (
           <span
             style={{

--- a/frontend/src/components/simulator/BoardOnCanvas.tsx
+++ b/frontend/src/components/simulator/BoardOnCanvas.tsx
@@ -293,6 +293,45 @@ export const BoardOnCanvas = ({
         title={board.running ? 'Running' : board.compiledProgram ? 'Compiled' : 'Idle'}
       />
 
+      {/* A board with a built-in microSD slot (XIAO Sense, M5Stack Core,
+          Cardputer): the visible way into the SD panel of its inspector,
+          which the right-click alone kept hidden from most people. Opens
+          the same board inspector, in every mode. */}
+      {getProBoard(boardKind)?.builtInSdCsPin !== undefined && onContextMenu && (
+        <button
+          type="button"
+          className="velxio-part-shortcut"
+          title="Files on the board's SD card: upload your own, download what the sketch wrote"
+          onClick={onContextMenu}
+          onMouseDown={(e) => e.stopPropagation()}
+          style={{
+            position: 'absolute',
+            left: x + 4,
+            top: y + size.h + 4,
+            zIndex: 11,
+            cursor: 'pointer',
+            fontSize: '10px',
+            fontWeight: 600,
+            lineHeight: '1.2',
+            padding: '2px 7px',
+            borderRadius: '10px',
+            border: '1px solid #0071e3',
+            background: '#0071e3',
+            color: '#fff',
+            whiteSpace: 'nowrap',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '4px',
+          }}
+        >
+          <svg width="9" height="11" viewBox="0 0 9 11" fill="none" aria-hidden="true">
+            <path d="M3 0.5h5.5v10h-8v-7.5z" stroke="#fff" strokeWidth="1" strokeLinejoin="round" />
+            <path d="M2.5 2.5v2M4.5 2.5v2M6.5 2.5v2" stroke="#fff" strokeWidth="1" />
+          </svg>
+          SD files
+        </button>
+      )}
+
       {/* Drag overlay — hidden during simulation */}
       {!running && (
         <div

--- a/frontend/src/components/simulator/PartInspectorDialog.tsx
+++ b/frontend/src/components/simulator/PartInspectorDialog.tsx
@@ -129,6 +129,11 @@ interface PartInspectorDialogProps {
   previewTagName?: string;
   /** Attributes to set on the preview element (boards need board-kind). */
   previewAttributes?: Record<string, string>;
+  /** The simulation is running: the part can be inspected (pins, datasheet,
+      the SD card's live contents) but not edited. Rotate/Delete are hidden
+      and the property editors are disabled; the canvas already withholds
+      onPinSelect so pins are labels, not wire starts. */
+  readOnly?: boolean;
 }
 
 /**
@@ -160,6 +165,7 @@ export const PartInspectorDialog: React.FC<PartInspectorDialogProps> = ({
   skipDeleteConfirm,
   previewTagName,
   previewAttributes,
+  readOnly = false,
 }) => {
   const { t } = useTranslation();
   const dialogRef = useRef<HTMLDivElement>(null);
@@ -645,6 +651,7 @@ export const PartInspectorDialog: React.FC<PartInspectorDialogProps> = ({
                       <select
                         className="pid-select"
                         value={current}
+                        disabled={readOnly}
                         onChange={(e) => onPropertyChange?.(componentId, prop.name, e.target.value)}
                       >
                         {prop.options.map((opt: string) => (
@@ -663,6 +670,7 @@ export const PartInspectorDialog: React.FC<PartInspectorDialogProps> = ({
                       type={prop.control === 'number' ? 'number' : 'text'}
                       className="pid-input"
                       value={current}
+                      disabled={readOnly}
                       onChange={(e) => onPropertyChange?.(componentId, prop.name, e.target.value)}
                     />
                   </div>
@@ -855,7 +863,7 @@ export const PartInspectorDialog: React.FC<PartInspectorDialogProps> = ({
         <div className="pid-actions">
           {/* Boards pass no onRotate (they do not rotate); they pass
               Board Options / Flash as extraActions instead. */}
-          {onRotate && (
+          {onRotate && !readOnly && (
             <button
               className="pid-action-button"
               onClick={() => onRotate(componentId)}
@@ -875,13 +883,15 @@ export const PartInspectorDialog: React.FC<PartInspectorDialogProps> = ({
               {a.label}
             </button>
           ))}
-          <button
-            className="pid-action-button pid-action-delete"
-            onClick={handleDeleteClick}
-            title={t('editor.componentProps.deleteTitle')}
-          >
-            {deleteLabel ?? t('editor.componentProps.delete')}
-          </button>
+          {!readOnly && (
+            <button
+              className="pid-action-button pid-action-delete"
+              onClick={handleDeleteClick}
+              title={t('editor.componentProps.deleteTitle')}
+            >
+              {deleteLabel ?? t('editor.componentProps.delete')}
+            </button>
+          )}
 
           {/* Buy lives here, right-aligned, so it is reachable from BOTH
               tabs — it used to sit at the end of the datasheet body, which

--- a/frontend/src/components/simulator/SdCardPanel.tsx
+++ b/frontend/src/components/simulator/SdCardPanel.tsx
@@ -46,6 +46,11 @@ function humanSize(n: number): string {
 export const SdCardPanel: React.FC<SdCardPanelProps> = ({ files, onChange, boardId }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const total = files.reduce((s, f) => s + fileBytes(f), 0);
+  // Whether THIS user may upload. Read at render so the panel can say so
+  // before the click: a "Paid" tag alone left people clicking "Add files"
+  // and only then learning it was gated, with no word about the free way
+  // (a data file in the project workspace lands on the card by itself).
+  const canUpload = sdCardUploadAllowed();
 
   // ── Live card contents: what is ON the card right now, including files
   //    the running sketch wrote (photos, logs). Read back from the bridge's
@@ -116,11 +121,19 @@ export const SdCardPanel: React.FC<SdCardPanelProps> = ({ files, onChange, board
       <div className="sd-card-label">
         SD Card files <span className="sd-card-paid">Paid</span>
       </div>
-      {files.length === 0 && (
+      {files.length === 0 && canUpload && (
         <div className="sd-card-hint">
           Upload your own files (images, audio, data). The project's data files
           are added automatically; source files (.ino, .h, .cpp, .py) stay off
           the card.
+        </div>
+      )}
+      {!canUpload && (
+        <div className="sd-card-hint">
+          Uploading your own files (images, audio, data) to the card is part of
+          the paid plans. On the free plan, any data file you add to the project
+          workspace (a .txt, .csv, .json...) is copied onto the card
+          automatically; source files (.ino, .h, .cpp, .py) stay off it.
         </div>
       )}
       {files.map((f) => (
@@ -139,8 +152,12 @@ export const SdCardPanel: React.FC<SdCardPanelProps> = ({ files, onChange, board
         </div>
       ))}
       <div className="sd-card-footer">
-        <button className="sd-card-add" onClick={openPicker}>
-          + Add files
+        <button
+          className="sd-card-add"
+          onClick={openPicker}
+          title={canUpload ? undefined : 'Uploading files to the card needs a paid plan'}
+        >
+          {canUpload ? '+ Add files' : '+ Add files (paid)'}
         </button>
         <span className="sd-card-total">
           {humanSize(total)} / {humanSize(SD_UPLOAD_MAX_BYTES)}

--- a/frontend/src/components/simulator/SimulatorCanvas.tsx
+++ b/frontend/src/components/simulator/SimulatorCanvas.tsx
@@ -494,6 +494,20 @@ export const SimulatorCanvas = ({ headerSlot }: SimulatorCanvasProps = {}) => {
     }
   }, [interactionRunning, setSelectedWire]);
 
+  /**
+   * Open the part inspector on a component, at a VIEWPORT anchor. Shared by
+   * the right-click and the on-canvas shortcut some parts show (the microSD
+   * card's "SD files" chip). Works while the simulation runs too: the dialog
+   * is read-only then, and the edit selection (marching ants) is not touched
+   * because the canvas is interact-only.
+   */
+  const openComponentInspector = (componentId: string, at: { x: number; y: number }) => {
+    if (!interactionRunningRef.current) setSelectedComponentId(componentId);
+    setPropertyDialogComponentId(componentId);
+    setPropertyDialogPosition(at);
+    setShowPropertyDialog(true);
+  };
+
   // Lets the touch handlers (defined in an earlier effect closure) reach the
   // drop-time breadboard seating declared further down.
   const seatDroppedComponentRef = useRef<(componentId: string) => void>(() => {});
@@ -2737,13 +2751,18 @@ export const SimulatorCanvas = ({ headerSlot }: SimulatorCanvasProps = {}) => {
             onContextMenu={(e) => {
               // Right click is where properties and pins live now. Selecting
               // first means the ants mark what the dialog is about to edit.
+              // While the simulation runs the inspector still opens (boards
+              // always did), read-only: no rotate/delete/wiring, but the
+              // datasheet, the pin roles and the SD card's live contents are
+              // exactly what a running circuit makes you want to look at.
               e.preventDefault();
               e.stopPropagation();
-              if (interactionRunning) return;
-              setSelectedComponentId(component.id);
-              setPropertyDialogComponentId(component.id);
-              setPropertyDialogPosition({ x: e.clientX, y: e.clientY });
-              setShowPropertyDialog(true);
+              openComponentInspector(component.id, { x: e.clientX, y: e.clientY });
+            }}
+            onOpenInspector={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              openComponentInspector(component.id, { x: e.clientX, y: e.clientY });
             }}
           />
 
@@ -3660,6 +3679,7 @@ export const SimulatorCanvas = ({ headerSlot }: SimulatorCanvasProps = {}) => {
               position={propertyDialogPosition}
               pinInfo={pinInfo || []}
               wireInProgress={Boolean(wireInProgress)}
+              readOnly={interactionRunning}
               onClose={() => setShowPropertyDialog(false)}
               onRotate={handleRotateComponent}
               onDelete={(id) => {
@@ -3681,7 +3701,7 @@ export const SimulatorCanvas = ({ headerSlot }: SimulatorCanvasProps = {}) => {
                   }
                 }
               }}
-              onPinSelect={(id, pinName) => {
+              onPinSelect={interactionRunning ? undefined : (id, pinName) => {
                 // Resolve world coords the SAME way wires + the pin overlay do,
                 // via calculatePinPosition, which rotates the pin around the
                 // wrapper centre for the component's rotation. The old
@@ -3796,6 +3816,7 @@ export const SimulatorCanvas = ({ headerSlot }: SimulatorCanvasProps = {}) => {
               // boards — it knows the wire count; a second ask here would stack.
               skipDeleteConfirm
               wireInProgress={Boolean(wireInProgress)}
+              readOnly={interactionRunning}
               onClose={() => setBoardContextMenu(null)}
               onPropertyChange={(id, propName, value) => {
                 // The board dialog's only editable "property" is the SD
@@ -3809,7 +3830,7 @@ export const SimulatorCanvas = ({ headerSlot }: SimulatorCanvasProps = {}) => {
                 setBoardContextMenu(null);
                 setBoardToRemove(id);
               }}
-              onPinSelect={(id, pinName) => {
+              onPinSelect={interactionRunning ? undefined : (id, pinName) => {
                 const b = boards.find((x) => x.id === id);
                 const pin = (document.getElementById(id) as any)?.pinInfo?.find(
                   (p: { name: string }) => p.name === pinName,

--- a/frontend/src/lib/proSdCardGate.ts
+++ b/frontend/src/lib/proSdCardGate.ts
@@ -43,7 +43,16 @@ export function triggerSdCardUpgradePrompt(): void {
   if (typeof window === 'undefined') return;
   window.dispatchEvent(
     new CustomEvent('velxio-pro-upgrade-prompt', {
-      detail: { componentName: 'microSD file upload' },
+      detail: {
+        componentName: 'microSD file upload',
+        // Any paid plan unlocks it (not only the top tier), and the free
+        // path exists: say both, so the modal is an answer, not a wall.
+        requiredPlan: 'maker',
+        description:
+          'Uploading your own files (images, audio, data) to the microSD card is ' +
+          'included in every paid plan. On the free plan, data files you add to ' +
+          'the project workspace are copied onto the card automatically.',
+      },
     }),
   );
 }


### PR DESCRIPTION
## Why

The microSD card's file panel (upload your own files, download what the sketch wrote) lived in the part inspector, reachable only by right-click, and that right-click was blocked while the simulation ran. A user with a card on the canvas had no way to discover the panel, that uploading is a paid feature, or that the free path exists (a data file in the workspace is copied onto the card). Boards with a built-in slot (XIAO Sense) already opened their inspector in every mode; components did not.

## What

- **"SD files" chip** under the microSD card, under parts with their own TF slot (`metadata.sdSlot`) and under boards with a built-in slot. Left click, any mode, opens the same inspector. It sits in the label row, already out of the pin-position math, so nothing moves on rotation; its mousedown never starts a drag.
- **Right-click on a component opens the inspector while running**, read-only: Rotate/Delete hidden, pins are labels (no wiring), property editors disabled. Key binding stays live. Boards get the same read-only treatment.
- **The SD panel says before the click** whether this user can upload: the button reads "Add files (paid)" and the hint names the free path.
- The upgrade event carries `requiredPlan: 'maker'` and a description, so an overlay's modal can stop selling a Maker feature as Pro.

## Tests

- `sd-card-panel-copy.test.ts`: server-rendered panel copy vs the gate.
- `sd-card-gate.test.ts`: one more case for the event detail.
- Verified in a browser against a local build: chip visible under the card and under the XIAO Sense, panel opens from the chip and from right-click during a run (no Rotate/Delete, pins as labels), card does not move when the chip is clicked, upgrade modal shows the paid-plan headline.

## Folders on the card (second commit)

The FAT16 image was root-only; a sketch reading `/MUSIC/tracklist.txt` could never find it. Now a `/` in a name lands the file in that directory (created on the way, any depth): subdirectories are cluster chains opening with `.` and `..`, short names unique per directory, LFN at every level, and the root carries the volume-label entry (fsck.fat flagged the mismatch). The panel gets **"+ Add folder"** (webkitdirectory, paths kept), rows and the live listing show paths, the reader descends folders.

Verified: `fsck.fat` clean and `mdir`/`mcopy` read every path back (`fat-image-mtools.test`, skipped where the tools are missing); the real XIAO ESP32-S3 firmware lists `/MUSIC` and opens `/MUSIC/TRACKS.TXT` from an uploaded folder. Long file names inside the sketch need the compile-side fix in #299.
