### PR TITLE
Stop promising a free Raspberry Pi, and say why a paid board will not start

### DIFF
--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -167,18 +167,21 @@ RUN rm -f package-lock.json \
 # ---- Stage 2: Final Production Image ----
 FROM python:3.12-slim
 
-# Install system dependencies, nginx, and QEMU runtime.
+# Install system dependencies and nginx.
 #
-# qemu-system-arm + qemu-utils provide qemu-system-aarch64 and qemu-img,
-# both invoked by app/services/qemu_manager.py for Raspberry Pi 3
-# simulation. They were missing for the entire 2024-2026 stretch when
-# Pi 3 simulation was advertised but broken — see docs/BOOT_IMAGES.md.
-# ~200 MB added to the image; trade-off is "Pi 3 actually works".
+# No qemu-system-arm / qemu-utils here any more. They existed only for
+# app/services/qemu_manager.py (Raspberry Pi Linux emulation), which left
+# this repo when the QEMU board lane became paid-only: nothing in the
+# open-source tree invokes qemu-system-aarch64 or qemu-img, so they were
+# ~200 MB of image for a code path that no longer exists. velxio.dev
+# installs them in its own Dockerfile and Velxio Desktop downloads a QEMU
+# build on first use.
 #
-# Other libs (libglib2.0-0, libgcrypt20, libslirp0, libpixman-1-0,
-# libfdt1) used to be needed only as runtime deps for libqemu-xtensa.so;
-# they're still needed but now also pulled in transitively by
-# qemu-system-arm.
+# libglib2.0-0, libgcrypt20, libslirp0, libpixman-1-0 and libfdt1 stay:
+# they are runtime deps of libqemu-xtensa.so (the in-process ESP32
+# emulator, which IS free and open-source) and used to arrive transitively
+# with qemu-system-arm. Dropping that package without keeping them listed
+# here would break every ESP32 simulation.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
@@ -193,8 +196,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libusb-1.0-0 \
     git \
     ccache \
-    qemu-system-arm \
-    qemu-utils \
     sdcc \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \

--- a/backend/app/api/routes/simulation.py
+++ b/backend/app/api/routes/simulation.py
@@ -3,6 +3,7 @@ import logging
 import socket
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from app.services.esp_qemu_manager import esp_qemu_manager
+from app.services.board_access import PRO_BOARD_MESSAGE
 from app.services.esp32_lib_manager import esp_lib_manager
 from app.core.hooks import dispatch_ws_sim_message, dispatch_ws_sim_disconnect
 
@@ -89,9 +90,16 @@ async def simulation_websocket(websocket: WebSocket, client_id: str):
                 'stm32_serial_input', 'stm32_sensor_attach', 'stm32_sensor_update',
                 'stm32_sensor_detach',
             ):
