### PR TITLE
Frontend Tests green again: pin npm on Node 22, regenerate the metadata

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -33,6 +33,25 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      # Node 22 bundles npm 10.9.8, whose dependency resolver crashes on this
+      # tree with "Cannot read properties of null (reading 'edgesOut')" before
+      # installing anything. Both Node 22 shards have been red since
+      # 2026-09-03 because of it; Node 20 ships an older npm and is unaffected.
+      #
+      # It is an npm bug, not a bad dependency: the same package.json installs
+      # cleanly on npm 11 and 12, and dropping @wasm-fmt/clang-format +
+      # @wasm-fmt/ruff_fmt (added 2026-09-04 with the Format-document feature)
+      # also makes 10.9.8 succeed — they are what makes the latent bug fire
+      # every time. Reproduced in a clean node:22 container with nothing but
+      # this package.json.
+      #
+      # Pinning the npm major rather than the exact patch: there is no
+      # lockfile in this repo (deliberately — see .gitignore), so npm resolves
+      # against the live registry on every run and the tree shape shifts on its
+      # own. A floor is what we need, not a freeze.
+      - name: Pin npm (Node 22 ships a resolver that cannot install this tree)
+        run: npm install -g npm@11
+
       # The metadata generator scans wokwi-elements/src/, which only ships in
       # the upstream repo (not on npm). Clone it once for the freshness check.
       - name: Clone wokwi-elements (for metadata regeneration only)

