### PR TITLE
fix(compile): the artifact cache must notice a template change, not just a code change

### DIFF
--- a/backend/app/api/routes/compile.py
+++ b/backend/app/api/routes/compile.py
@@ -83,12 +83,20 @@ _CACHE_BYPASS_TOKEN = os.environ.get("VELXIO_CACHE_BYPASS_TOKEN", "").strip()
 
 
 def _toolchain_epoch() -> str:
-    """Fingerprint the code that TURNS a request into build flags.
+    """Fingerprint everything that TURNS a request into build flags.
 
     A cached binary is only valid while the sdkconfig/CLI generation behind it
     is unchanged — flipping CONFIG_SPIRAM_MEMTEST off, say, must not keep
     serving images built with it on. Hashing the two service modules makes the
     invalidation automatic: edit them, every key changes.
+
+    The CONFIG_* lines themselves do NOT live in those modules: they live in
+    the esp-idf-template tree (sdkconfig.defaults.in, the CMakeLists, main.cpp,
+    partitions.csv), which the compiler renders and builds. A template-only
+    change used to leave the epoch untouched, so every sketch already in the
+    cache kept its stale image forever — measured when turning FatFs long
+    names on reached only sketches nobody had compiled before (2026-09-06).
+    Hash that tree too, path and bytes, in a stable order.
     """
     h = hashlib.sha256()
     here = Path(__file__).resolve().parents[2] / "services"
@@ -97,6 +105,13 @@ def _toolchain_epoch() -> str:
             h.update((here / name).read_bytes())
         except OSError:
             h.update(b"?")
+    template_dir = here / "esp-idf-template"
+    try:
+        for path in sorted(p for p in template_dir.rglob("*") if p.is_file()):
+            h.update(str(path.relative_to(template_dir)).encode())
+            h.update(path.read_bytes())
+    except OSError:
+        h.update(b"?")
     return h.hexdigest()[:16]
 
 

--- a/backend/tests/test_artifact_cache_epoch.py
+++ b/backend/tests/test_artifact_cache_epoch.py
@@ -1,0 +1,58 @@
+"""The artifact cache must not outlive a change to how binaries are built.
+
+`_toolchain_epoch()` is folded into every cache key so a build-flag change
+invalidates every stored image. The CONFIG_* lines do not live in the Python
+modules, though — they live in the esp-idf-template tree, so that tree has to
+be part of the fingerprint too. It was not, and turning FatFs long names on
+reached only sketches nobody had compiled before: everything already cached
+kept its stale image (measured on prod, 2026-09-06).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.api.routes import compile as compile_route
+
+
+def _template_dir() -> Path:
+    return Path(compile_route.__file__).resolve().parents[2] / "services" / "esp-idf-template"
+
+
+def test_epoch_is_stable_when_nothing_changes() -> None:
+    assert compile_route._toolchain_epoch() == compile_route._toolchain_epoch()
+
+
+def test_sdkconfig_template_change_changes_the_epoch() -> None:
+    path = _template_dir() / "sdkconfig.defaults.in"
+    before = compile_route._toolchain_epoch()
+    original = path.read_bytes()
+    try:
+        path.write_bytes(original + b"\nCONFIG_VELXIO_TEST_ONLY=y\n")
+        assert compile_route._toolchain_epoch() != before
+    finally:
+        path.write_bytes(original)
+    assert compile_route._toolchain_epoch() == before
+
+
+def test_any_template_file_change_changes_the_epoch() -> None:
+    # main.cpp and the partition table shape the image just as much as the
+    # sdkconfig does; a new file in the tree counts as well.
+    for name in ("main/main.cpp", "partitions.csv", "CMakeLists.txt"):
+        path = _template_dir() / name
+        before = compile_route._toolchain_epoch()
+        original = path.read_bytes()
+        try:
+            path.write_bytes(original + b"\n// velxio test\n")
+            assert compile_route._toolchain_epoch() != before, name
+        finally:
+            path.write_bytes(original)
+        assert compile_route._toolchain_epoch() == before, name
+
+    new_file = _template_dir() / "velxio_epoch_probe.tmp"
+    before = compile_route._toolchain_epoch()
+    try:
+        new_file.write_bytes(b"probe")
+        assert compile_route._toolchain_epoch() != before
+    finally:
+        new_file.unlink(missing_ok=True)
+    assert compile_route._toolchain_epoch() == before


### PR DESCRIPTION
## Why

`_toolchain_epoch()` is folded into every artifact-cache key so a build-flag change invalidates every stored binary. Its docstring uses "flipping `CONFIG_SPIRAM_MEMTEST` off must not keep serving images built with it on" as the example. But it hashes only `espidf_compiler.py` and `arduino_cli.py`, and no `CONFIG_` line lives there: they live in the `esp-idf-template` tree the compiler renders and builds.

Measured on prod right after #299 turned FatFs long names on. The probe sketch recompiled as `[served from the build cache - identical sources]` and ran the pre-change image:

```
[t] entry: TRACKS.TXT
[t] entry: TRACKL~1.TXT
[t] /MUSIC/tracklist.txt -> missing
[t] /MUSIC/TRACKL~1.TXT -> OPEN
```

So the fix reached only sketches nobody had compiled before, which is the opposite of who needs it.

## What

Hash the template tree as well (relative path + bytes, in sorted order), so `sdkconfig.defaults.in`, `main/main.cpp`, `partitions.csv` and the `CMakeLists.txt` all count toward the epoch.

Tests: the epoch is stable when nothing changes, and changes for an edit to the sdkconfig template, to any other template file, and for a new file appearing in the tree.

## Rollout

Deploying this changes the epoch, so every cached artifact is dropped and the next compile of each sketch is a real build. That is intended here (the cached images carry the old FatFs config), but it is a one-off load spike worth expecting on the first hours after the deploy.
