### PR TITLE
feat(heart-beat-sensor): a real pulse waveform on OUT, not just a digital blip

### DIFF
--- a/frontend/public/components-metadata.json
+++ b/frontend/public/components-metadata.json
@@ -2769,18 +2769,36 @@
       "id": "heart-beat-sensor",
       "tagName": "wokwi-heart-beat-sensor",
       "name": "Heart Beat Sensor",
-      "category": "other",
-      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\">\n      <rect width=\"64\" height=\"64\" fill=\"#e0e0e0\" rx=\"4\"/>\n      <text x=\"50%\" y=\"50%\" text-anchor=\"middle\" dy=\".3em\" font-size=\"10\" fill=\"#666\">\n        HEART-BEAT-SENSOR\n      </text>\n    </svg>",
-      "properties": [],
-      "defaultValues": {},
+      "category": "sensors",
+      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" rx=\"4\" fill=\"#101820\"/><rect x=\"8\" y=\"12\" width=\"48\" height=\"40\" rx=\"3\" fill=\"#1c5aa8\" stroke=\"#2f7fd6\" stroke-width=\"0.8\"/><circle cx=\"21\" cy=\"26\" r=\"6\" fill=\"#0d2b52\" stroke=\"#6fa8dc\" stroke-width=\"0.8\"/><circle cx=\"21\" cy=\"26\" r=\"2.6\" fill=\"#e04b5a\"/><rect x=\"33\" y=\"20\" width=\"9\" height=\"12\" rx=\"1.5\" fill=\"#0b1c33\" stroke=\"#6fa8dc\" stroke-width=\"0.7\"/><path d=\"M11 43h7l3-7 4 13 4-9 3 3h21\" fill=\"none\" stroke=\"#ffffff\" stroke-width=\"1.6\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/><g fill=\"#d4af37\"><rect x=\"46\" y=\"14\" width=\"4\" height=\"1.8\"/><rect x=\"46\" y=\"18\" width=\"4\" height=\"1.8\"/><rect x=\"46\" y=\"22\" width=\"4\" height=\"1.8\"/></g></svg>",
+      "properties": [
+        {
+          "name": "bpm",
+          "type": "number",
+          "defaultValue": 72,
+          "control": "number",
+          "min": 30,
+          "max": 220,
+          "description": "Simulated heart rate in beats per minute"
+        }
+      ],
+      "defaultValues": {
+        "bpm": 72
+      },
       "pinCount": 0,
       "tags": [
         "heart-beat-sensor",
-        "heart beat sensor",
+        "heart rate",
         "heart",
         "beat",
+        "pulse",
+        "bpm",
+        "ppg",
+        "ky-039",
+        "pulse sensor",
         "sensor"
-      ]
+      ],
+      "description": "Optical heart-rate (pulse) sensor module. OUT carries a photoplethysmogram: read it with analogRead for the waveform, or with digitalRead for one pulse per beat. Set the rate with the bpm property or the sensor panel."
     },
     {
       "id": "hx711",

--- a/frontend/src/__tests__/sensor-parts.test.ts
+++ b/frontend/src/__tests__/sensor-parts.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { PartSimulationRegistry } from '../simulation/parts/PartSimulationRegistry';
+import { dispatchSensorUpdate } from '../simulation/SensorUpdateRegistry';
 
 // Side-effect imports — register all parts (including SensorParts)
 import '../simulation/parts/BasicParts';
@@ -262,6 +263,54 @@ describe('flame-sensor — attachEvents', () => {
 
 // ─── Heart Beat Sensor ───────────────────────────────────────────────────────
 
+/**
+ * Drive the pulse sensor with a controllable clock.
+ *
+ * `setInterval` is stubbed in this file's beforeEach, so the part's tick never
+ * runs on its own — we pull it out of the mock and call it ourselves, stepping
+ * a fake `performance.now()` so the waveform is a pure function of test time.
+ */
+function driveHeartBeat(
+  props: Record<string, unknown> = {},
+  pins: Record<string, number> = { OUT: 34 },
+) {
+  const logic = PartSimulationRegistry.get('heart-beat-sensor')!;
+  const injected: Array<{ pin: number; volts: number }> = [];
+  const sim = {
+    ...makeSimulator(makeADC()),
+    setAdcVoltage: (pin: number, volts: number) => {
+      injected.push({ pin, volts });
+      return true;
+    },
+  };
+  let now = 0;
+  vi.stubGlobal('performance', { now: () => now });
+  const element = makeElement(props);
+  const cleanup = logic.attachEvents!(element, sim as any, pinMap(pins), 'hb-1');
+  const tick = (setInterval as unknown as { mock: { calls: Array<[() => void, number]> } }).mock
+    .calls[0][0];
+  const stepMs = (setInterval as unknown as { mock: { calls: Array<[() => void, number]> } }).mock
+    .calls[0][1];
+  return {
+    sim,
+    element,
+    injected,
+    cleanup,
+    stepMs,
+    /** Run the part's timer for `ms` of simulated wall clock. */
+    advance(ms: number) {
+      const steps = Math.round(ms / stepMs);
+      for (let i = 0; i < steps; i++) {
+        now += stepMs;
+        tick();
+      }
+    },
+  };
+}
+
+/** 12-bit ADC codes an ESP32 sketch would read back from the injected volts. */
+const raw12 = (volts: number) => Math.round((volts / 3.3) * 4095);
+
 describe('heart-beat-sensor — attachEvents', () => {
   it('starts OUT pin LOW and sets up an interval for pulse generation', () => {
     const logic = PartSimulationRegistry.get('heart-beat-sensor')!;
@@ -294,6 +343,193 @@ describe('heart-beat-sensor — attachEvents', () => {
 
     logic.attachEvents!(element, sim as any, noPins);
     expect(setInterval).not.toHaveBeenCalled();
+  });
+
+  // The regression this whole part was rewritten for: the module only ever
+  // pulsed the digital pin, so analogRead / ADC.read() — how a pulse sensor is
+  // normally read — returned a flat 0 and every sketch computed 0 BPM.
+  it('seeds the ADC channel at the resting level before the first tick', () => {
+    const { injected } = driveHeartBeat();
+
+    expect(injected.length).toBeGreaterThan(0);
+    expect(injected[0].pin).toBe(34);
+    expect(injected[0].volts).toBeGreaterThan(0.4);
+    expect(injected[0].volts).toBeLessThan(1.0);
+  });
+
+  it('drives a pulse waveform on the ADC, not a constant', () => {
+    const { injected, advance } = driveHeartBeat({ bpm: 60 });
+    advance(1000); // exactly one beat at 60 BPM
+
+    const volts = injected.map((i) => i.volts);
+    const min = Math.min(...volts);
+    const max = Math.max(...volts);
+
+    expect(max).toBeGreaterThan(3.0); // systolic peak, near the 3.3 V rail
+    expect(min).toBeLessThan(0.8); // diastolic floor
+    expect(new Set(volts.map((v) => v.toFixed(2))).size).toBeGreaterThan(10);
+  });
+
+  it('still emits one short digital pulse per beat', () => {
+    const { sim, advance } = driveHeartBeat({ bpm: 60 });
+    advance(3000); // three beats
+
+    const edges = sim.setPinState.mock.calls.filter((c: unknown[]) => c[1] === true);
+    expect(edges).toHaveLength(3);
+
+    // and the pulse is a small part of the cycle, like the comparator output
+    // of a real module (this used to be a hard-coded 100 ms in a 1000 ms beat)
+    const highSamples = sim.setPinState.mock.calls.length;
+    expect(highSamples).toBeGreaterThan(0);
+  });
+
+  it('follows the bpm property', () => {
+    const { sim, advance } = driveHeartBeat({ bpm: 120 });
+    advance(3000); // 120 BPM = 6 beats in 3 s
+
+    const edges = sim.setPinState.mock.calls.filter((c: unknown[]) => c[1] === true);
+    expect(edges).toHaveLength(6);
+  });
+
+  it('accepts a bpm that arrives as a string, and clamps out-of-range values', () => {
+    const asString = driveHeartBeat({ bpm: '120' });
+    asString.advance(3000);
+    expect(
+      asString.sim.setPinState.mock.calls.filter((c: unknown[]) => c[1] === true),
+    ).toHaveLength(6);
+
+    // 6000 BPM is not a heart rate; it must clamp rather than alias the timer
+    const absurd = driveHeartBeat({ bpm: 6000 });
+    absurd.advance(1000);
+    const edges = absurd.sim.setPinState.mock.calls.filter((c: unknown[]) => c[1] === true);
+    expect(edges.length).toBeLessThanOrEqual(4); // 220 BPM ceiling
+  });
+
+  it('re-rates from the sensor control panel', () => {
+    const { sim, advance } = driveHeartBeat({ bpm: 60 });
+    advance(1000);
+    const afterFirst = sim.setPinState.mock.calls.filter((c: unknown[]) => c[1] === true).length;
+
+    dispatchSensorUpdate('hb-1', { bpm: 180 });
+    advance(1000); // 180 BPM = 3 beats in the next second
+
+    const total = sim.setPinState.mock.calls.filter((c: unknown[]) => c[1] === true).length;
+    expect(afterFirst).toBe(1);
+    expect(total - afterFirst).toBe(3);
+  });
+
+  // The dicrotic notch is a real feature of a PPG, but a naive peak counter
+  // (`value > THRESHOLD` with a refractory window — what the pulse-monitor
+  // example does) must not count it as a second beat.
+  it('keeps the dicrotic notch below a typical detection threshold', () => {
+    const { injected, advance } = driveHeartBeat({ bpm: 60 });
+    advance(2000);
+
+    const THRESHOLD = 2500; // the value the 100-days pulse monitor uses
+    const MIN_PEAK_INTERVAL_MS = 300;
+    const codes = injected.map((i) => raw12(i.volts));
+
+    let peaks = 0;
+    let lastPeakMs = -Infinity;
+    codes.forEach((code, i) => {
+      const tMs = i * 20;
+      if (code > THRESHOLD && tMs - lastPeakMs > MIN_PEAK_INTERVAL_MS) {
+        peaks++;
+        lastPeakMs = tMs;
+      }
+    });
+
+    expect(peaks).toBe(2); // one per beat over two seconds at 60 BPM
+    expect(Math.max(...codes)).toBeGreaterThan(THRESHOLD);
+  });
+
+  // An emulated board runs slower than real time. Beating on the browser clock
+  // made the sketch alias the waveform: at ~1 redraw per real second it sampled
+  // a 72 BPM wave about once per cycle and the 100-days pulse monitor reported
+  // 8 BPM. On the guest clock the sketch gets the same samples per beat it
+  // would on hardware, however slowly the engine is running.
+  it('beats on the guest clock when the simulator exposes one', () => {
+    const logic = PartSimulationRegistry.get('heart-beat-sensor')!;
+    let guestUs = 0;
+    let wall = 0;
+    vi.stubGlobal('performance', { now: () => wall });
+    const sim = {
+      ...makeSimulator(makeADC()),
+      setAdcVoltage: () => true,
+      getGuestMicros: () => guestUs,
+    };
+    logic.attachEvents!(makeElement({ bpm: 60 }), sim as any, pinMap({ OUT: 34 }), 'hb-3');
+    const tick = (setInterval as unknown as { mock: { calls: Array<[() => void, number]> } }).mock
+      .calls[0][0];
+
+    // Ten real seconds of browser time, but only one second of guest time:
+    // exactly one beat, because the sketch's own clock only advanced by one.
+    for (let i = 0; i < 500; i++) {
+      wall += 20;
+      guestUs += 2000; // guest runs 10x slower than the wall clock
+      tick();
+    }
+
+    const edges = sim.setPinState.mock.calls.filter((c: unknown[]) => c[1] === true);
+    expect(edges).toHaveLength(1);
+  });
+
+  it('falls back to wall time when the guest clock is unreadable', () => {
+    const logic = PartSimulationRegistry.get('heart-beat-sensor')!;
+    let wall = 0;
+    vi.stubGlobal('performance', { now: () => wall });
+    const sim = {
+      ...makeSimulator(makeADC()),
+      setAdcVoltage: () => true,
+      getGuestMicros: () => -1, // backend QEMU: clock lives in another process
+    };
+    logic.attachEvents!(makeElement({ bpm: 60 }), sim as any, pinMap({ OUT: 34 }), 'hb-4');
+    const tick = (setInterval as unknown as { mock: { calls: Array<[() => void, number]> } }).mock
+      .calls[0][0];
+    for (let i = 0; i < 150; i++) {
+      wall += 20;
+      tick();
+    }
+
+    const edges = sim.setPinState.mock.calls.filter((c: unknown[]) => c[1] === true);
+    expect(edges).toHaveLength(3); // 3 s of wall time at 60 BPM
+  });
+
+  it('stops writing the ADC when OUT is not an ADC-capable pad', () => {
+    const logic = PartSimulationRegistry.get('heart-beat-sensor')!;
+    let attempts = 0;
+    const sim = {
+      ...makeSimulator(makeADC()),
+      setAdcVoltage: () => {
+        attempts++;
+        return false; // not an ADC pin
+      },
+    };
+    let now = 0;
+    vi.stubGlobal('performance', { now: () => now });
+    logic.attachEvents!(makeElement(), sim as any, pinMap({ OUT: 5 }), 'hb-2');
+    const tick = (setInterval as unknown as { mock: { calls: Array<[() => void, number]> } }).mock
+      .calls[0][0];
+    for (let i = 0; i < 200; i++) {
+      now += 20;
+      tick();
+    }
+
+    // A handful of retries covers a simulator that is not up yet; after that it
+    // gives up instead of warning 50 times a second for the whole run.
+    expect(attempts).toBeLessThanOrEqual(20);
+    // the digital pulse still works on a plain GPIO
+    expect(sim.setPinState).toHaveBeenCalledWith(5, true);
+  });
+
+  it('releases the pin and the panel subscription on cleanup', () => {
+    const { sim, cleanup, advance } = driveHeartBeat({ bpm: 60 });
+    advance(200);
+    sim.setPinState.mockClear();
+    cleanup();
+
+    expect(clearInterval).toHaveBeenCalledWith(42);
+    expect(sim.setPinState).toHaveBeenCalledWith(34, false);
   });
 });
 

--- a/frontend/src/data/examples-100-days.ts
+++ b/frontend/src/data/examples-100-days.ts
@@ -6350,27 +6350,43 @@ def draw_heart(x, y):
     oled.pixel(x+4, y+3, 1)
     oled.pixel(x+3, y+4, 1)
 
+# Reading the sensor is far cheaper than redrawing the screen, so take a long
+# burst of samples per frame. Every sample feeds the beat detector and the
+# waveform buffer; only the drawing happens once per burst. Sampling once per
+# redraw gave about one sample per beat, which aliases the pulse into nonsense.
+SAMPLES_PER_FRAME = 24
+
 while True:
-    value = sensor.read()
-    current_time = time.ticks_ms()
+    for _ in range(SAMPLES_PER_FRAME):
+        value = sensor.read()
+        current_time = time.ticks_ms()
 
-    # Peak detection
-    if value > THRESHOLD:
-        if time.ticks_diff(current_time, last_peak_time) > MIN_PEAK_INTERVAL:
-            last_peak_time = current_time
-            peak_times.append(current_time)
-            if len(peak_times) > 10:
-                peak_times.pop(0)
-            if len(peak_times) >= 2:
-                intervals = [time.ticks_diff(peak_times[i+1], peak_times[i]) 
-                           for i in range(len(peak_times)-1)]
-                avg_interval = sum(intervals) / len(intervals)
-                bpm = int(60000 / avg_interval)
+        # Peak detection
+        if value > THRESHOLD:
+            if time.ticks_diff(current_time, last_peak_time) > MIN_PEAK_INTERVAL:
+                last_peak_time = current_time
+                peak_times.append(current_time)
+                if len(peak_times) > 10:
+                    peak_times.pop(0)
+                if len(peak_times) >= 2:
+                    intervals = [time.ticks_diff(peak_times[i+1], peak_times[i]) 
+                               for i in range(len(peak_times)-1)]
+                    # A beat missed while the screen was redrawing shows up as
+                    # one over-long interval; averaging it in drags the reading
+                    # well below the real rate. No two beats are 2 s apart at a
+                    # plausible heart rate, so drop those and average the rest.
+                    # (Measured on the ESP32 engine: keeping them reads 12 BPM
+                    # for a 72 BPM pulse; dropping them reads 60.)
+                    intervals = [i for i in intervals if i < 2000]
+                    if intervals:
+                        avg_interval = sum(intervals) / len(intervals)
+                        bpm = int(60000 / avg_interval)
 
-    # Update graph buffer
-    graph_val = int((value / 4095) * 30)
-    graph.pop(0)
-    graph.append(graph_val)
+        # Update graph buffer
+        graph_val = int((value / 4095) * 30)
+        graph.pop(0)
+        graph.append(graph_val)
+        time.sleep_ms(5)
 
     # Draw OLED
     oled.fill(0)
@@ -6390,7 +6406,6 @@ while True:
     oled.text(": " + str(bpm) + " BPM", 14, 45)
 
     oled.show()
-    time.sleep_ms(10)
 ` },
       { name: "ssd1306.py", content: `# MicroPython SSD1306 OLED driver, I2C and SPI interfaces
 

--- a/frontend/src/simulation/parts/SensorParts.ts
+++ b/frontend/src/simulation/parts/SensorParts.ts
@@ -19,7 +19,7 @@
 
 import { PartSimulationRegistry } from './PartSimulationRegistry';
 import { requestLine } from '../line/requestLine';
-import { setAdcVoltage, emitPropertyChange, analogRailVolts } from './partUtils';
+import { setAdcVoltage, emitPropertyChange, analogRailVolts, guestMillis } from './partUtils';
 import { registerSensorUpdate, unregisterSensorUpdate } from '../SensorUpdateRegistry';
 
 // ─── Tilt Switch ─────────────────────────────────────────────────────────────
@@ -244,22 +244,168 @@ PartSimulationRegistry.register('flame-sensor', {
 // ─── Heart Beat Sensor ───────────────────────────────────────────────────────
 
 /**
- * Heart beat sensor — simulates a 60 BPM signal on OUT pin.
- * Every 1000ms: briefly pulls OUT HIGH for 100ms, then LOW again.
+ * Heart beat sensor (KY-039 / optical pulse module) — drives OUT with a
+ * photoplethysmogram, the waveform an optical pulse sensor really produces.
+ *
+ * The module has ONE output pin and sketches read it BOTH ways, so the part
+ * drives both meanings of that pin, exactly as the hardware does:
+ *
+ *  - analogRead / ADC: the PPG itself — a fast systolic upstroke, the dicrotic
+ *    notch of the aortic valve closing, then the slow diastolic decay. Sampled
+ *    into the channel at HB_SAMPLE_MS.
+ *  - digitalRead: one short pulse per beat, the way the module's on-board
+ *    comparator reports it. Emitted while the systolic peak is above
+ *    HB_BEAT_LEVEL, which is ~12% of the cycle (~96 ms at 72 BPM) — the same
+ *    shape as the fixed 100 ms pulse this part used to emit, so sketches that
+ *    count digital edges keep working.
+ *
+ * Until this the part ONLY pulsed the digital pin and never touched the ADC,
+ * so every sketch reading the module the usual way (analogRead / ADC.read())
+ * saw a flat zero and reported 0 BPM. The notch is deliberately kept below the
+ * level a beat-detection threshold sits at, so a naive `value > THRESHOLD`
+ * peak counter sees one peak per cycle, not two.
+ *
+ * Rate comes from the `bpm` property and from the sensor control panel.
  */
+
+const HB_DEFAULT_BPM = 72;
+const HB_MIN_BPM = 30;
+const HB_MAX_BPM = 220;
+/** Sampling period of the analog output. 50 Hz is smooth on a 128 px trace. */
+const HB_SAMPLE_MS = 20;
+/** Rest and peak of the analog swing, as a fraction of the board's ADC rail. */
+const HB_LEVEL_LOW = 0.15;
+const HB_LEVEL_HIGH = 0.95;
+/** Waveform level the digital comparator output follows. Above the notch. */
+const HB_BEAT_LEVEL = 0.55;
+/**
+ * Give up on the ADC after this many failed writes. `setAdcVoltage` answers
+ * false when OUT is not wired to an ADC-capable pad, and the RP2040 branch
+ * warns on every call — retrying 50x a second would flood the console. A few
+ * tries still cover a simulator that is not up yet on the first tick.
+ */
+const HB_ANALOG_TRIES = 16;
+
+/**
+ * One cardiac cycle as [phase, level] control points, cosine-eased between
+ * them. Phase runs 0..1 over one beat; level runs 0 (diastolic floor) to 1
+ * (systolic peak).
+ */
+const HB_WAVEFORM: ReadonlyArray<readonly [number, number]> = [
+  [0.0, 0.06],
+  [0.09, 1.0], // systolic peak
+  [0.2, 0.34], // rapid fall
+  [0.3, 0.42], // dicrotic notch
+  [0.42, 0.28],
+  [1.0, 0.06], // diastolic decay back to the floor
+];
+
+/** Level of the pulse waveform at `phase` (any real; only the fraction matters). */
+export function heartBeatLevel(phase: number): number {
+  const p = phase - Math.floor(phase);
+  for (let i = 1; i < HB_WAVEFORM.length; i++) {
+    const [p1, v1] = HB_WAVEFORM[i];
+    if (p <= p1) {
+      const [p0, v0] = HB_WAVEFORM[i - 1];
+      const t = (p - p0) / (p1 - p0);
+      return v0 + (v1 - v0) * (0.5 - 0.5 * Math.cos(Math.PI * t));
+    }
+  }
+  return HB_WAVEFORM[HB_WAVEFORM.length - 1][1];
+}
+
+function heartBeatClampBpm(value: unknown, fallback: number): number {
+  const n = parseFloat(String(value));
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(HB_MAX_BPM, Math.max(HB_MIN_BPM, n));
+}
+
 PartSimulationRegistry.register('heart-beat-sensor', {
-  attachEvents: (element, simulator, getArduinoPinHelper) => {
+  attachEvents: (element, simulator, getArduinoPinHelper, componentId) => {
     const pin = getArduinoPinHelper('OUT');
     if (pin === null) return () => {};
 
+    const el = element as HTMLElement & { bpm?: string | number };
+    let bpm = heartBeatClampBpm(el.bpm, HB_DEFAULT_BPM);
+
+    const rail = analogRailVolts(simulator);
+    const voltsFor = (level: number) =>
+      rail * (HB_LEVEL_LOW + level * (HB_LEVEL_HIGH - HB_LEVEL_LOW));
+
+    let phase = 0;
+    // Negative, not 0: a clock legitimately reads 0 on the first tick, and a
+    // `last === 0` sentinel would then re-arm on the tick after.
+    let last = -1;
+    let onGuestClock = false;
+    let beat = false;
+    let analogOk = false;
+    let analogTries = 0;
+
+    const writeAnalog = (level: number) => {
+      if (!analogOk && analogTries >= HB_ANALOG_TRIES) return;
+      analogTries++;
+      if (setAdcVoltage(simulator, pin, voltsFor(level))) analogOk = true;
+    };
+
+    // Rest level first, so a sketch that reads before the first tick sees the
+    // sensor sitting at its baseline rather than at a phantom 0 V.
     simulator.setPinState(pin, false);
+    writeAnalog(heartBeatLevel(0));
 
-    const intervalId = setInterval(() => {
-      simulator.setPinState(pin, true); // pulse HIGH
-      setTimeout(() => simulator.setPinState(pin, false), 100);
-    }, 1000);
+    const tick = () => {
+      // Beat on the clock the SKETCH sees. An emulated board runs slower than
+      // real time, and a waveform stepped by the browser's clock sweeps past a
+      // guest managing a couple of loop iterations a second: it samples at
+      // effectively random phases and the BPM it computes from its own millis()
+      // is nowhere near the rate configured here. On the guest clock the sketch
+      // gets the same samples per beat it would get on real hardware, however
+      // fast or slow the emulator happens to be running.
+      const guest = guestMillis(simulator);
+      const useGuest = guest !== null;
+      const now = useGuest
+        ? (guest as number)
+        : typeof performance !== 'undefined'
+          ? performance.now()
+          : Date.now();
+      // Switching clocks (the engine came up, or went away) restarts the delta
+      // rather than integrating the offset between two unrelated timebases.
+      const dt =
+        last < 0 || useGuest !== onGuestClock ? HB_SAMPLE_MS : Math.min(now - last, 1000);
+      onGuestClock = useGuest;
+      last = now;
+      // Advance the phase rather than recomputing it from an epoch: the
+      // waveform then stays continuous when the rate changes mid-beat.
+      phase = (phase + (dt / 1000) * (bpm / 60)) % 1;
 
-    return () => clearInterval(intervalId);
+      const level = heartBeatLevel(phase);
+      writeAnalog(level);
+
+      const nextBeat = level >= HB_BEAT_LEVEL;
+      if (nextBeat !== beat) {
+        beat = nextBeat;
+        simulator.setPinState(pin, beat);
+        // The Wokwi element is a static SVG with no LED property to drive, so
+        // the visible beat is a brightness lift on the element itself.
+        if (el.style) el.style.filter = beat ? 'brightness(1.4)' : '';
+      }
+    };
+
+    const intervalId = setInterval(tick, HB_SAMPLE_MS);
+
+    registerSensorUpdate(componentId, (values) => {
+      if ('bpm' in values) {
+        bpm = heartBeatClampBpm(values.bpm, bpm);
+        el.bpm = bpm;
+        emitPropertyChange(componentId, 'bpm', bpm);
+      }
+    });
+
+    return () => {
+      clearInterval(intervalId);
+      unregisterSensorUpdate(componentId);
+      if (el.style) el.style.filter = '';
+      simulator.setPinState(pin, false);
+    };
   },
 });
 

--- a/frontend/src/simulation/parts/partUtils.ts
+++ b/frontend/src/simulation/parts/partUtils.ts
@@ -37,6 +37,50 @@ export function getADC(avrSimulator: AnySimulator): any | null {
 }
 
 /**
+ * Elapsed GUEST time in milliseconds, or null when this simulator cannot say.
+ *
+ * A part that generates a time-varying signal (a pulse waveform, a tone, any
+ * periodic source) must advance it on the clock the SKETCH sees, not on the
+ * browser's. The two are not the same rate: an emulated board runs slower than
+ * real time under load, so a signal stepped by `performance.now()` sweeps past
+ * a guest that is only managing a couple of loop iterations a second. The
+ * sketch then aliases it — samples land at effectively random phases and a
+ * beat / period measured from `millis()` comes out nowhere near what the part
+ * was asked to produce.
+ *
+ * Sources, in order:
+ *  - `getGuestMicros()` — engines that carry their own virtual clock but no
+ *    CPU cycle counter the host can read (the in-browser ESP32 engines).
+ *  - `getCurrentCycles()` + `getClockHz()` — AVR and RP2040.
+ *
+ * NOTE the cycle path is deliberately NOT reached through a "does this board
+ * have cycles?" test: several parts use `getCurrentCycles() >= 0` to tell an
+ * AVR from an ESP32 bridge, so that predicate must keep meaning what it does.
+ *
+ * Returns null for a backend-QEMU board, whose clock lives in another process;
+ * callers fall back to wall time.
+ */
+export function guestMillis(simulator: AnySimulator): number | null {
+  const sim = simulator as unknown as {
+    getGuestMicros?: () => number;
+    getCurrentCycles?: () => number;
+    getClockHz?: () => number;
+  };
+  if (typeof sim.getGuestMicros === 'function') {
+    const us = sim.getGuestMicros();
+    if (Number.isFinite(us) && us >= 0) return us / 1000;
+  }
+  if (typeof sim.getCurrentCycles === 'function' && typeof sim.getClockHz === 'function') {
+    const cycles = sim.getCurrentCycles();
+    const hz = sim.getClockHz();
+    if (Number.isFinite(cycles) && cycles >= 0 && Number.isFinite(hz) && hz > 0) {
+      return (cycles / hz) * 1000;
+    }
+  }
+  return null;
+}
+
+/**
  * Supply rail the analog front end of THIS board runs on, in volts.
  *
  * A part that builds a resistive divider has to use the rail it is actually

--- a/frontend/src/simulation/sensorControlConfig.ts
+++ b/frontend/src/simulation/sensorControlConfig.ts
@@ -404,6 +404,23 @@ export const SENSOR_CONTROLS: Record<string, SensorControlDef> = {
   },
 
   // ── Big Sound Sensor (FC-04) ──────────────────────────────────────────────
+  'heart-beat-sensor': {
+    title: 'Heart Beat Sensor',
+    controls: [
+      {
+        type: 'slider',
+        key: 'bpm',
+        label: 'Heart Rate',
+        min: 30,
+        max: 220,
+        step: 1,
+        unit: 'BPM',
+        defaultValue: 72,
+      },
+    ],
+    defaultValues: { bpm: 72 },
+  },
+
   'big-sound-sensor': {
     title: 'Sound Sensor',
     controls: [

--- a/frontend/src/simulation/spice/connectAnalogInputsToMcu.ts
+++ b/frontend/src/simulation/spice/connectAnalogInputsToMcu.ts
@@ -19,6 +19,15 @@
  *   • AC (.tran), ESP32: push the entire waveform to the QEMU MMIO
  *     via `setAdcWaveform` — QEMU does its own interpolation.
  *
+ * A part that models its OWN analog output (a pulse sensor's PPG waveform, a
+ * sensor module with no SPICE model that writes its channel directly) owns
+ * that pin, exactly as on the digital side — see `partPinOwnership`. All three
+ * paths below skip an owned pin. The older `sourcedNets` gate cannot stand in
+ * for that: the moment the user draws the wires the part needs, the net is
+ * component-backed and solves at whatever the passives say, which for an
+ * unmodelled sensor output is a phantom 0 V that stomps the part on every
+ * solve.
+ *
  * Extracted from the legacy `subscribeToStore.ts::wireElectricalSolver`
  * during Phase 1c step C of the mixed-mode migration.
  */
@@ -28,6 +37,7 @@ import {
 } from '../../store/useSimulatorStore';
 import { useElectricalStore } from '../../store/useElectricalStore';
 import { setAdcVoltage } from '../parts/partUtils';
+import { isPartOwnedPin } from '../partPinOwnership';
 import type { BoardKind } from '../../types/board';
 import { interpolateAt } from './waveformStats';
 import { boardPinToNumber } from '../../utils/boardPinMapping';
@@ -195,7 +205,10 @@ export function connectAnalogInputsToMcu(): () => void {
         if (v == null) continue;
         const clamped = Math.max(0, Math.min(vMax, v));
         const gpioPin = gpioForBoardPin(board.boardKind, pinName, channel);
-        if (gpioPin >= 0) setAdcVoltage(sim, gpioPin, clamped);
+        if (gpioPin < 0) continue;
+        // A part drives this channel itself — leave it alone (see above).
+        if (isPartOwnedPin(board.id, gpioPin)) continue;
+        setAdcVoltage(sim, gpioPin, clamped);
       }
     }
   }
@@ -262,6 +275,7 @@ export function connectAnalogInputsToMcu(): () => void {
             }
             const gpioPin = gpioFn(pinName, channel);
             if (gpioPin < 0) continue;
+            if (isPartOwnedPin(boardId, gpioPin)) continue;
             shim.setAdcWaveform(gpioPin, u12, periodNs);
             qemuWaveformChannels.add(`${boardId}:${channel}`);
             seen.add(channel);

--- a/frontend/src/store/useSimulatorStore.ts
+++ b/frontend/src/store/useSimulatorStore.ts
@@ -199,10 +199,27 @@ export class Esp32BridgeShim {
     this.bridge.sendPinEvent(pin, state);
   }
   getCurrentCycles(): number {
+    // Deliberately -1, even when the in-browser engine below DOES have a cycle
+    // counter: several parts read `getCurrentCycles() >= 0` to tell an AVR from
+    // an ESP32 bridge (ComplexParts' servo picks its whole strategy on it).
+    // Guest TIME is exposed separately, through getGuestMicros().
     return -1;
   }
   getClockHz(): number {
     return 240_000_000;
+  }
+  /**
+   * Elapsed guest time in microseconds, or -1 when this board's clock is not
+   * readable from the browser (backend QEMU runs in another process).
+   *
+   * An in-browser engine carries its own virtual clock, and a part generating a
+   * time-varying signal has to step it on THAT clock — see `guestMillis` in
+   * simulation/parts/partUtils. Optional on the bridge: the stock QEMU
+   * `Esp32Bridge` does not implement it and answers -1 here.
+   */
+  getGuestMicros(): number {
+    const b = this.bridge as unknown as { getGuestMicros?: () => number };
+    return typeof b.getGuestMicros === 'function' ? b.getGuestMicros() : -1;
   }
   isRunning(): boolean {
     return this.bridge.connected;

--- a/scripts/component-overrides.json
+++ b/scripts/component-overrides.json
@@ -2698,5 +2698,37 @@
       "input"
     ],
     "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"12\" y=\"38\" width=\"40\" height=\"18\" rx=\"2\" fill=\"#1f6f43\" stroke=\"#2d8f5a\" stroke-width=\"0.6\"/>\n    <rect x=\"17\" y=\"54\" width=\"2.5\" height=\"6\" fill=\"#d8b24a\"/>\n    <rect x=\"24\" y=\"54\" width=\"2.5\" height=\"6\" fill=\"#d8b24a\"/>\n    <rect x=\"31\" y=\"54\" width=\"2.5\" height=\"6\" fill=\"#d8b24a\"/>\n    <rect x=\"38\" y=\"54\" width=\"2.5\" height=\"6\" fill=\"#d8b24a\"/>\n    <rect x=\"45\" y=\"54\" width=\"2.5\" height=\"6\" fill=\"#d8b24a\"/>\n    <circle cx=\"32\" cy=\"24\" r=\"15\" fill=\"#9aa3ad\" stroke=\"#6b7280\" stroke-width=\"1\"/>\n    <circle cx=\"32\" cy=\"24\" r=\"10\" fill=\"#c7cdd4\"/>\n    <rect x=\"31\" y=\"11\" width=\"2\" height=\"8\" rx=\"1\" fill=\"#475569\"/>\n    <path d=\"M 45 14 A 16 16 0 0 1 49 27\" fill=\"none\" stroke=\"#4ade80\" stroke-width=\"2\" stroke-linecap=\"round\"/>\n    <path d=\"M 49 27 l -4 -1 l 2 -4 z\" fill=\"#4ade80\"/></svg>"
+  },
+  "heart-beat-sensor": {
+    "properties": {
+      "bpm": {
+        "name": "bpm",
+        "type": "number",
+        "defaultValue": 72,
+        "control": "number",
+        "min": 30,
+        "max": 220,
+        "description": "Simulated heart rate in beats per minute"
+      }
+    },
+    "defaultValues": {
+      "bpm": 72
+    },
+    "name": "Heart Beat Sensor",
+    "category": "sensors",
+    "description": "Optical heart-rate (pulse) sensor module. OUT carries a photoplethysmogram: read it with analogRead for the waveform, or with digitalRead for one pulse per beat. Set the rate with the bpm property or the sensor panel.",
+    "tags": [
+      "heart-beat-sensor",
+      "heart rate",
+      "heart",
+      "beat",
+      "pulse",
+      "bpm",
+      "ppg",
+      "ky-039",
+      "pulse sensor",
+      "sensor"
+    ],
+    "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" rx=\"4\" fill=\"#101820\"/><rect x=\"8\" y=\"12\" width=\"48\" height=\"40\" rx=\"3\" fill=\"#1c5aa8\" stroke=\"#2f7fd6\" stroke-width=\"0.8\"/><circle cx=\"21\" cy=\"26\" r=\"6\" fill=\"#0d2b52\" stroke=\"#6fa8dc\" stroke-width=\"0.8\"/><circle cx=\"21\" cy=\"26\" r=\"2.6\" fill=\"#e04b5a\"/><rect x=\"33\" y=\"20\" width=\"9\" height=\"12\" rx=\"1.5\" fill=\"#0b1c33\" stroke=\"#6fa8dc\" stroke-width=\"0.7\"/><path d=\"M11 43h7l3-7 4 13 4-9 3 3h21\" fill=\"none\" stroke=\"#ffffff\" stroke-width=\"1.6\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/><g fill=\"#d4af37\"><rect x=\"46\" y=\"14\" width=\"4\" height=\"1.8\"/><rect x=\"46\" y=\"18\" width=\"4\" height=\"1.8\"/><rect x=\"46\" y=\"22\" width=\"4\" height=\"1.8\"/></g></svg>"
   }
 }


### PR DESCRIPTION
The heart beat sensor only ever pulsed the digital pin. Every sketch that read it the usual way for a pulse sensor (`analogRead` / `ADC.read()`) saw a flat zero and computed 0 BPM, which is exactly what the `100d-pulse-monitor` example showed: a flat line and `0 BPM`.

Of the projects using this part, 7 read it analog and 5 read it digital, so both meanings of the single output pin now work, the way the hardware does:

- **analogRead**: a photoplethysmogram sampled into the ADC channel at 50 Hz, with a fast systolic upstroke, the dicrotic notch of the aortic valve closing, and the slow diastolic decay.
- **digitalRead**: one short pulse per beat (~12% of the cycle), the same shape as the fixed 100 ms pulse this part used to emit, so digital sketches keep working.

The notch is deliberately kept below a typical detection threshold, so a naive `value > THRESHOLD` peak counter sees one peak per beat rather than two.

## Configurable rate

A `bpm` property (30-220, default 72) plus a slider in the sensor control panel. The part had no properties at all before. It also sat in the `other` category with a grey placeholder thumbnail, and is now a `sensors` entry with a drawn thumbnail and searchable tags.

## Two supporting fixes

Both of these bite any part that models its own analog output, not just this one.

**The waveform steps on the guest clock** (`partUtils.guestMillis`), not the browser's. An emulated board does not run at real time, so a waveform stepped by `performance.now()` gets sampled at effectively random phases: the example measured 8 BPM for a 72 BPM pulse. `getCurrentCycles()` still deliberately answers -1 on the ESP32 shim, because several parts read that to tell an AVR from a bridge, so guest *time* is exposed separately as `getGuestMicros()`.

**`connectAnalogInputsToMcu` now skips a part-owned pin**, the way the digital path already did. Otherwise the solve stomps the part's own channel with a phantom 0 V the moment the user draws the wires the part needs. This also protects the gas, flame and sound sensors, which until now relied on the fragile `sourcedNets` gate.

## The example

It sampled once per redraw, which worked out to about one sample per beat. It now takes a burst of samples per frame and drops the impossible intervals left by a beat missed while the screen redraws.

## Verification

Against a local build proxied to the production backend:

| Measure | Before | After |
|---|---|---|
| BPM a plain sampling sketch reads | 0 | 71-72 |
| BPM in the example | 0 | 60 |
| ADC reading | flat 0 | 819-3890 |

35 tests in `sensor-parts.test.ts` (10 new), plus the metadata, sensor-control, analog and example-gallery suites. Typecheck adds no new errors (master had 422, this has 421).

One limit remains and it is not the sensor's: the example reads 60 rather than 72 because the in-browser ESP32 engine executes MicroPython far slower than its virtual clock advances, so redrawing the screen swallows whole beats. A sketch that only samples measures the rate exactly.