### PR TITLE
feat(sd-card): folders on the card ("Add folder"), like a card written by a PC

### DIFF
--- a/frontend/src/__tests__/fat-image-mtools.test.ts
+++ b/frontend/src/__tests__/fat-image-mtools.test.ts
@@ -1,0 +1,73 @@
+/**
+ * fat-image-mtools.test.ts — the image `buildFat16Image` emits, checked by a
+ * FAT implementation that is not ours: dosfstools' fsck.fat (structure) and
+ * mtools' mdir (a recursive listing, long names included). Our own reader
+ * shares assumptions with our writer; a real card reader does not.
+ *
+ * Skipped where the tools are not installed (CI without dosfstools/mtools);
+ * runs on any dev box with `apt install dosfstools mtools`.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildFat16Image } from '../utils/fatImage';
+
+const have = (bin: string): boolean => spawnSync('which', [bin]).status === 0;
+const tools = have('fsck.fat') && have('mdir');
+
+describe.skipIf(!tools)('FAT16 image vs dosfstools + mtools', () => {
+  const enc = (t: string) => new TextEncoder().encode(t);
+
+  it('fsck.fat finds no errors and mdir lists every path, folders included', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'velxio-fat-'));
+    const path = join(dir, 'card.img');
+    try {
+      const img = buildFat16Image([
+        { name: 'MUSIC/tracklist.txt', data: enc('Blue Monday\n') },
+        { name: 'MUSIC/album one/song.wav', data: new Uint8Array(1500).fill(9) },
+        { name: 'readme.txt', data: enc('root') },
+        { name: 'a/b/c/deep.bin', data: new Uint8Array([1, 2, 3]) },
+        { name: 'holiday picture 2026.jpeg', data: enc('jpg') },
+      ]);
+      writeFileSync(path, img);
+
+      // -n: never modify; exit status 0 = clean. Its stdout names any
+      // problem (bad "." / ".." entries, wrong chains, orphan clusters).
+      const fsck = spawnSync('fsck.fat', ['-n', '-v', path], { encoding: 'utf8' });
+      const report = fsck.stdout + fsck.stderr;
+      expect(report, report).not.toMatch(/error|invalid|orphan|wrong/i);
+      expect(fsck.status, report).toBe(0);
+
+      // mdir -/ recurses; -b prints bare paths ("::/MUSIC/tracklist.txt").
+      const listing = execFileSync('mdir', ['-i', path, '-/', '-b', '::'], { encoding: 'utf8' });
+      const paths = listing
+        .split('\n')
+        .map((l) => l.trim().replace(/^::\/?/, ''))
+        .filter(Boolean);
+      for (const want of [
+        'MUSIC/tracklist.txt',
+        'MUSIC/album one/song.wav',
+        'readme.txt',
+        'a/b/c/deep.bin',
+        'holiday picture 2026.jpeg',
+      ]) {
+        expect(paths.map((p) => p.toLowerCase())).toContain(want.toLowerCase());
+      }
+
+      // And the bytes come back through mtools intact.
+      const song = execFileSync('mcopy', ['-i', path, '::/MUSIC/album one/song.wav', '-'], {
+        encoding: 'buffer',
+      });
+      expect(song.length).toBe(1500);
+      expect(song.every((b) => b === 9)).toBe(true);
+      const text = execFileSync('mcopy', ['-i', path, '::/MUSIC/tracklist.txt', '-'], {
+        encoding: 'utf8',
+      });
+      expect(text).toBe('Blue Monday\n');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/frontend/src/__tests__/fat-image.test.ts
+++ b/frontend/src/__tests__/fat-image.test.ts
@@ -4,7 +4,7 @@
  * and we assert a full round-trip (names + bytes), plus BPB/structure checks.
  */
 import { describe, it, expect } from 'vitest';
-import { buildFat16Image, readFat16Image, type SdFile } from '../utils/fatImage';
+import { buildFat16Image, normalizeSdPath, readFat16Image, type SdFile } from '../utils/fatImage';
 import { buildProjectSdImage, bytesToB64, decodeSdFiles } from '../utils/sdCardFiles';
 
 // ── Minimal FAT16 reader (test-only) — parses root dir + FAT chains ──────────
