### PR TITLE
fix(neopixel): make the WS2812 parts work on every board that can drive one

### DIFF
--- a/backend/app/services/esp32_signals.py
+++ b/backend/app/services/esp32_signals.py
@@ -38,6 +38,31 @@ SIG_LEDC_LS_CH0_OUT_IDX = 79  # add N for LS channel N (0..7)
 SIG_LEDC_LS_CH_LAST     = 86
 
 
+# RMT_SIG_OUT0_IDX per chip, read from the IDF headers shipped in this image
+# (components/soc/<chip>/include/soc/gpio_sig_map.h). Add the RMT TX channel
+# number to get the signal a GPIO must carry for that channel to reach the pad.
+#
+# Needed because the WS2812 frames the RMT decoder produces are useless to the
+# frontend without the GPIO they went out on: a NeoPixel PART on the canvas is
+# keyed by its DIN pin, and an RMT channel number cannot reach one.
+RMT_SIG_OUT0_IDX_BY_CHIP = {
+    'esp32': 87,
+    'esp32-s3': 81,
+    'esp32-c3': 51,
+}
+
+
+def rmt_signal_base(machine: str) -> int | None:
+    """The chip's RMT_SIG_OUT0_IDX, from a machine string like 'esp32-s3'."""
+    if not machine:
+        return None
+    if 'c3' in machine:
+        return RMT_SIG_OUT0_IDX_BY_CHIP['esp32-c3']
+    if 's3' in machine:
+        return RMT_SIG_OUT0_IDX_BY_CHIP['esp32-s3']
+    return RMT_SIG_OUT0_IDX_BY_CHIP['esp32']
+
+
 def ledc_signal_for_channel(channel: int) -> int:
     """Map a velxio-style unified LEDC channel index (0..15) to its
     GPIO Matrix signal source id.
@@ -77,6 +102,8 @@ __all__ = [
     "SIG_LEDC_LS_CH0_OUT_IDX",
     "SIG_LEDC_LS_CH_LAST",
     "SIG_GPIO_DIRECT_OUT_IDX",
+    "RMT_SIG_OUT0_IDX_BY_CHIP",
+    "rmt_signal_base",
     "ledc_signal_for_channel",
     "channel_for_ledc_signal",
 ]

--- a/backend/app/services/esp32_worker.py
+++ b/backend/app/services/esp32_worker.py
@@ -318,15 +318,20 @@ class _CallbacksT(ctypes.Structure):
 
 # ─── RMT / WS2812 NeoPixel decoder ───────────────────────────────────────────
 
-_WS2812_HIGH_THRESHOLD = 48  # RMT ticks; high pulse > threshold → bit 1
-
-
 def _decode_rmt_item(value: int) -> tuple[int, int, int, int]:
-    """Unpack a 32-bit RMT item → (level0, duration0, level1, duration1)."""
-    level0    = (value >> 31) & 1
-    duration0 = (value >> 16) & 0x7FFF
-    level1    = (value >> 15) & 1
-    duration1 =  value        & 0x7FFF
+    """Unpack a 32-bit RMT item → (level0, duration0, level1, duration1).
+
+    The layout is duration0[14:0], level0[15], duration1[30:16], level1[31] —
+    duration0 lives in the LOW half (IDF's rmt_symbol_word_t, and the legacy
+    rmt_item32_t before it). The two halves used to be read mirrored, so on a
+    WS2812 symbol — whose second half is always the low period, level1 = 0 —
+    `level0` came out 0 for every item and the bit classifier below, which is
+    gated on level0 == 1, never appended a single bit.
+    """
+    duration0 =  value        & 0x7FFF
+    level0    = (value >> 15) & 1
+    duration1 = (value >> 16) & 0x7FFF
+    level1    = (value >> 31) & 1
     return level0, duration0, level1, duration1
 
 
@@ -350,7 +355,7 @@ class _RmtDecoder:
         Process one RMT item.
         Returns a list of {r, g, b} pixel dicts on end-of-frame, else None.
         """
-        level0, dur0, _, dur1 = _decode_rmt_item(value)
+        level0, dur0, _level1, dur1 = _decode_rmt_item(value)
 
         # Reset pulse (both durations zero) signals end of frame
         if dur0 == 0 and dur1 == 0:
@@ -359,9 +364,15 @@ class _RmtDecoder:
             self._bits.clear()
             return pix or None
 
