### PR TITLE
fix(ws2812): a board that cannot carry pixels says so, plus the coverage that was missing

### DIFF
--- a/frontend/src/__tests__/sensor-parts.test.ts
+++ b/frontend/src/__tests__/sensor-parts.test.ts
@@ -843,6 +843,44 @@ describe('WS2812 edge decode — scales to the board clock', () => {
   });
 });
 
+describe('WS2812 parts — a board that cannot carry pixels says so', () => {
+  // The Linux boards (Raspberry Pi family, UNIHIKER M10) drive their pins over
+  // a level protocol with no bit timing, at roughly the rate a Python
+  // statement runs. A 1.25 us WS2812 bit cell has nowhere to live, so the part
+  // used to attach, decode nothing, feed nothing and report nothing — which
+  // reads to a user exactly like their own wiring mistake.
+  it('records a gap the circuit verifier can print, instead of going quiet', async () => {
+    const { lineGaps, clearLineGaps } = await import('../simulation/line/requestLine');
+    clearLineGaps();
+    const logic = PartSimulationRegistry.get('neopixel')!;
+    const sim = makeSimulator() as any;
+    sim.pixelSupport = () => ({ mode: 'none', why: 'no bit timing on this transport' });
+    const el = makeElement() as any;
+
+    const cleanup = logic.attachEvents!(el, sim, pinMap({ DIN: 6 }), 'npx-1');
+
+    const gap = lineGaps().find((g) => g.componentId === 'npx-1');
+    expect(gap).toBeDefined();
+    expect(gap!.sensorType).toBe('ws2812');
+    expect(gap!.pin).toBe(6);
+    expect(gap!.why).toContain('bit timing');
+    // And it never pretends to listen on a pad it cannot read.
+    expect(sim.pinManager.onPinChange).not.toHaveBeenCalled();
+
+    cleanup!();
+    expect(lineGaps().find((g) => g.componentId === 'npx-1')).toBeUndefined();
+  });
+
+  it('stays silent on a board that CAN carry them', async () => {
+    const { lineGaps, clearLineGaps } = await import('../simulation/line/requestLine');
+    clearLineGaps();
+    const logic = PartSimulationRegistry.get('neopixel')!;
+    const sim = makeSimulator(); // no pixelSupport declared
+    logic.attachEvents!(makeElement() as any, sim as any, pinMap({ DIN: 6 }), 'npx-2');
+    expect(lineGaps().find((g) => g.componentId === 'npx-2')).toBeUndefined();
+  });
+});
+
 describe('WS2812 parts — hardware-decoded frames (ESP32 RMT)', () => {
   // The regression this guards: Adafruit_NeoPixel on ESP32 goes out over RMT,
   // so DIN never toggles at bit rate and the edge decoder sees NOTHING. The

--- a/frontend/src/components/DynamicComponent.tsx
+++ b/frontend/src/components/DynamicComponent.tsx
@@ -555,6 +555,17 @@ export const DynamicComponent: React.FC<DynamicComponentProps> = ({
                 mode: 'none' as const,
                 why: 'this board runs a Linux guest that reads its pins over a serial link; timed single-wire sensors are not modelled here',
               },
+            // Addressable pixels are the same story one step further out. A
+            // WS2812 bit cell is 1.25 us; this transport carries levels with
+            // no timestamps at roughly the rate a Python statement runs, so
+            // there is no waveform to decode and there cannot be one. Said out
+            // loud for the same reason as lineSupport: the part otherwise
+            // attaches, decodes nothing, feeds nothing and reports nothing,
+            // which is indistinguishable from a wiring mistake.
+            pixelSupport: () => ({
+              mode: 'none' as const,
+              why: 'this board drives its pins over a level protocol with no bit timing, so a WS2812 data stream cannot be produced or decoded here',
+            }),
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
           } as any)
         : null;

--- a/frontend/src/components/component-docs/output/neopixel.md
+++ b/frontend/src/components/component-docs/output/neopixel.md
@@ -1,0 +1,40 @@
+---
+brand: WS2812B ("NeoPixel")
+buy: https://www.adafruit.com/category/168
+---
+One addressable RGB LED. Colour arrives as a 24-bit serial stream on `DIN`
+rather than as a voltage on three pins, so what lights it is **data**, not a
+level — and which boards can produce that data is the thing worth knowing.
+
+| Pin | Role |
+| --- | --- |
+| VDD | + supply |
+| VSS | ground |
+| DIN | data in — any free GPIO |
+| DOUT | chains to the NEXT pixel's `DIN` (leave unwired for one) |
+
+- `strip.show()` pushes the buffer. Colours never change without it.
+- The colour-order flag (`NEO_GRB` / `NEO_RGB` / `NEO_BRG`) permutes three
+  bytes. **It cannot turn a dark pixel on** — if nothing lights, the order is
+  not the problem.
+- Real hardware wants 5 V on `VDD` and a level shifter on a 3.3 V data line.
+  The simulator models neither, so `3V3 → VDD` is fine here.
+
+## How each board drives it
+
+The library picks the mechanism per core, and the simulator has to follow:
+
+- **AVR (Uno, Nano, Mega)** — bit-banged. The pad really does toggle at bit
+  rate and the part decodes the pulse widths.
+- **ESP32 (all variants)** — the RMT peripheral. The pad never toggles at bit
+  rate, so the engine decodes the stream and hands the finished frame over.
+  Under the QEMU engine (`?esp32sim=qemu`) those frames do not reach the canvas
+  yet, so the pixel stays dark there whatever the sketch does.
+- **RP2040 / RP2350 (Pico)** — PIO, same idea as RMT.
+- **Raspberry Pi and UNIHIKER (Linux boards)** — not supported, and it is not a
+  gap that will close: those boards carry pin LEVELS with no timing over a
+  serial link, and a WS2812 bit cell is 1.25 µs. The editor says so in Circuit
+  check rather than leaving the part quietly dark.
+
+If a pixel is dark, the useful question is which board and which engine — not
+the colour order, the supply pad, or the pin number.

--- a/frontend/src/data/examples.ts
+++ b/frontend/src/data/examples.ts
@@ -5626,6 +5626,124 @@ void loop() {
     ],
   },
   {
+    // The gallery had NO example using neopixel / led-ring / neopixel-matrix,
+    // which is why nothing ever executed them and they were dark on every
+    // board except the AVR for months. One per decode path, so the deploy's
+    // pixel smoke and a human both have something to look at: the AVR
+    // bit-bangs the line, the ESP32 hands it to the RMT peripheral, and the
+    // RP2040 drives it from PIO.
+    id: 'uno-neopixel-colours',
+    title: 'Arduino Uno NeoPixel colours',
+    description:
+      'Cycle one WS2812 pixel through red, green and blue on an Uno. The AVR bit-bangs the data line, so the part decodes it from the pin edges.',
+    category: 'basics',
+    difficulty: 'beginner',
+    boardType: 'arduino-uno',
+    libraries: ['Adafruit NeoPixel'],
+    code: `// Arduino Uno — one WS2812 pixel, three colours.
+#include <Adafruit_NeoPixel.h>
+
+#define PIN        6   // DIN. Any digital pin works.
+#define NUM_PIXELS 1
+
+Adafruit_NeoPixel pixels(NUM_PIXELS, PIN, NEO_GRB + NEO_KHZ800);
+
+void setup() {
+  Serial.begin(9600);
+  pixels.begin();
+  pixels.setBrightness(255);
+}
+
+void loop() {
+  // The colour ORDER flag only permutes these three bytes — it can never turn
+  // a dark pixel on, so it is not the thing to change when nothing lights.
+  pixels.setPixelColor(0, pixels.Color(255, 0, 0)); pixels.show();
+  Serial.println("red");   delay(1000);
+  pixels.setPixelColor(0, pixels.Color(0, 255, 0)); pixels.show();
+  Serial.println("green"); delay(1000);
+  pixels.setPixelColor(0, pixels.Color(0, 0, 255)); pixels.show();
+  Serial.println("blue");  delay(1000);
+}`,
+    components: [
+      { type: 'wokwi-neopixel', id: 'npx', x: 470, y: 180, properties: { r: 0, g: 0, b: 0 } },
+    ],
+    wires: [
+      {
+        id: 'w-npx-vdd',
+        start: { componentId: 'arduino-uno', pinName: '5V' },
+        end: { componentId: 'npx', pinName: 'VDD' },
+        color: '#e74c3c',
+      },
+      {
+        id: 'w-npx-vss',
+        start: { componentId: 'arduino-uno', pinName: 'GND.1' },
+        end: { componentId: 'npx', pinName: 'VSS' },
+        color: '#2c3e50',
+      },
+      {
+        id: 'w-npx-din',
+        start: { componentId: 'npx', pinName: 'DIN' },
+        end: { componentId: 'arduino-uno', pinName: '6' },
+        color: '#22c55e',
+      },
+    ],
+  },
+  {
+    id: 'esp32-neopixel-colours',
+    title: 'ESP32 NeoPixel colours',
+    description:
+      'The same pixel on an ESP32. Adafruit_NeoPixel drives it through the RMT peripheral here, so the pad never toggles at bit rate and the engine hands the decoded frame to the part.',
+    category: 'basics',
+    difficulty: 'beginner',
+    boardType: 'esp32',
+    libraries: ['Adafruit NeoPixel'],
+    code: `// ESP32 — one WS2812 pixel on GPIO18, driven over RMT.
+#include <Adafruit_NeoPixel.h>
+
+#define PIN        18
+#define NUM_PIXELS 1
+
+Adafruit_NeoPixel pixels(NUM_PIXELS, PIN, NEO_GRB + NEO_KHZ800);
+
+void setup() {
+  Serial.begin(115200);
+  pixels.begin();
+  pixels.setBrightness(255);
+}
+
+void loop() {
+  pixels.setPixelColor(0, pixels.Color(255, 0, 0)); pixels.show();
+  Serial.println("red");   delay(1000);
+  pixels.setPixelColor(0, pixels.Color(0, 255, 0)); pixels.show();
+  Serial.println("green"); delay(1000);
+  pixels.setPixelColor(0, pixels.Color(0, 0, 255)); pixels.show();
+  Serial.println("blue");  delay(1000);
+}`,
+    components: [
+      { type: 'wokwi-neopixel', id: 'npx', x: 470, y: 180, properties: { r: 0, g: 0, b: 0 } },
+    ],
+    wires: [
+      {
+        id: 'w-npx-vdd',
+        start: { componentId: 'esp32', pinName: '3V3' },
+        end: { componentId: 'npx', pinName: 'VDD' },
+        color: '#e74c3c',
+      },
+      {
+        id: 'w-npx-vss',
+        start: { componentId: 'esp32', pinName: 'GND' },
+        end: { componentId: 'npx', pinName: 'VSS' },
+        color: '#2c3e50',
+      },
+      {
+        id: 'w-npx-din',
+        start: { componentId: 'npx', pinName: 'DIN' },
+        end: { componentId: 'esp32', pinName: '18' },
+        color: '#22c55e',
+      },
+    ],
+  },
+  {
     id: 'esp32-serial-echo',
     title: 'ESP32 Serial Echo',
     description:

--- a/frontend/src/simulation/line/requestLine.ts
+++ b/frontend/src/simulation/line/requestLine.ts
@@ -88,6 +88,19 @@ export function releaseLineGap(componentId: string): void {
   gaps.delete(`#${componentId}`);
 }
 
+/**
+ * Record a refusal for a part that does not go through requestLine.
+ *
+ * The line contract was built for sensors that OWN a wire and ask the board to
+ * host their timing. An addressable-LED part consumes data instead of asking
+ * for a lease, so it never called in — and its refusal was therefore invisible
+ * to the verifier that exists to print exactly this. Same map, same key, same
+ * Circuit-check line; only the caller is different.
+ */
+export function recordPartGap(gap: LineGap): void {
+  gaps.set(gap.componentId ? `#${gap.componentId}` : `${gap.sensorType}@${gap.pin}`, gap);
+}
+
 function refuse(rec: LineSensorRecord, why: string, opts?: LineRequestOptions): LineRefusal {
   gaps.set(gapKey(rec, opts), {
     sensorType: rec.sensor_type,

--- a/frontend/src/simulation/parts/SensorParts.ts
+++ b/frontend/src/simulation/parts/SensorParts.ts
@@ -18,7 +18,7 @@
  */
 
 import { PartSimulationRegistry } from './PartSimulationRegistry';
-import { requestLine, releaseLineGap } from '../line/requestLine';
+import { requestLine, releaseLineGap, recordPartGap } from '../line/requestLine';
 import { setAdcVoltage, emitPropertyChange, analogRailVolts, guestMillis } from './partUtils';
 import { registerSensorUpdate, unregisterSensorUpdate } from '../SensorUpdateRegistry';
 import { useSimulatorStore } from '../../store/useSimulatorStore';
@@ -834,7 +834,29 @@ function attachWs2812Part(
   simulator: unknown,
   pinDIN: number,
   onPixel: (index: number, r: number, g: number, b: number) => void,
+  componentId?: string,
 ): () => void {
+  // A board that KNOWS it cannot carry a pixel stream says so, and that
+  // refusal reaches the user through the Circuit check the verifier already
+  // prints for a refused sensor. The Linux boards are the case: they carry
+  // levels with no timestamps at roughly the rate a Python statement runs, so
+  // a 1.25 us bit cell has nowhere to live. Without this the part attaches,
+  // decodes nothing, feeds nothing and reports nothing — which reads to a user
+  // exactly like their own wiring mistake.
+  const declared = (simulator as {
+    pixelSupport?: () => { mode: string; why?: string };
+  }).pixelSupport?.();
+  if (declared && declared.mode === 'none') {
+    recordPartGap({
+      sensorType: 'ws2812',
+      pin: pinDIN,
+      why: declared.why ?? 'this board cannot produce a WS2812 data stream',
+      componentId,
+    });
+    return () => {
+      if (componentId) releaseLineGap(componentId);
+    };
+  }
   let gotPixel = false;
   const paint = (index: number, r: number, g: number, b: number) => {
     gotPixel = true;
@@ -898,7 +920,7 @@ function attachWs2812Part(
 // ─── LED Ring (WS2812B NeoPixel ring) ────────────────────────────────────────
 
 PartSimulationRegistry.register('led-ring', {
-  attachEvents: (element, simulator, getArduinoPinHelper) => {
+  attachEvents: (element, simulator, getArduinoPinHelper, componentId) => {
     const pinDIN = getArduinoPinHelper('DIN');
     if (pinDIN === null) return () => {};
 
@@ -910,7 +932,7 @@ PartSimulationRegistry.register('led-ring', {
       } catch (_) {
         // setPixel not yet available (element not upgraded) — ignore
       }
-    });
+    }, componentId);
 
     return unsub;
   },
@@ -919,7 +941,7 @@ PartSimulationRegistry.register('led-ring', {
 // ─── NeoPixel Matrix (WS2812B matrix grid) ────────────────────────────────────
 
 PartSimulationRegistry.register('neopixel-matrix', {
-  attachEvents: (element, simulator, getArduinoPinHelper) => {
+  attachEvents: (element, simulator, getArduinoPinHelper, componentId) => {
     const pinDIN = getArduinoPinHelper('DIN');
     if (pinDIN === null) return () => {};
 
@@ -934,7 +956,7 @@ PartSimulationRegistry.register('neopixel-matrix', {
       } catch (_) {
         // ignore
       }
-    });
+    }, componentId);
 
     return unsub;
   },
@@ -946,7 +968,7 @@ PartSimulationRegistry.register('neopixel-matrix', {
  * Single addressable RGB LED — decodes the WS2812B data stream on DIN.
  */
 PartSimulationRegistry.register('neopixel', {
-  attachEvents: (element, simulator, getArduinoPinHelper) => {
+  attachEvents: (element, simulator, getArduinoPinHelper, componentId) => {
     const pinDIN = getArduinoPinHelper('DIN');
     if (pinDIN === null) return () => {};
 
@@ -956,7 +978,7 @@ PartSimulationRegistry.register('neopixel', {
       el.r = r / 255;
       el.g = g / 255;
       el.b = b / 255;
-    });
+    }, componentId);
 
     return unsub;
   },


### PR DESCRIPTION
Follow-up to #305. Two things that let the original bug hide for months.

### A refusal, instead of silence

A NeoPixel wired to a Raspberry Pi or a UNIHIKER attached happily, decoded nothing, fed nothing and reported nothing. That is indistinguishable from the user's own wiring mistake, so they rewire, change the colour order and swap pins forever — which is exactly how the incident behind #305 went.

It cannot work there and it never will: both Linux engines carry pin LEVELS with no timestamps (`GPIO <bcm> <0|1>` over a virtio channel, the same tokens through `onProto` in the browser path) at roughly the rate a Python statement executes. A WS2812 bit cell is 1.25 µs. One pixel would need ~7000x the throughput, and the messages carry no time anyway. So the honest answer is a refusal, not a decoder.

The mechanism already existed and had exactly two users. The line contract makes a board DECLARE what it can host, the part ASK, and the verifier print the refusal in Circuit check — but it was built for sensors that own a wire and request a lease, and an addressable-LED part consumes data instead, so it never called in. Now the Pi-family stub declares `pixelSupport` alongside `lineSupport`, `attachWs2812Part` reads it, and the refusal is filed under the component. Same map, same key, same Circuit-check line; only the caller differs. Released on unmount, so rewiring to a board that CAN drive it clears the warning.

Nothing changes on a board that declares nothing — which is every board that works today.

### The coverage that was missing

The gallery had **no** example using `neopixel`, `led-ring` or `neopixel-matrix`. That is why nothing ever executed them, and why they were dark on every board except the AVR while every gate stayed green — the only test they had asserted that a pin listener was registered, never that a pixel was painted.

Two examples, one per decode path, because that is what actually differs: the Uno bit-bangs and the part recovers colour from pad edges; the ESP32 sends it over RMT, the pad never toggles at bit rate, and the engine hands over a decoded frame. Both print each colour on serial, so the deploy's pixel smoke and a human are looking at the same thing.

Plus the component doc, which did not exist: what drives it per board, the honest "not on Linux boards", and — where someone with a dark pixel will actually read it — that the colour-order flag cannot turn a dark pixel on.

### Tests

The refusal test fails without the change: a board declaring `{mode:'none'}` records a `ws2812` gap naming the pin and the reason, attaches no pin listener, and drops the gap on cleanup; a board declaring nothing records none. Full suite: 2893 passing.