-                await dispatch_ws_sim_message(
+                handled = await dispatch_ws_sim_message(
                     websocket, client_id, msg_type, msg_data, qemu_callback,
                 )
+                if not handled and msg_type in ('start_pi', 'start_stm32'):
+                    # No extension installed: say so instead of going quiet.
+                    # Silence here reads as a hung Run button — the user gets
+                    # no error, no serial output and no stop. Only the two
+                    # start messages answer; the rest of the lane's traffic
+                    # would just repeat the same line.
+                    await qemu_callback('error', {'message': PRO_BOARD_MESSAGE})
 
             # ── ESP32 lifecycle ──────────────────────────────────────────
             elif msg_type == 'start_esp32':

--- a/frontend/src/i18n/locales/de/seo2.json
+++ b/frontend/src/i18n/locales/de/seo2.json
@@ -120,12 +120,12 @@
     },
     "rpi": {
       "hero": {
-        "title": "Kostenloser Raspberry Pi 3 Simulator",
+        "title": "Raspberry Pi 3 Simulator",
         "accent": "Volles Linux · Python · GPIO – In Ihrem Browser",
         "subtitle": "Führen Sie einen vollständigen Raspberry Pi 3B mit Raspberry Pi OS direkt in Ihrem Browser aus – ARM Cortex-A53 Quad-Core-Emulation über QEMU. Schreiben Sie Python, steuern Sie GPIO, installieren Sie Pakete. Keine Hardware erforderlich.",
         "ctaPrimary": "Pi 3 Simulator öffnen",
         "ctaSecondary": "Dokumentation lesen",
-        "trust": "Kostenlos & Open-Source · QEMU ARM64 · Volles Raspberry Pi OS",
+        "trust": "QEMU ARM64 · Vollstaendiges Raspberry Pi OS · Maker- und Pro-Tarife",
         "imageAlt": "Raspberry Pi 3 Board Illustration"
       },
       "what": {

--- a/frontend/src/i18n/locales/en/seo2.json
+++ b/frontend/src/i18n/locales/en/seo2.json
@@ -120,12 +120,12 @@
     },
     "rpi": {
       "hero": {
-        "title": "Free Raspberry Pi 3 Simulator",
+        "title": "Raspberry Pi 3 Simulator",
         "accent": "Full Linux · Python · GPIO — In Your Browser",
         "subtitle": "Run a full Raspberry Pi 3B with Raspberry Pi OS directly in your browser — ARM Cortex-A53 quad-core emulation via QEMU. Write Python, control GPIO, install packages. No hardware needed.",
         "ctaPrimary": "Open Pi 3 Simulator",
         "ctaSecondary": "Read the Docs",
-        "trust": "Free & open-source · QEMU ARM64 · Full Raspberry Pi OS",
+        "trust": "QEMU ARM64 · Full Raspberry Pi OS · Maker and Pro plans",
         "imageAlt": "Raspberry Pi 3 board illustration"
       },
       "what": {

--- a/frontend/src/i18n/locales/es/seo2.json
+++ b/frontend/src/i18n/locales/es/seo2.json
@@ -120,12 +120,12 @@
     },
     "rpi": {
       "hero": {
-        "title": "Simulador gratuito de Raspberry Pi 3",
+        "title": "Simulador de Raspberry Pi 3",
         "accent": "Linux completo · Python · GPIO — En tu navegador",
         "subtitle": "Ejecuta una Raspberry Pi 3B completa con Raspberry Pi OS directamente en tu navegador — emulación ARM Cortex-A53 de cuatro núcleos mediante QEMU. Escribe Python, controla GPIO, instala paquetes. Sin necesidad de hardware.",
         "ctaPrimary": "Abrir Simulador Pi 3",
         "ctaSecondary": "Leer la Documentación",
-        "trust": "Gratuito y de código abierto · QEMU ARM64 · Raspberry Pi OS completo",
+        "trust": "QEMU ARM64 · Raspberry Pi OS completo · Planes Maker y Pro",
         "imageAlt": "Ilustración de placa Raspberry Pi 3"
       },
       "what": {

--- a/frontend/src/i18n/locales/fr/seo2.json
+++ b/frontend/src/i18n/locales/fr/seo2.json
@@ -120,12 +120,12 @@
     },
     "rpi": {
       "hero": {
-        "title": "Simulateur Raspberry Pi 3 gratuit",
+        "title": "Simulateur Raspberry Pi 3",
         "accent": "Linux complet · Python · GPIO — Dans votre navigateur",
         "subtitle": "Exécutez un Raspberry Pi 3B complet avec Raspberry Pi OS directement dans votre navigateur — émulation ARM Cortex-A53 quad-core via QEMU. Écrivez du Python, contrôlez les GPIO, installez des paquets. Aucun matériel nécessaire.",
         "ctaPrimary": "Ouvrir le simulateur Pi 3",
         "ctaSecondary": "Lire la documentation",
-        "trust": "Gratuit et open-source · QEMU ARM64 · Raspberry Pi OS complet",
+        "trust": "QEMU ARM64 · Raspberry Pi OS complet · Offres Maker et Pro",
         "imageAlt": "Illustration de la carte Raspberry Pi 3"
       },
       "what": {

--- a/frontend/src/i18n/locales/it/seo2.json
+++ b/frontend/src/i18n/locales/it/seo2.json
@@ -120,12 +120,12 @@
     },
     "rpi": {
       "hero": {
-        "title": "Simulatore gratuito Raspberry Pi 3",
+        "title": "Simulatore Raspberry Pi 3",
         "accent": "Linux completo · Python · GPIO — Nel tuo browser",
         "subtitle": "Esegui un Raspberry Pi 3B completo con Raspberry Pi OS direttamente nel tuo browser — emulazione ARM Cortex-A53 quad-core tramite QEMU. Scrivi Python, controlla GPIO, installa pacchetti. Nessun hardware necessario.",
         "ctaPrimary": "Apri il simulatore Pi 3",
         "ctaSecondary": "Leggi la documentazione",
-        "trust": "Gratuito e open-source · QEMU ARM64 · Raspberry Pi OS completo",
+        "trust": "QEMU ARM64 · Raspberry Pi OS completo · Piani Maker e Pro",
         "imageAlt": "Illustrazione della scheda Raspberry Pi 3"
       },
       "what": {

--- a/frontend/src/i18n/locales/ja/seo2.json
+++ b/frontend/src/i18n/locales/ja/seo2.json
@@ -120,12 +120,12 @@
     },
     "rpi": {
       "hero": {
-        "title": "無料のRaspberry Pi 3シミュレーター",
+        "title": "Raspberry Pi 3 シミュレーター",
         "accent": "完全なLinux · Python · GPIO — ブラウザで",
         "subtitle": "ブラウザでRaspberry Pi 3BをRaspberry Pi OSとともに直接実行—QEMUによるARM Cortex-A53クアッドコアエミュレーション。Pythonの記述、GPIO制御、パッケージのインストール。ハードウェア不要。",
         "ctaPrimary": "Pi 3シミュレーターを開く",
         "ctaSecondary": "ドキュメントを読む",
-        "trust": "無料＆オープンソース · QEMU ARM64 · 完全なRaspberry Pi OS",
+        "trust": "QEMU ARM64 · 完全な Raspberry Pi OS · Maker および Pro プラン",
         "imageAlt": "Raspberry Pi 3ボードのイラスト"
       },
       "what": {

--- a/frontend/src/i18n/locales/pt-br/seo2.json
+++ b/frontend/src/i18n/locales/pt-br/seo2.json
@@ -120,12 +120,12 @@
     },
     "rpi": {
       "hero": {
-        "title": "Simulador Grátis Raspberry Pi 3",
+        "title": "Simulador de Raspberry Pi 3",
         "accent": "Linux Completo · Python · GPIO — No Seu Navegador",
         "subtitle": "Execute um Raspberry Pi 3B completo com Raspberry Pi OS diretamente no seu navegador — emulação ARM Cortex-A53 quad-core via QEMU. Escreva Python, controle GPIO, instale pacotes. Sem necessidade de hardware.",
         "ctaPrimary": "Abrir Simulador Pi 3",
         "ctaSecondary": "Ler a Documentação",
-        "trust": "Grátis e de código aberto · QEMU ARM64 · Raspberry Pi OS completo",
+        "trust": "QEMU ARM64 · Raspberry Pi OS completo · Planos Maker e Pro",
         "imageAlt": "Ilustração da placa Raspberry Pi 3"
       },
       "what": {

--- a/frontend/src/i18n/locales/ru/seo2.json
+++ b/frontend/src/i18n/locales/ru/seo2.json
@@ -120,12 +120,12 @@
     },
     "rpi": {
       "hero": {
-        "title": "Бесплатный симулятор Raspberry Pi 3",
+        "title": "Симулятор Raspberry Pi 3",
         "accent": "Полноценный Linux · Python · GPIO — в вашем браузере",
         "subtitle": "Запустите полноценный Raspberry Pi 3B с Raspberry Pi OS прямо в браузере — эмуляция четырёхъядерного ARM Cortex-A53 через QEMU. Пишите на Python, управляйте GPIO, устанавливайте пакеты. Оборудование не требуется.",
         "ctaPrimary": "Открыть симулятор Pi 3",
         "ctaSecondary": "Читать документацию",
-        "trust": "Бесплатно и с открытым исходным кодом · QEMU ARM64 · Полноценная Raspberry Pi OS",
+        "trust": "QEMU ARM64 · Полная Raspberry Pi OS · Тарифы Maker и Pro",
         "imageAlt": "Иллюстрация платы Raspberry Pi 3"
       },
       "what": {

--- a/frontend/src/i18n/locales/zh-cn/seo2.json
+++ b/frontend/src/i18n/locales/zh-cn/seo2.json
@@ -120,12 +120,12 @@
     },
     "rpi": {
       "hero": {
-        "title": "免费Raspberry Pi 3仿真器",
+        "title": "Raspberry Pi 3 模拟器",
         "accent": "完整的Linux · Python · GPIO —— 在你的浏览器中",
         "subtitle": "直接在浏览器中运行完整的Raspberry Pi 3B和Raspberry Pi OS——通过QEMU进行ARM Cortex-A53四核仿真。编写Python，控制GPIO，安装软件包。无需硬件。",
         "ctaPrimary": "打开Pi 3仿真器",
         "ctaSecondary": "阅读文档",
-        "trust": "免费开源 · QEMU ARM64 · 完整的Raspberry Pi OS",
+        "trust": "QEMU ARM64 · 完整 Raspberry Pi OS · Maker 和 Pro 套餐",
         "imageAlt": "Raspberry Pi 3板示意图"
       },
       "what": {

--- a/frontend/src/lib/proBoardGate.ts
+++ b/frontend/src/lib/proBoardGate.ts
@@ -12,9 +12,12 @@
  * `proRoutes.ts`): the OSS app defines a stable doorbell; the overlay plugs in.
  *
  *   - OSS without an overlay  -> default impl returns 'allow'. Self-hosted
- *     deployments don't block in the UI; the missing emulation binary plus a
- *     Pro-framed backend message handle availability (see stm32_lib_manager /
- *     the Pi boot-image provider).
+ *     deployments don't block in the UI: the board can be placed and the
+ *     project stays loadable, but nothing starts. Since 2026-09-06 the
+ *     emulators themselves are not in this repo at all (they live in the
+ *     optional app.pro_boards backend package), so the simulation route
+ *     answers start_pi / start_stm32 with board_access.PRO_BOARD_MESSAGE.
+ *     Availability is a backend answer, never a UI lie.
  *   - With the pro overlay     -> installBoardGateImpl() returns 'block' for a
  *     non-paid user on the web, and the caller fires the upgrade prompt.
  *   - Desktop (Tauri)          -> overlay returns 'allow'; the per-board QEMU

--- a/frontend/src/seoRoutes.ts
+++ b/frontend/src/seoRoutes.ts
@@ -225,9 +225,12 @@ export const SEO_ROUTES: SeoRoute[] = [
     priority: 0.85,
     changefreq: 'monthly',
     seoMeta: {
-      title: 'Free Raspberry Pi 3 Simulator — Full Linux Emulation in Your Browser | Velxio',
+      // Not "free": Raspberry Pi Linux emulation is a paid feature of
+      // velxio.dev and Velxio Desktop (2026-09-06). The page still targets
+      // the same query, it just stops promising a price it does not have.
+      title: 'Raspberry Pi 3 Simulator — Full Linux Emulation in Your Browser | Velxio',
       description:
-        'Simulate Raspberry Pi 3 for free. Full ARM Cortex-A53 Linux emulation via QEMU — run Python, bash, RPi.GPIO in your browser. No Raspberry Pi hardware needed.',
+        'Simulate a Raspberry Pi 3 online. Full ARM Cortex-A53 Linux emulation via QEMU — run Python, bash and RPi.GPIO in your browser. No Raspberry Pi hardware needed.',
       url: `${DOMAIN}/raspberry-pi-simulator`,
     },
   },


### PR DESCRIPTION
Follow-up to #303, which moved the Raspberry Pi Linux and STM32 emulators out of this repo. Two things were left inconsistent with those boards being paid-only, plus the image still carried QEMU for a code path that no longer exists.

## 1. The route went silent

Forwarding `start_pi` / `start_stm32` to an absent extension meant a self-hosted user placed a Pi, pressed Run, and got **nothing** — no error, no serial, no stop. Before #303 the route answered with `board_access.PRO_BOARD_MESSAGE` when the emulator was missing. It answers again now, for the two start messages only; the rest of the lane's traffic would just repeat the same line.

The stale comment in `lib/proBoardGate.ts` — which still told readers that `stm32_lib_manager` and the boot-image provider handled availability — now describes what actually happens.

## 2. The SEO surface promised a price that no longer exists

`/raspberry-pi-simulator` said *"Free Raspberry Pi 3 Simulator … Simulate Raspberry Pi 3 for free"*, and the hero title said the same in all nine locales. Retitled without the claim; the pages still target the same queries. The hero trust line names the plans instead of "Free & open-source".

## 3. ~200 MB of QEMU the open-source image cannot use

`Dockerfile.standalone` drops `qemu-system-arm` and `qemu-utils`. They existed only for `app/services/qemu_manager.py`, which left with the lane; nothing open-source invokes `qemu-system-aarch64` or `qemu-img` any more.

`libglib2.0-0`, `libgcrypt20`, `libslirp0`, `libpixman-1-0` and `libfdt1` stay listed explicitly — they are runtime deps of `libqemu-xtensa.so`, the free in-process ESP32 emulator, and used to arrive transitively with `qemu-system-arm`. Dropping the package without keeping them would have broken every ESP32 simulation.

## Verification

- Open-source unit gate: **465 passed, 14 skipped**
- Frontend suites measured against unmodified `master` in the same checkout: **19 files / 4 tests failing before, 16 / 1 after** — this introduces none. The residue is a local `node_modules` symlink (`Denied ID …/littlefs.wasm`) and pre-existing timeouts.