-        # Classify the high pulse → bit 1 or bit 0
+        # Classify the bit by comparing the two halves of its own symbol, not
+        # against an absolute tick count. A WS2812 '1' is high-longer-than-low
+        # and a '0' is high-shorter-than-low whatever resolution the driver
+        # picked — the in-browser engine decodes it exactly this way. The old
+        # fixed threshold of 48 ticks was an order of magnitude off for the two
+        # drivers in this image, which both build symbols at 10 MHz with 8 ticks
+        # for a 1 and 4 for a 0, so every bit classified as 0: a black strip.
         if level0 == 1 and dur0 > 0:
-            self._bits.append(1 if dur0 > _WS2812_HIGH_THRESHOLD else 0)
+            self._bits.append(1 if dur0 > dur1 else 0)
 
         # Every 24 bits → one GRB pixel → convert to RGB
         while len(self._bits) >= 24:
@@ -682,6 +693,7 @@ def main() -> None:  # noqa: C901  (complexity OK for inline worker)
             ledc_signal_for_channel,
             SIG_LEDC_HS_CH0_OUT_IDX,
             SIG_LEDC_LS_CH_LAST,
+            rmt_signal_base,
         )
     except ImportError:
         import importlib.util as _ilu, pathlib as _pl
@@ -695,7 +707,34 @@ def main() -> None:  # noqa: C901  (complexity OK for inline worker)
         ledc_signal_for_channel = sys.modules['esp32_signals'].ledc_signal_for_channel
         SIG_LEDC_HS_CH0_OUT_IDX = sys.modules['esp32_signals'].SIG_LEDC_HS_CH0_OUT_IDX
         SIG_LEDC_LS_CH_LAST = sys.modules['esp32_signals'].SIG_LEDC_LS_CH_LAST
+        rmt_signal_base = sys.modules['esp32_signals'].rmt_signal_base
     _signal_router = SignalRouter()
+    _rmt_sig_base = rmt_signal_base(machine)
+
+    def _gpio_for_rmt_channel(channel: int) -> int | None:
+        """Which GPIO an RMT TX channel is routed to, or None.
+
+        The decoded pixels are useless to the frontend without this: a NeoPixel
+        PART on the canvas is keyed by its DIN pin, and the channel number
+        cannot reach one, so every ws2812_update was delivered to nobody.
+
+        Read straight from the GPIO matrix rather than the SignalRouter, whose
+        snapshot deliberately keeps only the LEDC signal window.
+        """
+        if _rmt_sig_base is None:
+            return None
+        want = _rmt_sig_base + channel
+        try:
+            out_sel_ptr = lib.qemu_picsimlab_get_internals(2)
+            if not out_sel_ptr:
+                return None
+            out_sel = (ctypes.c_uint32 * _GPIO_COUNT).from_address(out_sel_ptr)
+            for gpio_pin in range(_GPIO_COUNT):
+                if (int(out_sel[gpio_pin]) & 0xFF) == want:
+                    return gpio_pin
+        except Exception:  # noqa: BLE001
+            return None
+        return None
 
     def _refresh_signal_routing() -> None:
         """Scan `gpio_out_sel[40]` and reconcile the SignalRouter.
@@ -1305,7 +1344,8 @@ def main() -> None:  # noqa: C901  (complexity OK for inline worker)
             _rmt_decoders[channel] = _RmtDecoder(channel)
         pixels = _rmt_decoders[channel].feed(value)
         if pixels:
-            _emit({'type': 'ws2812_update', 'channel': channel, 'pixels': pixels})
+            _emit({'type': 'ws2812_update', 'channel': channel,
+                   'pin': _gpio_for_rmt_channel(channel), 'pixels': pixels})
 
     def _on_gpio_matrix(gpio: int, signal_id: int) -> None:
         """Synchronous GPIO Matrix routing event from libqemu 1.1.0+.

--- a/frontend/src/__tests__/sensor-parts.test.ts
+++ b/frontend/src/__tests__/sensor-parts.test.ts
@@ -782,6 +782,51 @@ describe('WS2812 edge decode — scales to the board clock', () => {
     expect(el.b).toBe(1);
   });
 
