### PR TITLE
fix(espidf): build FatFs with long file names, like the Arduino IDE's core

### DIFF
--- a/backend/app/services/esp-idf-template/sdkconfig.defaults.in
+++ b/backend/app/services/esp-idf-template/sdkconfig.defaults.in
@@ -104,6 +104,20 @@ CONFIG_BT_BLE_42_FEATURES_SUPPORTED=y
 CONFIG_BT_BLE_42_ADV_EN=y
 CONFIG_BT_BLE_42_SCAN_EN=y
 
+# ── FatFs: long file names, like the real board ──────────────────────────
+# ESP-IDF's FatFs defaults to 8.3 names only (FATFS_LFN_NONE). A sketch that
+# does SD.open("/MUSIC/tracklist.txt") then fails here while it works on the
+# hardware, because the Arduino IDE's core is built by esp32-arduino-lib-builder
+# with long names ON: the card holds the file as TRACKL~1.TXT plus its VFAT
+# long-name entries, and only an LFN-aware FatFs can match the real name.
+# Mirror lib-builder's configs/defconfig.common (found through the microSD
+# card panel: an uploaded folder was listed by the panel and invisible to
+# the sketch, 2026-09-06).
+CONFIG_FATFS_LFN_STACK=y
+CONFIG_FATFS_API_ENCODING_UTF_8=y
+CONFIG_FATFS_CODEPAGE_850=y
+CONFIG_FATFS_USE_LABEL=y
+
 # ── mbedTLS: PSK key-exchange ciphersuites ───────────────────────────────
 # arduino-esp32's WiFiClientSecure/ssl_client.cpp wraps its ENTIRE body
 # (start_ssl_client, ssl_init, send_ssl_data, ...) in

--- a/backend/tests/test_espidf_options.py
+++ b/backend/tests/test_espidf_options.py
@@ -197,6 +197,23 @@ def test_render_sdkconfig_enables_mbedtls_psk(compiler: ESPIDFCompiler) -> None:
     assert 'CONFIG_MBEDTLS_KEY_EXCHANGE_PSK=y' in text
 
 
+def test_render_sdkconfig_enables_fatfs_long_names(compiler: ESPIDFCompiler) -> None:
+    # ESP-IDF's FatFs defaults to 8.3 names only. The Arduino IDE's core
+    # (esp32-arduino-lib-builder defconfig.common) turns long names on, so a
+    # sketch doing SD.open("/MUSIC/tracklist.txt") works on the board and
+    # must work here: the microSD card image stores that file as
+    # TRACKL~1.TXT + VFAT long-name entries, which only an LFN-aware FatFs
+    # matches by its real name.
+    from app.services.espidf_compiler import _TEMPLATE_DIR
+    for target in ('esp32', 'esp32s3', 'esp32c3'):
+        opts = compiler._normalize_options(None, idf_target=target)
+        text = compiler._render_sdkconfig(opts, _TEMPLATE_DIR)
+        assert 'CONFIG_FATFS_LFN_STACK=y' in text
+        assert 'CONFIG_FATFS_API_ENCODING_UTF_8=y' in text
+        assert 'CONFIG_FATFS_CODEPAGE_850=y' in text
+        assert 'CONFIG_FATFS_USE_LABEL=y' in text
+
+
 def test_render_sdkconfig_debug_level_verbose(compiler: ESPIDFCompiler) -> None:
     from app.services.espidf_compiler import _TEMPLATE_DIR
     opts = compiler._normalize_options(


### PR DESCRIPTION
## Why

`SD.open("/MUSIC/tracklist.txt")` works on the real board and fails in the simulator. ESP-IDF's FatFs defaults to 8.3 names only (`FATFS_LFN_NONE`), so a file the card stores as `TRACKL~1.TXT` plus VFAT long-name entries can only be opened as `TRACKL~1.TXT`. The Arduino IDE's core is built by esp32-arduino-lib-builder with long names on.

Measured on prod with a XIAO ESP32-S3 probe sketch against an uploaded folder:

```
[t] entry: TRACKS.TXT
[t] entry: TRACKL~1.TXT
[t] /MUSIC/TRACKS.TXT -> OPEN
[t] /MUSIC/tracklist.txt -> missing
[t] /MUSIC/TRACKL~1.TXT -> OPEN
```

## What

Mirror lib-builder's `configs/defconfig.common` in the IDF template: `CONFIG_FATFS_LFN_STACK=y`, `CONFIG_FATFS_API_ENCODING_UTF_8=y`, `CONFIG_FATFS_CODEPAGE_850=y`, `CONFIG_FATFS_USE_LABEL=y`. Test pins the four lines for esp32 / esp32s3 / esp32c3.

## Rollout

A rendered-defaults change already drops the generated `sdkconfig` and forces a configure on each warm build dir, so this reaches every variant on its next compile (one reconfigure per variant, then warm again). Pairs with #298 (the SD panel) and #300 (folders on the card).
