### PR TITLE
fix(canvas): a DHT22 on a Raspberry Pi blanked the whole editor

### DIFF
--- a/frontend/src/components/DynamicComponent.tsx
+++ b/frontend/src/components/DynamicComponent.tsx
@@ -512,7 +512,7 @@ export const DynamicComponent: React.FC<DynamicComponentProps> = ({
       // bridge of the board this component is actually wired to: `gpio_in`
       // for the guest, the canvas-fed `pin<N>` value the browser engine's
       // shims read, and the PinManager so wires and SPICE see the edge.
-      const { piBoardId, wiredBoardId } = (() => {
+      const { piBoardId, piBoardKind, wiredBoardId } = (() => {
         const st = useSimulatorStore.getState();
         const ownPins = new Set<string>();
         for (const w of st.wires) {
@@ -714,13 +714,25 @@ export const DynamicComponent: React.FC<DynamicComponentProps> = ({
         metadata.id,
       );
 
-      cleanupSimulationEvents = logic.attachEvents(
-        el,
-        ownedSimulator,
-        getArduinoPin,
-        id,
-        getPinResolver,
-      );
+      // A part that throws while attaching must not take the editor with it.
+      // `piBoardKind` was referenced here but never destructured, so every
+      // DHT22 or HC-SR04 wired to a Pi-family board threw a ReferenceError out
+      // of attachEvents — and with no error boundary anywhere in this app, the
+      // whole React root unmounted. The user did not get a broken sensor, they
+      // got a blank white page, on a canvas they could no longer edit to undo
+      // it. One missing identifier should cost one dead part, not the app.
+      try {
+        cleanupSimulationEvents = logic.attachEvents(
+          el,
+          ownedSimulator,
+          getArduinoPin,
+          id,
+          getPinResolver,
+        );
+      } catch (e) {
+        console.error(`[part] ${metadata.id} (${id}) failed to attach:`, e);
+        cleanupSimulationEvents = undefined;
+      }
     }
 
     return () => {


### PR DESCRIPTION
**P0, live in production since 2026-09-04.**

`piBoardKind` is read at `DynamicComponent.tsx:554` but was never destructured from the IIFE that returns it, so it was a free global. The Pi-family stub's `lineSupport()` throws `ReferenceError`, `requestLine` calls it unguarded, and that call sits inside `attachEvents` — which nothing catches. There is no error boundary anywhere in this frontend, so the React root unmounts.

The user does not get a broken sensor. They get a blank white page, on a canvas they can no longer edit to remove the part that caused it, on MOUNT — so a project that autoloads such a circuit blanks before anyone can act.

Reproduced against production:

```
$ open https://velxio.dev/example/unihiker-temp-humidity
root.children.length === 0
ReferenceError: piBoardKind is not defined
```

With the fix, the same page renders (`rootChildren: 1`, 21 KB of DOM).

### Who hits it

Every Raspberry Pi Zero/1/2/3/4/5 and UNIHIKER M10 canvas carrying a DHT22 or an HC-SR04. Three shipped DFRobot examples are dead on arrival — `unihiker-temp-humidity`, `unihiker-ultrasonic-range`, `unihiker-iot-smart-home` — all with gallery thumbnails, so they are entry points from the gallery and from partner links.

### Why it shipped

The overlay build skips `tsc`. The compiler reports it and always did:

```
src/components/DynamicComponent.tsx(554,16): error TS2552: Cannot find name 'piBoardKind'
```

One word fixes it; the IIFE already returns the field on both branches.

### The second half

`attachEvents` is now wrapped, so this class cannot blank the app again: a part that throws while attaching costs one dead part and a `console.error`, not the application. Worth considering separately — adding the overlay typecheck from CLAUDE.md to the deploy gate, which is exactly the recipe that would have caught this.