+  /**
+   * An engine whose PIO does not model instruction delays (rp2040js) emits the
+   * right SHAPE at the wrong scale: measured, a '1' comes out 2 steps high / 1
+   * low and a '0' 1 high / 2 low, a bit period of 3 where the wire says 10.
+   * Every one of those widths is far under any threshold derived from real
+   * WS2812 timing, so an absolute rule reads 0x000000 off a perfectly good
+   * frame — which is what the Pico did.
+   */
+  it('decodes a waveform compressed 3x by an engine that skips PIO delays', () => {
+    const logic = PartSimulationRegistry.get('neopixel')!;
+    let t = 0;
+    let handler: ((pin: number, high: boolean) => void) | null = null;
+    const sim = {
+      pinManager: {
+        onPinChange: vi.fn((_p: number, cb: (p: number, h: boolean) => void) => {
+          handler = cb;
+          return () => {};
+        }),
+        onPwmChange: vi.fn().mockReturnValue(() => {}),
+        triggerPinChange: vi.fn(),
+      },
+      getADC: vi.fn().mockReturnValue(null),
+      setPinState: vi.fn(),
+      getClockHz: () => 125_000_000,
+      getCurrentCycles: () => t,
+    };
+    const el = makeElement() as any;
+    logic.attachEvents!(el, sim as any, pinMap({ DIN: 6 }));
+
+    t += 4000; // latch
+    for (const byte of [0x00, 0xff, 0x00]) {
+      for (let i = 7; i >= 0; i--) {
+        const one = (byte >> i) & 1;
+        handler!(6, true);
+        t += one ? 2 : 1;
+        handler!(6, false);
+        t += one ? 1 : 2;
+      }
+    }
+
+    expect(el.r).toBe(1); // 0xFF in the R slot (GRB order)
+    expect(el.g).toBe(0);
+    expect(el.b).toBe(0);
+  });
+
   it('does not attach the edge decoder when the board has no cycle counter', () => {
     // The ESP32 shim answers -1. Decoding edges against a frozen clock makes
     // every high measure 0 cycles and paints solid black over the frames the

--- a/frontend/src/simulation/Esp32Bridge.ts
+++ b/frontend/src/simulation/Esp32Bridge.ts
@@ -26,7 +26,8 @@
  *     { type: 'ledc_duty',     data: { channel: number, duty_pct: number } }
  *     { type: 'gpio_routing',  data: { gpio: number, signal_id: number } }
  *     { type: 'gpio_routing_clear', data: { gpio: number } }
- *     { type: 'ws2812_update', data: { channel: number, pixels: [number, number, number][] } }
+ *     { type: 'ws2812_update', data: { channel: number, pin?: number,
+ *                                        pixels: Array<{r,g,b}> | [r,g,b][] } }
  *     { type: 'i2c_event',        data: { addr: number, data: number } }
  *     { type: 'i2c_transaction',  data: { addr: number, data: number[] } }
  *     { type: 'spi_event',        data: { data: number } }
@@ -511,8 +512,16 @@ export class Esp32Bridge {
         }
         case 'ws2812_update': {
           const channel = msg.data.channel as number;
-          const raw = msg.data.pixels as [number, number, number][];
-          const pixels: Ws2812Pixel[] = raw.map(([r, g, b]) => ({ r, g, b }));
+          // The QEMU worker sends objects ({r,g,b}, esp32_worker._RmtDecoder);
+          // the header above documents triplets, and destructuring an object as
+          // an array yields three undefineds — a whole strip of NaN. Accept
+          // both rather than pick a side and break the other producer.
+          const raw = msg.data.pixels as Array<
+            [number, number, number] | { r: number; g: number; b: number }
+          >;
+          const pixels: Ws2812Pixel[] = raw.map((px) =>
+            Array.isArray(px) ? { r: px[0], g: px[1], b: px[2] } : px,
+          );
           const pin = msg.data.pin as number | undefined;
           this.onWs2812Update?.(channel, pixels, pin ?? null);
           break;

--- a/frontend/src/simulation/RP2040Simulator.ts
+++ b/frontend/src/simulation/RP2040Simulator.ts
@@ -1221,6 +1221,22 @@ export class RP2040Simulator implements LineCapable {
   }
 
   /**
+   * Simulated time in NANOSECONDS, or -1 before the chip exists.
+   *
+   * A CPU cycle count is the wrong ruler for anything a PERIPHERAL emits. The
+   * PIO runs off its own divider and steps between instructions, so several
+   * PIO edges can land inside one CPU cycle and read back as simultaneous —
+   * which is what made a WS2812 driven from PIO (every RP2040 NeoPixel, see
+   * Adafruit_Neopixel_RP2.cpp) decode as zero-width pulses. rp2040js advances
+   * this clock per instruction in execOne, before stepPIO, so it separates
+   * edges the cycle counter cannot.
+   */
+  getCurrentNanos(): number {
+    const clock = (this.rp2040 as unknown as { clock?: { nanos?: number } } | null)?.clock;
+    return typeof clock?.nanos === 'number' ? clock.nanos : -1;
+  }
+
+  /**
    * Schedule a GPIO pin state change at a specific future cycle count.
    * Enables cycle-accurate protocol simulation (e.g. HC-SR04 echo timing).
    */

--- a/frontend/src/simulation/line/requestLine.ts
+++ b/frontend/src/simulation/line/requestLine.ts
@@ -69,8 +69,27 @@ export function clearLineGaps(): void {
   gaps.clear();
 }
 
+/**
+ * The key a refusal is filed under.
+ *
+ * Keyed by COMPONENT when the caller identifies itself, so a part that is
+ * rewired replaces its own entry instead of leaving one behind. Keyed by
+ * type@pin only for anonymous callers, which is what the map used to do for
+ * everyone: rewire a refused DHT22 from GPIO 4 to a pin the board can host and
+ * the success deleted dht22@5 while dht22@4 stayed, so the Circuit check kept
+ * telling a user who had already fixed their wiring that it was still broken.
+ */
+function gapKey(rec: LineSensorRecord, opts?: LineRequestOptions): string {
+  return opts?.componentId ? `#${opts.componentId}` : `${rec.sensor_type}@${rec.pin}`;
+}
+
+/** Drop a part's recorded refusal — call from a part's cleanup. */
+export function releaseLineGap(componentId: string): void {
+  gaps.delete(`#${componentId}`);
+}
+
 function refuse(rec: LineSensorRecord, why: string, opts?: LineRequestOptions): LineRefusal {
-  gaps.set(`${rec.sensor_type}@${rec.pin}`, {
+  gaps.set(gapKey(rec, opts), {
     sensorType: rec.sensor_type,
     pin: rec.pin,
     why,
@@ -105,7 +124,7 @@ export function requestLine(
     const hub = isLineCapable(sim) && sim.lineHub ? sim.lineHub() : null;
     if (!hub) return refuse(rec, 'the board declares local line support but provides no hub', opts);
     hub.attach(rec);
-    gaps.delete(`${rec.sensor_type}@${rec.pin}`);
+    gaps.delete(gapKey(rec, opts));
     return {
       mode: 'local',
       update: (props) => hub.update(rec.pin, props),
@@ -128,7 +147,7 @@ export function requestLine(
     const { sensor_type, pin, ...props } = rec;
     const taken = chan.registerSensor(sensor_type, pin, props);
     if (!taken) return refuse(rec, 'the host declined the sensor', opts);
-    gaps.delete(`${rec.sensor_type}@${rec.pin}`);
+    gaps.delete(gapKey(rec, opts));
     return {
       mode: 'hosted',
       update: (p) => chan.updateSensor?.(pin, { ...props, ...p }),

--- a/frontend/src/simulation/parts/ProtocolParts.ts
+++ b/frontend/src/simulation/parts/ProtocolParts.ts
@@ -19,7 +19,7 @@
  */
 
 import { PartSimulationRegistry } from './PartSimulationRegistry';
-import { requestLine } from '../line/requestLine';
+import { requestLine, releaseLineGap } from '../line/requestLine';
 import { VirtualDS1307, VirtualBMP280, VirtualDS3231, VirtualPCF8574 } from '../I2CBusManager';
 import type { I2CDevice } from '../I2CBusManager';
 import { HD44780Decoder } from '../HD44780Decoder';
@@ -634,6 +634,9 @@ PartSimulationRegistry.register('dht22', {
 
     return () => {
       if (answer.mode !== 'none') answer.release();
+      // A refusal left a gap recorded; drop it so a rewire cannot keep
+      // reporting a sensor the user has already moved.
+      else releaseLineGap(componentId);
       unregisterSensorUpdate(componentId);
     };
   },

--- a/frontend/src/simulation/parts/SensorParts.ts
+++ b/frontend/src/simulation/parts/SensorParts.ts
@@ -18,9 +18,10 @@
  */
 
 import { PartSimulationRegistry } from './PartSimulationRegistry';
-import { requestLine } from '../line/requestLine';
+import { requestLine, releaseLineGap } from '../line/requestLine';
 import { setAdcVoltage, emitPropertyChange, analogRailVolts, guestMillis } from './partUtils';
 import { registerSensorUpdate, unregisterSensorUpdate } from '../SensorUpdateRegistry';
+import { useSimulatorStore } from '../../store/useSimulatorStore';
 
 // ─── Tilt Switch ─────────────────────────────────────────────────────────────
 
@@ -627,12 +628,24 @@ export function createNeopixelDecoder(
   // every edge timestamped at cycle 0, so every high measured 0 cycles, every
   // bit decoded as 0, and the part painted #000000 on every frame. Reading
   // black off a real signal looks exactly like a part that does nothing.
-  const readCycles = (): number => {
+  // Prefer NANOSECONDS. A cycle count is the wrong ruler for a signal a
+  // PERIPHERAL emits: the RP2040/RP2350 PIO steps between CPU instructions off
+  // its own divider, so several pixel edges land inside one cycle and read back
+  // as simultaneous. Cycles remain the fallback for cores that bit-bang from
+  // CPU code (the AVR), where they are exact.
+  let unitHz = Number(simulator.getClockHz?.()) || 16_000_000;
+  const readNanos = (): number => {
+    const ns = simulator.getCurrentNanos?.();
+    if (typeof ns === 'number' && ns >= 0) {
+      unitHz = 1e9;
+      return ns;
+    }
     const c = simulator.getCurrentCycles?.();
     if (typeof c === 'number' && c >= 0) return c;
     const legacy = simulator.cpu?.cycles;
     return typeof legacy === 'number' ? legacy : -1;
   };
+  const readCycles = readNanos;
   // A board with no cycle counter cannot be decoded from edges at all (the
   // ESP32 shim answers -1: its guest runs in an engine or in QEMU). Refuse
   // rather than decode garbage — those boards deliver whole frames instead,
@@ -640,15 +653,23 @@ export function createNeopixelDecoder(
   // broken clock would paint black straight over them.
   if (readCycles() < 0) return () => {};
 
-  // Physical WS2812B timings in cycles of THIS board's clock: a '1' holds the
-  // line high ~0.7 us and a '0' ~0.35 us, so 0.5 us splits them; a frame is
-  // latched by >50 us low. On a 16 MHz AVR these come out as the 8 and 800 that
-  // used to be hard-coded here — which is why the AVR was the one family where
-  // this worked, and why every faster core silently decoded all-ones or,
-  // without a working clock, all-zeros.
-  const clockHz = Number(simulator.getClockHz?.()) || 16_000_000;
-  const BIT1_THRESHOLD = Math.max(1, Math.round(clockHz * 0.5e-6));
-  const RESET_CYCLES = Math.max(8 * BIT1_THRESHOLD, Math.round(clockHz * 50e-6));
+  // Classify each bit AGAINST ITS OWN BIT PERIOD, not against an absolute
+  // width. A WS2812 '1' holds the line high for ~56% of the bit period and a
+  // '0' for ~28%, and that RATIO is the one thing every engine reproduces: it
+  // is 70/125 vs 35/125 on real silicon, 2/3 vs 1/3 under rp2040js (which does
+  // not model PIO instruction delays, so its waveform is ~3x fast), and 7/10 vs
+  // 2/10 under rp2350js. An absolute threshold is right for exactly one of
+  // those three and silently reads 0x00 or 0xFF for the others.
+  //
+  // Seeded from the nominal 1.25 us bit period so the very first edge pair of a
+  // run has something to compare against; every completed bit replaces it with
+  // what this board actually produces.
+  const perSecond = () => unitHz;
+  let periodRef = Math.max(2, Math.round(perSecond() * 1.25e-6));
+  // The only threshold that stays absolute, because it separates FRAMES rather
+  // than bits: a WS2812 latches after >50 us low, which no bit period comes
+  // near on any engine.
+  const latchGap = () => Math.max(8 * periodRef, Math.round(perSecond() * 50e-6));
 
   let lastRisingCycle = 0;
   let lastFallingCycle = 0;
@@ -659,40 +680,70 @@ export function createNeopixelDecoder(
   let byteBuf: number[] = [];
   let pixelIndex = 0;
 
+  let lastHighDur = 0;
+  // The first bit after a latch is held until its low arrives, because only
+  // then is this board's bit period known. Classifying it against the seeded
+  // period got the top bit of every frame's first byte wrong on the RP2040
+  // (0xFF read back 0x80 — a green pixel at half brightness). Only ever the
+  // FIRST bit of a frame, so the last bit is never left pending and no pixel
+  // is dropped at the end of a run.
+  let pendingHigh = -1;
+
+  /** Fold one decoded bit into the frame, emitting a pixel every 24. */
+  const pushBit = (bit: number) => {
+    bitBuf = (bitBuf << 1) | bit;
+    bitsCollected++;
+    if (bitsCollected < 8) return;
+    byteBuf.push(bitBuf & 0xff);
+    bitBuf = 0;
+    bitsCollected = 0;
+    if (byteBuf.length === 3) {
+      const [g, r, b] = byteBuf;
+      onPixel(pixelIndex++, r, g, b);
+      byteBuf = [];
+    }
+  };
+
   const unsub = pinManager.onPinChange(pinDIN, (_: number, high: boolean) => {
     const now = readCycles();
 
     if (high) {
       const lowDur = now - lastFallingCycle;
-      if (lowDur > RESET_CYCLES) {
+      const isLatch = lowDur > latchGap();
+      // Learn this board's real bit period from the bit that just finished —
+      // its high plus the low that followed. A latch gap is not a bit, so it
+      // never pollutes the reference.
+      if (!isLatch && lowDur > 0) {
+        if (pendingHigh >= 0) periodRef = pendingHigh + lowDur;
+        else if (lastHighDur > 0) periodRef = lastHighDur + lowDur;
+      }
+      if (pendingHigh >= 0) {
+        pushBit(pendingHigh * 2 > periodRef ? 1 : 0);
+        pendingHigh = -1;
+      }
+      if (isLatch) {
         pixelIndex = 0;
         byteBuf = [];
         bitBuf = 0;
         bitsCollected = 0;
+        // Next bit is the frame's first: hold it for its own period.
+        lastHighDur = 0;
       }
       lastRisingCycle = now;
       lastHigh = true;
     } else {
       if (lastHigh) {
         const highDur = now - lastRisingCycle;
-        const bit = highDur > BIT1_THRESHOLD ? 1 : 0;
-
-        bitBuf = (bitBuf << 1) | bit;
-        bitsCollected++;
-
-        if (bitsCollected === 8) {
-          byteBuf.push(bitBuf & 0xff);
-          bitBuf = 0;
-          bitsCollected = 0;
-
-          if (byteBuf.length === 3) {
-            const g = byteBuf[0];
-            const r = byteBuf[1];
-            const b = byteBuf[2];
-            onPixel(pixelIndex++, r, g, b);
-            byteBuf = [];
-          }
+        // No measurable time between the edges means this board reports every
+        // edge in a frame at the same instant. There is no signal to recover;
+        // emitting anyway paints a confident wrong colour (solid black on the
+        // RP boards for two releases). Stay silent and let the liveness
+        // warning in attachWs2812Part tell the user something real.
+        if (periodRef > 0 && (highDur > 0 || lastHighDur > 0)) {
+          if (lastHighDur === 0) pendingHigh = highDur; // frame's first bit
+          else pushBit(highDur * 2 > periodRef ? 1 : 0);
         }
+        lastHighDur = highDur;
       }
       lastFallingCycle = now;
       lastHigh = false;
@@ -700,6 +751,61 @@ export function createNeopixelDecoder(
   });
 
   return unsub;
+}
+
+/** How long a run may go without a single pixel frame before we say so. Long
+ *  enough for a cold guest to boot and reach the first show(). */
+const NO_PIXEL_GRACE_MS = 6000;
+
+/**
+ * Call `next` whenever the simulation re-arms (Run / Reset bump hexEpoch).
+ *
+ * Same subscription the burnout monitor uses. Imported lazily through the store
+ * module the parts already depend on; in a unit test with no live store this
+ * degrades to "never fires", which is what the tests want.
+ */
+function onRunEpoch(next: (epoch: number) => void): () => void {
+  try {
+    const store = useSimulatorStore as unknown as {
+      subscribe?: (fn: (s: { hexEpoch?: number; running?: boolean }) => void) => () => void;
+      getState?: () => { hexEpoch?: number; running?: boolean };
+    };
+    if (typeof store?.subscribe !== 'function') return () => {};
+    const seed = store.getState?.();
+    if (seed?.running) next(seed.hexEpoch ?? 0);
+    return store.subscribe((st) => {
+      if (st.running) next(st.hexEpoch ?? 0);
+    });
+  } catch (_) {
+    return () => {};
+  }
+}
+
+/**
+ * Report, once, that a WS2812 part received nothing for a whole run.
+ *
+ * Goes to `velxio-circuit-fault`, the channel the dead-solve reporter and the
+ * burnout monitor already use, so it lands in the Circuit check group of the
+ * output console the user is already reading — rather than inventing a fourth
+ * place to look.
+ */
+function reportNoPixelData(pinDIN: number): void {
+  const message =
+    `NeoPixel on DIN ${pinDIN}: no pixel data reached this part in the first ` +
+    `${NO_PIXEL_GRACE_MS / 1000} s of the run. The sketch may be fine — this ` +
+    `board's core can drive WS2812 through a hardware peripheral (RMT on ` +
+    `ESP32, PIO on RP2040) that this engine does not decode. Changing the ` +
+    `colour order, the supply pad or the data pin will not help.`;
+  try {
+    window.dispatchEvent(
+      new CustomEvent('velxio-circuit-fault', {
+        detail: { kind: 'no-pixel-data', message },
+      }),
+    );
+  } catch (_) {
+    // No DOM (unit tests) — the console line below is the whole report.
+  }
+  console.warn(`[ws2812] ${message}`);
 }
 
 /**
@@ -729,7 +835,13 @@ function attachWs2812Part(
   pinDIN: number,
   onPixel: (index: number, r: number, g: number, b: number) => void,
 ): () => void {
-  const unsubDecoder = createNeopixelDecoder(simulator as any, pinDIN, onPixel);
+  let gotPixel = false;
+  const paint = (index: number, r: number, g: number, b: number) => {
+    gotPixel = true;
+    onPixel(index, r, g, b);
+  };
+
+  const unsubDecoder = createNeopixelDecoder(simulator as any, pinDIN, paint);
 
   const hw = simulator as {
     subscribeWs2812?: (
@@ -739,10 +851,45 @@ function attachWs2812Part(
   };
   const unsubHardware =
     hw.subscribeWs2812?.(pinDIN, (pixels) => {
-      pixels.forEach((px, i) => onPixel(i, px.r, px.g, px.b));
+      pixels.forEach((px, i) => paint(i, px.r, px.g, px.b));
     }) ?? (() => {});
 
+  // Say something when NOTHING arrives.
+  //
+  // Both sources above fail silently by design: the decoder returns a no-op
+  // when the board has no clock, and the hardware feed is an optional chain.
+  // A part wired correctly to a board whose engine cannot produce its data
+  // therefore sat black and said nothing — that silence is what cost a real
+  // user two weeks, not the missing pixels.
+  //
+  // Deliberately a LIVENESS check and not a capability check. A capability
+  // probe answers "yes" for three of the boards that are actually dark: the
+  // ESP32 shim exposes subscribeWs2812 whatever engine is behind it, and the
+  // RP2040 answers getCurrentCycles() even though its PIO produces no
+  // decodable edges. Only observing that no frame arrived is honest.
+  //
+  // Armed off the store's run epoch, never off attach: parts attach at MOUNT
+  // and re-attach on any rewire, so a timer started here would fire long
+  // before the user pressed Run.
+  let warned = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let lastEpoch: number | null = null;
+  const armed = onRunEpoch((epoch) => {
+    if (epoch === lastEpoch) return;
+    lastEpoch = epoch;
+    gotPixel = false;
+    if (timer !== null) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = null;
+      if (gotPixel || warned) return;
+      warned = true;
+      reportNoPixelData(pinDIN);
+    }, NO_PIXEL_GRACE_MS);
+  });
+
   return () => {
+    if (timer !== null) clearTimeout(timer);
+    armed();
     unsubDecoder();
     unsubHardware();
   };
@@ -899,6 +1046,9 @@ PartSimulationRegistry.register('hc-sr04', {
 
     return () => {
       if (answer.mode !== 'none') answer.release();
+      // A refusal left a gap recorded; drop it so a rewire cannot keep
+      // reporting a sensor the user has already moved.
+      else releaseLineGap(componentId);
       unregisterSensorUpdate(componentId);
     };
   },

--- a/frontend/src/simulation/verify/circuitVerifier.ts
+++ b/frontend/src/simulation/verify/circuitVerifier.ts
@@ -109,19 +109,6 @@ export async function verifyCircuit(
   // blocking "cannot emulate" fault below.
   const nonFiniteBranches = new Set<string>();
 
-  // Run a forced .op solve so currents are scalar and deterministic.
-  const opInput: BuildNetlistInput = { ...input, analysis: { kind: 'op' } };
-  const { netlist, pinNetMap, nets } = buildNetlist(opInput);
-
-  // ── Ideal sources fighting over one net (graph-based, no solve) ────────
-  // Two ideal voltage sources on the same pair of nodes make the .op matrix
-  // singular. ngspice then rejects the whole deck and the live solver publishes
-  // no voltages at all: every meter reads 0 V, every LED goes dark, and until
-  // 2026-09-05 nothing said why (a 7805's VOUT wired into a XIAO's 5V pin was
-  // reported as "my 9 V battery reads 0 V"). Detected from the netlist itself
-  // so both sides get named; blocking, because nothing on the canvas solves.
-  errors.push(...findSourceConflicts(netlist, input));
-
   // ── Line-owning sensors the wired board cannot host (no solve) ────────
   // A DHT22 or an HC-SR04 asks the board it is wired to for the line
   // contract when it mounts (simulation/line/requestLine). A board that
@@ -140,6 +127,26 @@ export async function verifyCircuit(
       message: `${gap.sensorType} on GPIO ${gap.pin} will not answer here: ${gap.why}`,
     });
   }
+
+  // Reported BEFORE the netlist is built, on purpose. This loop reads nothing
+  // but input.components, and buildNetlist throws on a canvas the emitter
+  // cannot express — verifyCircuitFromStore then returns null and the toolbar
+  // treats null as "proceed, say nothing". Ordered after it, an unrelated
+  // netlist failure elsewhere on the canvas swallowed the one warning telling
+  // the user their sensor will never answer.
+  // Run a forced .op solve so currents are scalar and deterministic.
+  const opInput: BuildNetlistInput = { ...input, analysis: { kind: 'op' } };
+  const { netlist, pinNetMap, nets } = buildNetlist(opInput);
+
+  // ── Ideal sources fighting over one net (graph-based, no solve) ────────
+  // Two ideal voltage sources on the same pair of nodes make the .op matrix
+  // singular. ngspice then rejects the whole deck and the live solver publishes
+  // no voltages at all: every meter reads 0 V, every LED goes dark, and until
+  // 2026-09-05 nothing said why (a 7805's VOUT wired into a XIAO's 5V pin was
+  // reported as "my 9 V battery reads 0 V"). Detected from the netlist itself
+  // so both sides get named; blocking, because nothing on the canvas solves.
+  errors.push(...findSourceConflicts(netlist, input));
+
 
   // ── Board over-voltage (graph-based, no solve) ─────────────────────────
   // Runs BEFORE the solve so it still reports even when an external source on


### PR DESCRIPTION
A user spent two weeks on a NeoPixel that never lit, on a project the agent helped them build. It turned out the part had never worked on any ESP32 or any RP2040 — and on the ESP32-S3 it did not merely stay dark, it froze the sketch.

Measured in the real app, before and after, with `scripts/neopixel-part-matrix.mjs` in velxio-prod (one scenario per board per engine, reading the element's own r/g/b through the shadow roots):

| board | before | after |
|---|---|---|
| Uno / Mega | worked | unchanged |
| ESP32, C3, C6 | black | byte-exact |
| Pico / Pico W | black | byte-exact |
| ESP32-S3 | black, and the sketch hung | byte-exact, runs |
| ESP32 under QEMU | black | 3 of 4 faults fixed, one is below us |

### Why it was broken, three different ways

**ESP32 — the frame was decoded and then dropped.** The part recovered colours only by timing edges on DIN, which describes a bit-banging core. On ESP32, `Adafruit_NeoPixel` goes through the RMT peripheral: the pad never toggles at bit rate. The engine had the pixels all along and handed them to a DOM id whose only renderer, `components/velxio-components/NeoPixel.tsx`, is imported by nothing. Frames now travel by PIN, which is the thing a placed part can be keyed by.

**RP2040/RP2350 — the decoder read the wrong clock, then the wrong ruler.** It read `simulator.cpu.cycles`, and only the AVR has a `cpu`; every edge on a Pico timestamped at cycle 0, so a real 241-edge PIO signal decoded to solid black. Reading `getCurrentCycles()`/`getClockHz()` is not enough either: rp2040js does not model PIO instruction delays, so its waveform is ~3x fast. Bits are now classified against their own period — a ratio every engine reproduces — with nanoseconds preferred where a board offers them.

**QEMU — every RMT symbol was read backwards.** `_decode_rmt_item` took `level0` from bit 31; on a WS2812 symbol that is always 0, so the classifier never appended a single bit. The threshold was also an order of magnitude off, and the payload carried no pin. This does not light the QEMU path yet: libqemu's `esp32_rmt` never delivers the all-zero end-of-frame symbol, which is exactly the one the decoder waits on.

### Saying so when a part gets nothing

Both pixel sources fail silently by design, so a correctly wired part on a board whose engine cannot feed it sat black and reported nothing. That silence is what cost the user two weeks. There is now a liveness warning on the existing `velxio-circuit-fault` channel — deliberately liveness and not a capability probe, because a probe answers "supported" for three of the boards that were measured dark.

Two pre-existing defects in the same diagnostic path came with it: sensor-gap warnings were collected after a `buildNetlist` that throws (so an unrelated netlist failure silently swallowed them), and a refusal keyed by `type@pin` survived a rewire, telling users who had already fixed their wiring that it was still broken.

### Not fixed here

The ESP32-S3 hang is an engine bug: `esp32s3js` advances its RMT decode only on the ISR's TX_THR clear, and the IDF5 driver masks that interrupt at `rmt_tx_mark_eof()`, so TX_END never fires and `rmtWrite` waits forever. `esp32js` and `esp32c3js` already carry the fix (`nextChunkAt`/`tick`/`thrMissed`); the S3 needs the same port. A host-side drain in the pro overlay unblocks it meanwhile. **The C6 is latent**: it escapes only because its `TX_LIM` register reads back 0, so making that register faithful would give it the same hang.

Tests drive an exact 24-bit frame at 16/125/150 MHz and at the 3x-compressed shape rp2040js actually emits; all fail without these changes. Full suite green apart from one pre-existing load-sensitive Z80 timeout.