### PR TITLE
fix(pio): let a peripheral be asked about one state machine, not the bus

### DIFF
--- a/frontend/src/simulation/PioPeripheral.ts
+++ b/frontend/src/simulation/PioPeripheral.ts
@@ -30,8 +30,15 @@ export interface PioPeripheral {
   feedWord(word: number, pioIndex?: number, smIndex?: number): Uint8Array[];
   /** True while the firmware is streaming bulk data the peripheral wants the
    *  plumbing to DISCARD (keep only a few words so the PIO TXSTALLs). Words
-   *  taken by this path are NOT fed to the peripheral. */
-  inDiscardableWriteData(): boolean;
+   *  taken by this path are NOT fed to the peripheral.
+   *
+   *  `pioIndex`/`smIndex` say which state machine is being asked about, where
+   *  the host plumbing knows (the RP2350 hook passes them; the RP2040 one
+   *  iterates its machines unindexed and does not). It matters on a board that
+   *  puts two peripherals on one PIO: a radio streaming its 224 KB firmware
+   *  must not make the host throw away the speaker's words on a machine the
+   *  radio never touches. Answer for the whole bus when they are undefined. */
+  inDiscardableWriteData(pioIndex?: number, smIndex?: number): boolean;
   /**
    * Optional: "I have already consumed this state machine's words; the PIO
    * does not need to shift them out."


### PR DESCRIPTION
`inDiscardableWriteData()` answered for the whole PIO block. On a board that puts two peripherals on one block - the Stellar Unicorn has its panel, its speaker and its radio there at once - that means the radio 224 KB firmware download makes the host discard the *speaker* words as well.

The panel escapes because `consumesTxWords` is checked first and it claims its own machine. The speaker deliberately leaves `consumesTxWords` false (its PIO program still has to run), so its words do reach the discard path, and nothing today stops them.

This widens the signature with the indices the RP2350 host already has in scope, so a composite peripheral can route the question to whichever child owns that machine, and still answer for the whole bus when they are undefined.

The RP2040 hook iterates its machines unindexed and keeps passing nothing. That board has no composite peripheral, so it reads exactly the same answer as before - no change to the Pico W radio path.

Type-only here; the routing and its regression test live in the private overlay CompositePioPeripheral.