--- a/frontend/public/components-metadata.json
+++ b/frontend/public/components-metadata.json
@@ -2766,41 +2766,6 @@
       ]
     },
     {
-      "id": "heart-beat-sensor",
-      "tagName": "wokwi-heart-beat-sensor",
-      "name": "Heart Beat Sensor",
-      "category": "sensors",
-      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" rx=\"4\" fill=\"#101820\"/><rect x=\"8\" y=\"12\" width=\"48\" height=\"40\" rx=\"3\" fill=\"#1c5aa8\" stroke=\"#2f7fd6\" stroke-width=\"0.8\"/><circle cx=\"21\" cy=\"26\" r=\"6\" fill=\"#0d2b52\" stroke=\"#6fa8dc\" stroke-width=\"0.8\"/><circle cx=\"21\" cy=\"26\" r=\"2.6\" fill=\"#e04b5a\"/><rect x=\"33\" y=\"20\" width=\"9\" height=\"12\" rx=\"1.5\" fill=\"#0b1c33\" stroke=\"#6fa8dc\" stroke-width=\"0.7\"/><path d=\"M11 43h7l3-7 4 13 4-9 3 3h21\" fill=\"none\" stroke=\"#ffffff\" stroke-width=\"1.6\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/><g fill=\"#d4af37\"><rect x=\"46\" y=\"14\" width=\"4\" height=\"1.8\"/><rect x=\"46\" y=\"18\" width=\"4\" height=\"1.8\"/><rect x=\"46\" y=\"22\" width=\"4\" height=\"1.8\"/></g></svg>",
-      "properties": [
-        {
-          "name": "bpm",
-          "type": "number",
-          "defaultValue": 72,
-          "control": "number",
-          "min": 30,
-          "max": 220,
-          "description": "Simulated heart rate in beats per minute"
-        }
-      ],
-      "defaultValues": {
-        "bpm": 72
-      },
-      "pinCount": 0,
-      "tags": [
-        "heart-beat-sensor",
-        "heart rate",
-        "heart",
-        "beat",
-        "pulse",
-        "bpm",
-        "ppg",
-        "ky-039",
-        "pulse sensor",
-        "sensor"
-      ],
-      "description": "Optical heart-rate (pulse) sensor module. OUT carries a photoplethysmogram: read it with analogRead for the waveform, or with digitalRead for one pulse per beat. Set the rate with the bpm property or the sensor panel."
-    },
-    {
       "id": "hx711",
       "tagName": "wokwi-hx711",
       "name": "HX711",
@@ -4521,6 +4486,41 @@
         "hc-sr04",
         "hc",
         "sr04"
+      ]
+    },
+    {
+      "id": "heart-beat-sensor",
+      "tagName": "wokwi-heart-beat-sensor",
+      "name": "Heart Beat Sensor",
+      "category": "sensors",
+      "description": "Optical heart-rate (pulse) sensor module. OUT carries a photoplethysmogram: read it with analogRead for the waveform, or with digitalRead for one pulse per beat. Set the rate with the bpm property or the sensor panel.",
+      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" rx=\"4\" fill=\"#101820\"/><rect x=\"8\" y=\"12\" width=\"48\" height=\"40\" rx=\"3\" fill=\"#1c5aa8\" stroke=\"#2f7fd6\" stroke-width=\"0.8\"/><circle cx=\"21\" cy=\"26\" r=\"6\" fill=\"#0d2b52\" stroke=\"#6fa8dc\" stroke-width=\"0.8\"/><circle cx=\"21\" cy=\"26\" r=\"2.6\" fill=\"#e04b5a\"/><rect x=\"33\" y=\"20\" width=\"9\" height=\"12\" rx=\"1.5\" fill=\"#0b1c33\" stroke=\"#6fa8dc\" stroke-width=\"0.7\"/><path d=\"M11 43h7l3-7 4 13 4-9 3 3h21\" fill=\"none\" stroke=\"#ffffff\" stroke-width=\"1.6\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/><g fill=\"#d4af37\"><rect x=\"46\" y=\"14\" width=\"4\" height=\"1.8\"/><rect x=\"46\" y=\"18\" width=\"4\" height=\"1.8\"/><rect x=\"46\" y=\"22\" width=\"4\" height=\"1.8\"/></g></svg>",
+      "properties": [
+        {
+          "name": "bpm",
+          "type": "number",
+          "defaultValue": 72,
+          "control": "number",
+          "min": 30,
+          "max": 220,
+          "description": "Simulated heart rate in beats per minute"
+        }
+      ],
+      "defaultValues": {
+        "bpm": 72
+      },
+      "pinCount": 0,
+      "tags": [
+        "heart-beat-sensor",
+        "heart rate",
+        "heart",
+        "beat",
+        "pulse",
+        "bpm",
+        "ppg",
+        "ky-039",
+        "pulse sensor",
+        "sensor"
       ]
     },
     {


### PR DESCRIPTION
Frontend Tests has been red on **every push since 2026-09-03** (run 1180; last green 1179). Neither failure is a test — the four red shards are two unrelated problems, one per Node version.

## Node 22: the dependency install never runs

```
npm error Cannot read properties of null (reading 'edgesOut')
```

Node 22 bundles npm 10.9.8, whose resolver crashes on this tree before installing anything. Node 20 ships an older npm and is unaffected, which is why exactly half the matrix is red.

It is an npm bug, not a bad dependency. Reproduced in a clean `node:22` container with nothing but `frontend/package.json`:

| Setup | Result |
|---|---|
| current `package.json`, npm 10.9.8 | `edgesOut` crash |
| same, npm 11.19.1 | installs |
| same, npm 12.0.2 | installs |
| current minus `@wasm-fmt/clang-format` + `@wasm-fmt/ruff_fmt`, npm 10.9.8 | installs |

Those two packages arrived on 2026-09-04 with the Format-document feature; they are what makes the latent bug fire every time.

One honest caveat: the *first* red run predates them and hit the same error with a `package.json` that installs cleanly today. This repo keeps no lockfile on purpose, so npm resolves against the live registry on every run and the tree shape moves on its own. That is why this pins the npm **major** rather than an exact patch — a floor, not a freeze.

## Node 20: `components-metadata.json` is stale

The freshness check regenerates the file and diffs it. `heart-beat-sensor` sits at index 94 in the committed file; the generator puts it at 151. Same 157 components, byte-identical content, different order — it was hand-edited into place in `cd1a97d2` instead of regenerated.

Fixed by running `npm run generate:metadata` and committing the result. Verified before committing that the regeneration adds and drops **no** component id: removing one blanks every saved project that uses the part.