@@ -215,6 +215,111 @@ describe('sdCardFiles upload helpers', () => {
     )!;
     expect(f.data.length).toBe(700);
     expect(f.data.every((b) => b === 0x7e)).toBe(true);
+  });
+});
+
+describe('folders: a "/" in the name puts the file in that directory', () => {
+  const enc = (t: string) => new TextEncoder().encode(t);
+
+  it('lists nested paths back, bytes exact, any depth', () => {
+    const img = buildFat16Image([
+      { name: 'MUSIC/tracklist.txt', data: enc('Blue Monday\n') },
+      { name: 'MUSIC/album one/song.wav', data: new Uint8Array([1, 2, 3, 4]) },
+      { name: 'readme.txt', data: enc('root') },
+      { name: 'a/b/c/d/deep.bin', data: new Uint8Array(700).fill(7) },
+    ]);
+    const got = readFat16Image(img);
+    // Names that fit 8.3 come back upper-cased (no LFN is written for them,
+    // same as the root has always behaved); long names come back exact.
+    const byName = Object.fromEntries(got.map((f) => [f.name.toLowerCase(), f]));
+    expect(Object.keys(byName).sort()).toEqual(
+      ['music/album one/song.wav', 'music/tracklist.txt', 'a/b/c/d/deep.bin', 'readme.txt'].sort(),
+    );
+    expect(got.map((f) => f.name)).toContain('MUSIC/tracklist.txt');
+    expect(new TextDecoder().decode(byName['music/tracklist.txt'].data)).toBe('Blue Monday\n');
+    expect(Array.from(byName['music/album one/song.wav'].data)).toEqual([1, 2, 3, 4]);
+    expect(byName['a/b/c/d/deep.bin'].size).toBe(700);
+    expect(byName['a/b/c/d/deep.bin'].data.every((b) => b === 7)).toBe(true);
+  });
+
+  it('a subdirectory starts with "." and ".." pointing at itself and its parent', () => {
+    const img = buildFat16Image([{ name: 'DIR/SUB/f.txt', data: enc('x') }]);
+    const u16 = (o: number) => img[o] | (img[o + 1] << 8);
+    const bps = u16(11);
+    const reserved = u16(14);
+    const numFats = img[16];
+    const rootEntries = u16(17);
+    const fatSz = u16(22);
+    const rootStart = (reserved + numFats * fatSz) * bps;
+    const dataStart = rootStart + Math.ceil((rootEntries * 32) / bps) * bps;
+    const clusterAt = (cl: number) => dataStart + (cl - 2) * bps * img[13];
+
+    // Root: the volume label first (fsck.fat wants one to match the boot
+    // sector), then DIR, attr 0x10, some first cluster.
+    expect(img[rootStart + 11]).toBe(0x08);
+    const r1 = rootStart + 32;
+    expect(String.fromCharCode(...img.subarray(r1, r1 + 11))).toBe('DIR        ');
+    expect(img[r1 + 11]).toBe(0x10);
+    const dirCl = u16(r1 + 26);
+    expect(dirCl).toBeGreaterThanOrEqual(2);
+    // DIR's listing: ".", ".." (parent = root = 0), then SUB.
+    const d = clusterAt(dirCl);
+    expect(String.fromCharCode(...img.subarray(d, d + 11))).toBe('.          ');
+    expect(u16(d + 26)).toBe(dirCl);
+    expect(String.fromCharCode(...img.subarray(d + 32, d + 43))).toBe('..         ');
+    expect(u16(d + 32 + 26)).toBe(0);
+    expect(String.fromCharCode(...img.subarray(d + 64, d + 75))).toBe('SUB        ');
+    const subCl = u16(d + 64 + 26);
+    // SUB's ".." points back at DIR.
+    const sd = clusterAt(subCl);
+    expect(u16(sd + 32 + 26)).toBe(dirCl);
+  });
+
+  it('a folder with more entries than one cluster holds spans a chain', () => {
+    // 1 sector per cluster = 16 entries; "." + ".." + 30 files needs 2+.
+    const files: SdFile[] = [];
+    for (let i = 0; i < 30; i++) files.push({ name: `LOGS/L${i}.TXT`, data: enc(`log ${i}`) });
+    const got = readFat16Image(buildFat16Image(files));
+    expect(got.map((f) => f.name).sort()).toEqual(files.map((f) => f.name).sort());
+    expect(new TextDecoder().decode(got.find((f) => f.name === 'LOGS/L29.TXT')!.data)).toBe('log 29');
+  });
+
+  it('long names work inside folders too', () => {
+    const got = readFat16Image(
+      buildFat16Image([{ name: 'My Photos/holiday picture 2026.jpeg', data: enc('jpg') }]),
+    );
+    expect(got.map((f) => f.name)).toEqual(['My Photos/holiday picture 2026.jpeg']);
+  });
+
+  it('folder names are case-insensitive, like FAT: one folder, both files', () => {
+    const got = readFat16Image(
+      buildFat16Image([
+        { name: 'Music/a.txt', data: enc('a') },
+        { name: 'MUSIC/b.txt', data: enc('b') },
+      ]),
+    );
+    expect(got.map((f) => f.name.toLowerCase()).sort()).toEqual(['music/a.txt', 'music/b.txt']);
+  });
+
+  it('normalizeSdPath: slashes tidy, "." and ".." dropped, backslashes accepted', () => {
+    expect(normalizeSdPath('/MUSIC//tracklist.txt/')).toBe('MUSIC/tracklist.txt');
+    expect(normalizeSdPath('.\\data\\cfg.json')).toBe('data/cfg.json');
+    expect(normalizeSdPath('a/../b.txt')).toBe('a/b.txt');
+    expect(normalizeSdPath('///')).toBe('');
+  });
+
+  it('buildProjectSdImage: uploads and workspace files keep their paths, overrides by path', () => {
+    const img = buildProjectSdImage(
+      [{ name: 'data/config.json', content: '{"a":1}' }],
+      decodeSdFiles([
+        { name: '/MUSIC/tracklist.txt', contentB64: bytesToB64(enc('t')) },
+        { name: 'DATA/config.json', contentB64: bytesToB64(enc('{"a":2}')) },
+      ]),
+    );
+    const got = readFat16Image(img);
+    const byName = Object.fromEntries(got.map((f) => [f.name, new TextDecoder().decode(f.data)]));
+    expect(Object.keys(byName).sort()).toEqual(['DATA/config.json', 'MUSIC/tracklist.txt']);
+    expect(byName['DATA/config.json']).toBe('{"a":2}'); // the upload wins
   });
 });
 

--- a/frontend/src/components/simulator/ComponentPropertyDialog.css
+++ b/frontend/src/components/simulator/ComponentPropertyDialog.css
@@ -413,6 +413,19 @@
   transform: translateY(-1px);
   box-shadow: 0 2px 8px var(--color-accent-soft-strong);
 }
+.sd-card-add-group {
+  display: inline-flex;
+  gap: 6px;
+}
+.sd-card-add--secondary {
+  background-color: transparent;
+  color: var(--color-action-primary);
+  border: 1px solid var(--color-action-primary);
+  padding: 4px 11px;
+}
+.sd-card-add--secondary:hover {
+  background-color: var(--color-accent-soft);
+}
 .sd-card-total {
   font-size: 11px;
   color: var(--wb-11);

--- a/frontend/src/components/simulator/SdCardPanel.tsx
+++ b/frontend/src/components/simulator/SdCardPanel.tsx
@@ -10,7 +10,9 @@
  *
  * Files are persisted on the component as `properties.sdFiles`
  * (`{ name, contentB64 }[]`), so they travel with the project (.vlx) and feed
- * `buildProjectSdImage` on the next run.
+ * `buildProjectSdImage` on the next run. `name` is a card PATH: "Add folder"
+ * keeps the picked folder's tree ("MUSIC/tracklist.txt"), the Wokwi model,
+ * so a sketch that opens a file inside a directory finds it.
  */
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
@@ -18,7 +20,7 @@ import {
   SD_UPLOAD_MAX_BYTES,
   type UploadedSdFile,
 } from '../../utils/sdCardFiles';
-import { readFat16Image, type FatDirFile } from '../../utils/fatImage';
+import { normalizeSdPath, readFat16Image, type FatDirFile } from '../../utils/fatImage';
 import { sdCardUploadAllowed, triggerSdCardUpgradePrompt } from '../../lib/proSdCardGate';
 import { getEsp32Bridge, useSimulatorStore } from '../../store/useSimulatorStore';
 
@@ -45,6 +47,7 @@ function humanSize(n: number): string {
 
 export const SdCardPanel: React.FC<SdCardPanelProps> = ({ files, onChange, boardId }) => {
   const inputRef = useRef<HTMLInputElement>(null);
+  const folderInputRef = useRef<HTMLInputElement>(null);
   const total = files.reduce((s, f) => s + fileBytes(f), 0);
   // Whether THIS user may upload. Read at render so the panel can say so
   // before the click: a "Paid" tag alone left people clicking "Add files"
@@ -82,20 +85,23 @@ export const SdCardPanel: React.FC<SdCardPanelProps> = ({ files, onChange, board
     const url = URL.createObjectURL(new Blob([new Uint8Array(f.data)]));
     const a = document.createElement('a');
     a.href = url;
-    a.download = f.name;
+    a.download = f.name.split('/').pop() ?? f.name; // a path is not a download name
     a.click();
     setTimeout(() => URL.revokeObjectURL(url), 5000);
   };
 
-  const openPicker = (): void => {
+  const openPicker = (which: 'files' | 'folder'): void => {
     // Gate the PAID action: a non-paid user gets the upgrade prompt instead.
     if (!sdCardUploadAllowed()) {
       triggerSdCardUpgradePrompt();
       return;
     }
-    inputRef.current?.click();
+    (which === 'folder' ? folderInputRef : inputRef).current?.click();
   };
 
+  // A folder pick keeps each file's path under the picked folder
+  // (webkitRelativePath, "MUSIC/tracklist.txt"); a plain file pick has no
+  // path and lands in the root.
   const handlePick = async (e: React.ChangeEvent<HTMLInputElement>): Promise<void> => {
     const picked = Array.from(e.target.files ?? []);
     e.target.value = '';
@@ -103,16 +109,25 @@ export const SdCardPanel: React.FC<SdCardPanelProps> = ({ files, onChange, board
     const next = [...files];
     let running = total;
     for (const file of picked) {
+      const rel = (file as File & { webkitRelativePath?: string }).webkitRelativePath;
+      const name = normalizeSdPath(rel || file.name);
+      if (!name) continue;
       const bytes = new Uint8Array(await file.arrayBuffer());
       if (running + bytes.length > SD_UPLOAD_MAX_BYTES) continue; // skip oversize
       running += bytes.length;
-      const entry: UploadedSdFile = { name: file.name, contentB64: bytesToB64(bytes) };
-      const idx = next.findIndex((f) => f.name.toLowerCase() === file.name.toLowerCase());
+      const entry: UploadedSdFile = { name, contentB64: bytesToB64(bytes) };
+      const idx = next.findIndex((f) => f.name.toLowerCase() === name.toLowerCase());
       if (idx >= 0) next[idx] = entry;
       else next.push(entry);
     }
     onChange(next);
   };
+
+  // The directory picker is a non-standard attribute React's typings do not
+  // know; set it on the element itself.
+  useEffect(() => {
+    folderInputRef.current?.setAttribute('webkitdirectory', '');
+  }, []);
 
   const remove = (name: string): void => onChange(files.filter((f) => f.name !== name));
 
@@ -123,16 +138,16 @@ export const SdCardPanel: React.FC<SdCardPanelProps> = ({ files, onChange, board
       </div>
       {files.length === 0 && canUpload && (
         <div className="sd-card-hint">
-          Upload your own files (images, audio, data). The project's data files
-          are added automatically; source files (.ino, .h, .cpp, .py) stay off
-          the card.
+          Upload your own files (images, audio, data), or a whole folder to keep
+          its tree on the card. The project's data files are added automatically;
+          source files (.ino, .h, .cpp, .py) stay off the card.
         </div>
       )}
       {!canUpload && (
         <div className="sd-card-hint">
-          Uploading your own files (images, audio, data) to the card is part of
-          the paid plans. On the free plan, any data file you add to the project
-          workspace (a .txt, .csv, .json...) is copied onto the card
+          Uploading your own files or folders (images, audio, data) to the card
+          is part of the paid plans. On the free plan, any data file you add to
+          the project workspace (a .txt, .csv, .json...) is copied onto the card
           automatically; source files (.ino, .h, .cpp, .py) stay off it.
         </div>
       )}
@@ -152,19 +167,39 @@ export const SdCardPanel: React.FC<SdCardPanelProps> = ({ files, onChange, board
         </div>
       ))}
       <div className="sd-card-footer">
-        <button
-          className="sd-card-add"
-          onClick={openPicker}
-          title={canUpload ? undefined : 'Uploading files to the card needs a paid plan'}
-        >
-          {canUpload ? '+ Add files' : '+ Add files (paid)'}
-        </button>
+        <span className="sd-card-add-group">
+          <button
+            className="sd-card-add"
+            onClick={() => openPicker('files')}
+            title={canUpload ? undefined : 'Uploading files to the card needs a paid plan'}
+          >
+            {canUpload ? '+ Add files' : '+ Add files (paid)'}
+          </button>
+          <button
+            className="sd-card-add sd-card-add--secondary"
+            onClick={() => openPicker('folder')}
+            title={
+              canUpload
+                ? 'Upload a folder; its files keep their paths on the card'
+                : 'Uploading folders to the card needs a paid plan'
+            }
+          >
+            + Add folder
+          </button>
+        </span>
         <span className="sd-card-total">
           {humanSize(total)} / {humanSize(SD_UPLOAD_MAX_BYTES)}
         </span>
       </div>
       <input
         ref={inputRef}
+        type="file"
+        multiple
+        style={{ display: 'none' }}
+        onChange={handlePick}
+      />
+      <input
+        ref={folderInputRef}
         type="file"
         multiple
         style={{ display: 'none' }}

--- a/frontend/src/utils/fatImage.ts
+++ b/frontend/src/utils/fatImage.ts
@@ -14,14 +14,32 @@
  * not fit 8.3 get a generated 8.3 alias plus VFAT long-name (LFN) entries so the
  * real filename is preserved.
  *
- * Scope: root directory only (flat). Subdirectories (folder trees) are a later
- * enhancement.
+ * Folders: a name with '/' in it ("MUSIC/tracklist.txt") lands in that
+ * directory, created on the way, any depth. A subdirectory is a cluster chain
+ * of entries starting with "." and "..", grown as its listing needs; the
+ * root keeps its fixed 512 slots. A sketch then reads
+ * `SD.open("/MUSIC/tracklist.txt")` exactly as on a card written by a PC.
  */
 
 export interface SdFile {
-  /** File name (no leading slash). Long names are preserved via LFN. */
+  /** Path on the card, '/'-separated, no leading slash ("MUSIC/song.wav").
+   *  Long names are preserved via LFN in every directory level. */
   name: string;
   data: Uint8Array;
+}
+
+/**
+ * Normalise a card path: '\' becomes '/', empty / "." / ".." segments are
+ * dropped, no leading or trailing slash. Returns '' for a name with nothing
+ * left in it (the caller skips those).
+ */
+export function normalizeSdPath(raw: string): string {
+  return raw
+    .replace(/\\/g, '/')
+    .split('/')
+    .map((seg) => seg.trim())
+    .filter((seg) => seg !== '' && seg !== '.' && seg !== '..')
+    .join('/');
 }
 
 const SEC = 512;
@@ -104,7 +122,8 @@ export interface BuildFatOptions {
 
 /** A file listed out of a FAT16 image by `readFat16Image`. */
 export interface FatDirFile {
-  /** Long name when LFN entries were present, else the 8.3 name. */
+  /** Path from the card root, '/'-separated ("MUSIC/tracklist.txt"). Long
+   *  names when LFN entries were present, else the 8.3 names. */
   name: string;
   size: number;
   data: Uint8Array;
@@ -117,13 +136,16 @@ function readU32(buf: Uint8Array, off: number): number {
   return (buf[off] | (buf[off + 1] << 8) | (buf[off + 2] << 16) | (buf[off + 3] << 24)) >>> 0;
 }
 
+/** VFAT long-name entry: 13 UTF-16 code units in fixed byte slots. */
+const LFN_SLOTS = [1, 3, 5, 7, 9, 14, 16, 18, 20, 22, 24, 28, 30];
+
 /**
- * List the ROOT directory of a FAT16 "super-floppy" image and extract each
- * file's bytes — the inverse of `buildFat16Image`, but general enough for a
- * card a guest OS (FatFs / Arduino SD) has written to: it follows real
- * cluster chains, honours sectors-per-cluster from the BPB, decodes VFAT
- * long names and skips deleted/volume/directory entries. Subdirectories are
- * not descended (the builder is root-only too).
+ * List every file of a FAT16 "super-floppy" image, subdirectories included,
+ * and extract each file's bytes — the inverse of `buildFat16Image`, but
+ * general enough for a card a guest OS (FatFs / Arduino SD) has written to:
+ * it follows real cluster chains, honours sectors-per-cluster from the BPB,
+ * decodes VFAT long names, skips deleted / volume-label entries and descends
+ * directories (loops and runaway depth are guarded).
  *
  * Returns [] for anything that does not look like a mountable FAT16 volume —
  * the caller treats that as "no readable card", never as an error.
@@ -146,76 +168,191 @@ export function readFat16Image(img: Uint8Array): FatDirFile[] {
     const clusterBytes = spc * bytesPerSec;
     if (dataStart >= img.length) return [];
 
-    const out: FatDirFile[] = [];
-    // LFN entries accumulate (in on-disk reverse order) until their 8.3 entry.
-    let lfnParts: Array<{ seq: number; chars: string }> = [];
+    const clusterAt = (cl: number): number => dataStart + (cl - 2) * clusterBytes;
+    const nextOf = (cl: number): number => readU16(img, fatStart + cl * 2);
+    const isChain = (cl: number): boolean => cl >= 2 && cl < 0xfff8;
 
-    for (let slot = 0; slot < rootEntries; slot++) {
-      const d = rootStart + slot * 32;
-      if (d + 32 > img.length) break;
-      const first = img[d];
-      if (first === 0x00) break; // end of directory
-      if (first === 0xe5) {
-        lfnParts = []; // deleted entry
-        continue;
+    /** Byte offsets of the 32-byte entries of a directory: the fixed root
+     *  region, or a cluster chain for a subdirectory. */
+    const entryOffsets = (startCluster: number | null): number[] => {
+      const offs: number[] = [];
+      if (startCluster === null) {
+        for (let slot = 0; slot < rootEntries; slot++) offs.push(rootStart + slot * 32);
+        return offs;
       }
-      const attr = img[d + 11];
-      if ((attr & 0x0f) === 0x0f) {
-        // VFAT long-name entry: 13 UTF-16 chars in fixed slots.
-        const slots = [1, 3, 5, 7, 9, 14, 16, 18, 20, 22, 24, 28, 30];
-        let chars = '';
-        for (const s of slots) {
-          const code = img[d + s] | (img[d + s + 1] << 8);
-          if (code === 0x0000 || code === 0xffff) break;
-          chars += String.fromCharCode(code);
-        }
-        lfnParts.push({ seq: img[d] & 0x1f, chars });
-        continue;
+      const seen = new Set<number>();
+      for (let cl = startCluster; isChain(cl) && !seen.has(cl); cl = nextOf(cl)) {
+        seen.add(cl);
+        const at = clusterAt(cl);
+        if (at + clusterBytes > img.length) break;
+        for (let o = at; o < at + clusterBytes; o += 32) offs.push(o);
+        if (seen.size > 65536) break;
       }
-      if (attr & 0x08 || attr & 0x10) {
-        // volume label / directory
-        lfnParts = [];
-        continue;
-      }
+      return offs;
+    };
 
-      let name: string;
-      if (lfnParts.length) {
-        name = lfnParts
-          .sort((a, b) => a.seq - b.seq)
-          .map((p) => p.chars)
-          .join('');
-      } else {
-        const base = String.fromCharCode(...img.subarray(d, d + 8)).trimEnd();
-        const ext = String.fromCharCode(...img.subarray(d + 8, d + 11)).trimEnd();
-        name = ext ? `${base}.${ext}` : base;
-      }
-      lfnParts = [];
-
-      const size = readU32(img, d + 28);
-      let cluster = readU16(img, d + 26);
+    const readChain = (first: number, size: number): Uint8Array => {
       const data = new Uint8Array(size);
       let got = 0;
+      let cluster = first;
       // Follow the chain; guard against loops with a step cap.
-      for (let steps = 0; got < size && cluster >= 2 && cluster < 0xfff8; steps++) {
+      for (let steps = 0; got < size && isChain(cluster); steps++) {
         if (steps > 1_000_000) break;
-        const at = dataStart + (cluster - 2) * clusterBytes;
+        const at = clusterAt(cluster);
         if (at >= img.length) break;
         const take = Math.min(clusterBytes, size - got, img.length - at);
         data.set(img.subarray(at, at + take), got);
         got += take;
-        cluster = readU16(img, fatStart + cluster * 2);
+        cluster = nextOf(cluster);
       }
-      out.push({ name, size, data: got === size ? data : data.subarray(0, got) });
-    }
+      return got === size ? data : data.subarray(0, got);
+    };
+
+    const out: FatDirFile[] = [];
+    const visitedDirs = new Set<number>();
+
+    const walk = (startCluster: number | null, prefix: string, depth: number): void => {
+      if (depth > 32) return;
+      // LFN entries accumulate (in on-disk reverse order) until their 8.3 entry.
+      let lfnParts: Array<{ seq: number; chars: string }> = [];
+      for (const d of entryOffsets(startCluster)) {
+        if (d + 32 > img.length) break;
+        const first = img[d];
+        if (first === 0x00) break; // end of directory
+        if (first === 0xe5) {
+          lfnParts = []; // deleted entry
+          continue;
+        }
+        const attr = img[d + 11];
+        if ((attr & 0x0f) === 0x0f) {
+          let chars = '';
+          for (const s of LFN_SLOTS) {
+            const code = img[d + s] | (img[d + s + 1] << 8);
+            if (code === 0x0000 || code === 0xffff) break;
+            chars += String.fromCharCode(code);
+          }
+          lfnParts.push({ seq: img[d] & 0x1f, chars });
+          continue;
+        }
+        if (attr & 0x08) {
+          lfnParts = []; // volume label
+          continue;
+        }
+
+        let name: string;
+        if (lfnParts.length) {
+          name = lfnParts
+            .sort((a, b) => a.seq - b.seq)
+            .map((p) => p.chars)
+            .join('');
+        } else {
+          const base = String.fromCharCode(...img.subarray(d, d + 8)).trimEnd();
+          const ext = String.fromCharCode(...img.subarray(d + 8, d + 11)).trimEnd();
+          name = ext ? `${base}.${ext}` : base;
+        }
+        lfnParts = [];
+
+        const cluster = readU16(img, d + 26);
+        if (attr & 0x10) {
+          // Directory: descend, skipping the self/parent links.
+          if (name === '.' || name === '..') continue;
+          if (!isChain(cluster) || visitedDirs.has(cluster)) continue;
+          visitedDirs.add(cluster);
+          walk(cluster, `${prefix}${name}/`, depth + 1);
+          continue;
+        }
+
+        const size = readU32(img, d + 28);
+        out.push({ name: prefix + name, size, data: readChain(cluster, size) });
+      }
+    };
+
+    walk(null, '', 0);
     return out;
   } catch {
     return [];
   }
 }
 
+/** One directory of the tree `buildFat16Image` lays out. Children keyed by
+ *  lower-cased segment so "Music" and "MUSIC" are one folder, as on FAT. */
+interface DirNode {
+  name: string;
+  dirs: Map<string, DirNode>;
+  files: SdFile[];
+}
+
+function buildTree(files: SdFile[]): DirNode {
+  const root: DirNode = { name: '', dirs: new Map(), files: [] };
+  for (const f of files) {
+    const path = normalizeSdPath(f.name);
+    if (!path) continue;
+    const segs = path.split('/');
+    let node = root;
+    for (let i = 0; i < segs.length - 1; i++) {
+      const key = segs[i].toLowerCase();
+      let child = node.dirs.get(key);
+      if (!child) {
+        child = { name: segs[i], dirs: new Map(), files: [] };
+        node.dirs.set(key, child);
+      }
+      node = child;
+    }
+    const leaf = segs[segs.length - 1];
+    // A file cannot share a name with a folder beside it; the folder wins
+    // (it may hold other uploads), the file is dropped rather than aliased.
+    if (node.dirs.has(leaf.toLowerCase())) continue;
+    const idx = node.files.findIndex((x) => x.name.toLowerCase() === leaf.toLowerCase());
+    const entry = { name: leaf, data: f.data };
+    if (idx >= 0) node.files[idx] = entry;
+    else node.files.push(entry);
+  }
+  return root;
+}
+
+/** VFAT long-name entries for `name` (empty when it fits 8.3), in the
+ *  on-disk order: highest sequence first, right before the 8.3 entry. */
+function lfnEntriesFor(name: string, short: string): Uint8Array[] {
+  if (fitsShort(name)) return [];
+  const entries: Uint8Array[] = [];
+  const cksum = lfnChecksum(short);
+  const chars = name + '\u0000'; // name + NUL terminator; rest padded 0xFFFF
+  const count = Math.ceil(chars.length / 13);
+  for (let seq = 1; seq <= count; seq++) {
+    const e = new Uint8Array(32);
+    e[0] = seq | (seq === count ? 0x40 : 0x00);
+    e[11] = 0x0f; // LFN attribute
+    e[13] = cksum;
+    for (let k = 0; k < 13; k++) {
+      const ci = (seq - 1) * 13 + k;
+      const code = ci < chars.length ? chars.charCodeAt(ci) : 0xffff;
+      e[LFN_SLOTS[k]] = code & 0xff;
+      e[LFN_SLOTS[k] + 1] = (code >> 8) & 0xff;
+    }
+    entries.unshift(e); // reverse order
+  }
+  return entries;
+}
+
+/** A 32-byte 8.3 directory entry. */
+function dirEntry(short11: string, attr: number, firstCluster: number, size: number): Uint8Array {
+  const e = new Uint8Array(32);
+  writeAscii(e, 0, short11, 11);
+  e[11] = attr;
+  writeU16(e, 20, 0); // first cluster (high word) — 0 for FAT16
+  writeU16(e, 26, firstCluster); // first cluster (low word)
+  writeU32(e, 28, size);
+  return e;
+}
+
+const ATTR_VOLUME = 0x08;
+const ATTR_DIR = 0x10;
+const ATTR_ARCHIVE = 0x20;
+
 /**
- * Build a FAT16 image containing `files` in the root directory.
- * Throws if the files don't fit the volume or the root directory.
+ * Build a FAT16 image containing `files`; a '/' in a name puts the file in
+ * that folder (created as needed). Throws if the files don't fit the volume
+ * or the root directory.
  */
 export function buildFat16Image(files: SdFile[], opts: BuildFatOptions = {}): Uint8Array {
   const volumeBytes = opts.volumeBytes ?? 8 * 1024 * 1024;
@@ -263,7 +400,8 @@ export function buildFat16Image(files: SdFile[], opts: BuildFatOptions = {}): Ui
   img[36] = 0x80; // drive number
   img[38] = 0x29; // extended boot signature
   writeU32(img, 39, 0x564c5849); // volume id ("VLXI")
-  writeAscii(img, 43, (opts.label ?? 'VELXIO SD').toUpperCase(), 11);
+  const label11 = ((opts.label ?? 'VELXIO SD').toUpperCase() + '           ').slice(0, 11);
+  writeAscii(img, 43, label11, 11);
   writeAscii(img, 54, 'FAT16   ', 8);
   img[510] = 0x55;
   img[511] = 0xaa;
@@ -281,68 +419,97 @@ export function buildFat16Image(files: SdFile[], opts: BuildFatOptions = {}): Ui
   const rootStart = (reserved + numFats * fatSz) * SEC;
   const dataStart = (reserved + numFats * fatSz + rootDirSectors) * SEC;
   const clusterBytes = spc * SEC;
+  const entriesPerCluster = clusterBytes / 32;
 
   let nextCluster = 2;
-  let rootSlot = 0;
-  const used = new Set<string>(); // short-name uniqueness across files
-
-  for (const f of files) {
-    const short = shortNameFor(f.name, used);
-    const need83 = !fitsShort(f.name);
-
-    // Long-name (VFAT) entries, stored in reverse before the 8.3 entry.
-    const lfnEntries: Uint8Array[] = [];
-    if (need83) {
-      const cksum = lfnChecksum(short);
-      const chars = f.name + '\u0000'; // name + NUL terminator; rest padded 0xFFFF
-      const count = Math.ceil(chars.length / 13);
-      for (let seq = 1; seq <= count; seq++) {
-        const e = new Uint8Array(32);
-        e[0] = seq | (seq === count ? 0x40 : 0x00);
-        e[11] = 0x0f; // LFN attribute
-        e[13] = cksum;
-        const slots = [1, 3, 5, 7, 9, 14, 16, 18, 20, 22, 24, 28, 30];
-        for (let k = 0; k < 13; k++) {
-          const ci = (seq - 1) * 13 + k;
-          const code = ci < chars.length ? chars.charCodeAt(ci) : 0xffff;
-          e[slots[k]] = code & 0xff;
-          e[slots[k] + 1] = (code >> 8) & 0xff;
-        }
-        lfnEntries.unshift(e); // reverse order
-      }
-    }
-
-    // Allocate clusters and write data.
-    const len = f.data.length;
-    const fileClusters = Math.max(1, Math.ceil(len / clusterBytes));
-    if (nextCluster + fileClusters - 1 > totalClusters + 1) {
+  /** Reserve a chain of `count` clusters, linked in the FAT; returns the
+   *  first. The caller fills the data. */
+  const allocChain = (count: number): number => {
+    if (nextCluster + count - 1 > totalClusters + 1) {
       throw new Error(`fatImage: files exceed volume capacity (${volumeBytes} bytes)`);
     }
-    const startCluster = nextCluster;
-    for (let i = 0; i < fileClusters; i++) {
+    const first = nextCluster;
+    for (let i = 0; i < count; i++) {
       const cl = nextCluster++;
-      const at = dataStart + (cl - 2) * clusterBytes;
-      img.set(f.data.subarray(i * clusterBytes, (i + 1) * clusterBytes), at);
-      setFat(cl, i === fileClusters - 1 ? 0xffff : cl + 1);
+      setFat(cl, i === count - 1 ? 0xffff : cl + 1);
+    }
+    return first;
+  };
+  const writeChain = (first: number, bytes: Uint8Array): void => {
+    let cl = first;
+    for (let off = 0; off < bytes.length; off += clusterBytes) {
+      img.set(bytes.subarray(off, off + clusterBytes), dataStart + (cl - 2) * clusterBytes);
+      cl = readU16(img, fat1 + cl * 2);
+    }
+  };
+
+  /**
+   * Lay out one directory: reserve its own clusters first (a subdirectory's
+   * listing size is known from its children's names alone), then place the
+   * children, whose first clusters the entries need, then write the entries.
+   * Returns the directory's first cluster (0 for the root, which lives in
+   * the fixed root region).
+   */
+  const layoutDir = (node: DirNode, parentCluster: number, isRoot: boolean): number => {
+    const used = new Set<string>(); // short-name uniqueness within THIS directory
+    type Planned = { short: string; lfn: Uint8Array[]; dir?: DirNode; file?: SdFile };
+    const planned: Planned[] = [];
+    for (const dir of node.dirs.values()) {
+      const short = shortNameFor(dir.name, used);
+      planned.push({ short, lfn: lfnEntriesFor(dir.name, short), dir });
+    }
+    for (const file of node.files) {
+      const short = shortNameFor(file.name, used);
+      planned.push({ short, lfn: lfnEntriesFor(file.name, short), file });
+    }
+    const entryCount = planned.reduce((n, p) => n + p.lfn.length + 1, isRoot ? 0 : 2);
+
+    let selfCluster = 0;
+    if (isRoot) {
+      // +1: the volume-label entry below.
+      if (entryCount + 1 > rootEntries) {
+        throw new Error('fatImage: too many files for the root directory (max 512 entries)');
+      }
+    } else {
+      selfCluster = allocChain(Math.max(1, Math.ceil(entryCount / entriesPerCluster)));
     }
 
-    // Root directory: LFN entries (if any) then the 8.3 entry.
-    const entriesNeeded = lfnEntries.length + 1;
-    if (rootSlot + entriesNeeded > rootEntries) {
-      throw new Error('fatImage: too many files for the root directory (max 512 entries)');
+    const entries: Uint8Array[] = [];
+    if (isRoot) {
+      // The label the boot sector carries, as the root's own entry too: a
+      // checker (fsck.fat) treats a boot-sector label without one as a fault.
+      entries.push(dirEntry(label11, ATTR_VOLUME, 0, 0));
+    } else {
+      entries.push(dirEntry('.          ', ATTR_DIR, selfCluster, 0));
+      entries.push(dirEntry('..         ', ATTR_DIR, parentCluster, 0));
     }
-    for (const e of lfnEntries) {
-      img.set(e, rootStart + rootSlot * 32);
-      rootSlot++;
+    for (const p of planned) {
+      let first: number;
+      let attr: number;
+      let size = 0;
+      if (p.dir) {
+        first = layoutDir(p.dir, selfCluster, false);
+        attr = ATTR_DIR;
+      } else {
+        const data = p.file!.data;
+        size = data.length;
+        first = allocChain(Math.max(1, Math.ceil(size / clusterBytes)));
+        writeChain(first, data);
+        attr = ATTR_ARCHIVE;
+      }
+      entries.push(...p.lfn, dirEntry(p.short, attr, first, size));
     }
-    const d = rootStart + rootSlot * 32;
-    rootSlot++;
-    writeAscii(img, d, short, 11); // 8.3 name
-    img[d + 11] = 0x20; // attr = archive
-    writeU16(img, d + 26, startCluster); // first cluster (low word)
-    writeU16(img, d + 20, 0); // first cluster (high word) — 0 for FAT16
-    writeU32(img, d + 28, len); // file size
-  }
 
+    if (isRoot) {
+      entries.forEach((e, i) => img.set(e, rootStart + i * 32));
+    } else {
+      const listing = new Uint8Array(entries.length * 32);
+      entries.forEach((e, i) => listing.set(e, i * 32));
+      writeChain(selfCluster, listing);
+    }
+    return selfCluster;
+  };
+
+  layoutDir(buildTree(files), 0, true);
   return img;
 }

--- a/frontend/src/utils/sdCardFiles.ts
+++ b/frontend/src/utils/sdCardFiles.ts
@@ -10,7 +10,7 @@
  * Uint8Array disk image handed to the `microsd-card` simulation part via
  * `element.sdImageData`.
  */
-import { buildFat16Image, type SdFile, type BuildFatOptions } from './fatImage';
+import { buildFat16Image, normalizeSdPath, type SdFile, type BuildFatOptions } from './fatImage';
 
 export interface WorkspaceFileLike {
   name: string;
@@ -19,6 +19,8 @@ export interface WorkspaceFileLike {
 
 /** An uploaded SD file as persisted on the component (`properties.sdFiles`). */
 export interface UploadedSdFile {
+  /** Path on the card, '/'-separated ("MUSIC/tracklist.txt"); a folder
+   *  upload keeps its tree this way. Plain names land in the root. */
   name: string;
   /** Base64 of the raw bytes (binaries included). */
   contentB64: string;
@@ -49,8 +51,10 @@ export function decodeSdFiles(raw: unknown): SdFile[] {
   const out: SdFile[] = [];
   for (const e of raw) {
     if (e && typeof e.name === 'string' && typeof e.contentB64 === 'string') {
+      const name = normalizeSdPath(e.name);
+      if (!name) continue;
       try {
-        out.push({ name: e.name, data: b64ToBytes(e.contentB64) });
+        out.push({ name, data: b64ToBytes(e.contentB64) });
       } catch {
         /* skip malformed entry */
       }
@@ -74,13 +78,19 @@ export function buildProjectSdImage(
   uploaded: SdFile[] = [],
   opts?: BuildFatOptions,
 ): Uint8Array {
+  // Keyed by normalised, case-folded PATH: FAT is case-insensitive and
+  // "MUSIC/a.txt" and "music/a.txt" are the same file.
   const byName = new Map<string, SdFile>();
   for (const f of workspaceFiles) {
     if (SD_EXCLUDED_SOURCES.test(f.name)) continue;
-    byName.set(f.name.toLowerCase(), { name: f.name, data: new TextEncoder().encode(f.content) });
+    const name = normalizeSdPath(f.name);
+    if (!name) continue;
+    byName.set(name.toLowerCase(), { name, data: new TextEncoder().encode(f.content) });
   }
   for (const f of uploaded) {
-    byName.set(f.name.toLowerCase(), f);
+    const name = normalizeSdPath(f.name);
+    if (!name) continue;
+    byName.set(name.toLowerCase(), { name, data: f.data });
   }
   return buildFat16Image([...byName.values()], opts);
 }


### PR DESCRIPTION
## Why

The FAT16 image the microSD card mounts was root-only: a sketch reading `/MUSIC/tracklist.txt` could never find it, whatever the user uploaded, and the panel dropped every path on upload. Wokwi accepts a whole folder tree; so does a card you format on a PC.

Follow-up to #298 (this commit was pushed as #298 merged, so it never made it in).

## What

- **fatImage**: a `/` in a name lands the file in that directory, created on the way, any depth. Subdirectories are cluster chains of entries opening with `.` and `..`, grown as their listing needs; short names are unique per directory; long names get LFN entries at every level. The root now carries the volume-label entry the boot sector already announced (fsck.fat flagged the mismatch). `readFat16Image` descends folders and returns paths, loop/depth guarded.
- **sdCardFiles**: names are normalised card paths (`normalizeSdPath`: `\` to `/`, empty/`.`/`..` segments dropped); the project-file auto-copy and the uploads dedupe by case-folded path.
- **SdCardPanel**: "+ Add folder" (webkitdirectory) keeps each file's `webkitRelativePath`; rows and the live "Card contents" show paths; Download uses the basename.

## Verified

- `fsck.fat` clean and `mdir`/`mcopy` read every path back (`fat-image-mtools.test`, skipped where the tools are missing).
- The real XIAO ESP32-S3 firmware lists `/MUSIC` and opens `/MUSIC/TRACKS.TXT` from an uploaded folder, in the browser against a local build.
- Long file names inside the sketch still need FatFs LFN on the compile side: #299.
