### PR TITLE
fix(ws2812): take the no-pixel-data warning back when the board was only slow

### DIFF
--- a/frontend/src/__tests__/ws2812-liveness.test.ts
+++ b/frontend/src/__tests__/ws2812-liveness.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+/**
+ * The WS2812 liveness report, and the correction that keeps it honest.
+ *
+ * The warning exists because a NeoPixel driven through a hardware peripheral
+ * the engine does not decode stays black in complete silence — the failure
+ * that started this whole line of work. But its six-second grace cannot tell
+ * that apart from a guest that has simply not booted yet: an ESP32-P4 needs
+ * well over a minute to reach its first show(), and the warning is already
+ * out by then, telling the user a diagnosis that is wrong for their board.
+ *
+ * So the contract is two-sided: warn when nothing arrives, and take it back
+ * when something does. This file drives the store the part subscribes to,
+ * which the other sensor-part tests deliberately leave inert.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type StoreState = { hexEpoch?: number; running?: boolean };
+const listeners: Array<(s: StoreState) => void> = [];
+let state: StoreState = { hexEpoch: 0, running: false };
+
+// Keep every other export of the store module (SensorParts imports helpers
+// from it too); only the store object itself is ours.
+vi.mock('../store/useSimulatorStore', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const useSimulatorStore = (() => state) as unknown as {
+    subscribe: (fn: (s: StoreState) => void) => () => void;
+    getState: () => StoreState;
+  };
+  useSimulatorStore.subscribe = (fn: (s: StoreState) => void) => {
+    listeners.push(fn);
+    return () => {
+      const i = listeners.indexOf(fn);
+      if (i >= 0) listeners.splice(i, 1);
+    };
+  };
+  useSimulatorStore.getState = () => state;
+  return { ...actual, useSimulatorStore };
+});
+
+/** Press Run: bump the epoch and tell every subscriber. */
+function pressRun(epoch: number): void {
+  state = { hexEpoch: epoch, running: true };
+  for (const fn of [...listeners]) fn(state);
+}
+
+/** A board whose engine hands whole decoded frames to the part (ESP32 RMT). */
+function makeRmtSimulator() {
+  const sinks = new Map<number, (px: Array<{ r: number; g: number; b: number }>) => void>();
+  return {
+    pinManager: { onPinChange: vi.fn(), offPinChange: vi.fn() },
+    subscribeWs2812: vi.fn((pin: number, fn: (px: never[]) => void) => {
+      sinks.set(pin, fn as never);
+      return () => sinks.delete(pin);
+    }),
+    emitFrame: (pin: number, px: Array<{ r: number; g: number; b: number }>) =>
+      sinks.get(pin)?.(px),
+  };
+}
+
+const makeElement = () => ({ r: 0, g: 0, b: 0 }) as Record<string, unknown>;
+const pinMap =
+  (map: Record<string, number>) =>
+  (name: string): number | null =>
+    name in map ? map[name] : null;
+
+describe('WS2812 liveness report', () => {
+  let faults: Array<{ kind?: string; message?: string }>;
+  const onFault = (e: Event) =>
+    faults.push((e as CustomEvent).detail as { kind?: string; message?: string });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    faults = [];
+    listeners.length = 0;
+    state = { hexEpoch: 0, running: false };
+    window.addEventListener('velxio-circuit-fault', onFault);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    window.removeEventListener('velxio-circuit-fault', onFault);
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  async function attach() {
+    // Side-effect import: parts register themselves on load.
+    await import('../simulation/parts/SensorParts');
+    const { PartSimulationRegistry } = await import('../simulation/parts/PartSimulationRegistry');
+    const logic = PartSimulationRegistry.get('neopixel')!;
+    const sim = makeRmtSimulator();
+    logic.attachEvents!(makeElement() as never, sim as never, pinMap({ DIN: 6 }) as never, 'npx-1');
+    return sim;
+  }
+
+  it('says so when a whole run goes by with no pixel frame', async () => {
+    await attach();
+    pressRun(1);
+    vi.advanceTimersByTime(6000);
+
+    const warn = faults.find((f) => f.kind === 'no-pixel-data');
+    expect(warn).toBeDefined();
+    expect(warn!.message).toContain('DIN 6');
+  });
+
+  it('stays quiet when a frame arrives inside the grace', async () => {
+    const sim = await attach();
+    pressRun(1);
+    sim.emitFrame(6, [{ r: 255, g: 0, b: 0 }]);
+    vi.advanceTimersByTime(6000);
+
+    expect(faults.find((f) => f.kind === 'no-pixel-data')).toBeUndefined();
+  });
+
+  it('takes the warning back when the slow board finally paints', async () => {
+    const sim = await attach();
+    pressRun(1);
+    vi.advanceTimersByTime(6000);
+    expect(faults.find((f) => f.kind === 'no-pixel-data')).toBeDefined();
+
+    // An ESP32-P4 gets here a minute into the run, long after the warning.
+    vi.advanceTimersByTime(60_000);
+    sim.emitFrame(6, [{ r: 255, g: 0, b: 0 }]);
+
+    const late = faults.find((f) => f.kind === 'pixel-data-late');
+    expect(late).toBeDefined();
+    expect(late!.message).toContain('DIN 6');
+    expect(late!.message).toMatch(/disregard the warning above/);
+  });
+
+  it('corrects once, not on every frame of the animation', async () => {
+    const sim = await attach();
+    pressRun(1);
+    vi.advanceTimersByTime(6000);
+    for (let i = 0; i < 5; i++) sim.emitFrame(6, [{ r: i, g: 0, b: 0 }]);
+
+    expect(faults.filter((f) => f.kind === 'pixel-data-late')).toHaveLength(1);
+  });
+});

--- a/frontend/src/simulation/parts/SensorParts.ts
+++ b/frontend/src/simulation/parts/SensorParts.ts
@@ -792,10 +792,12 @@ function onRunEpoch(next: (epoch: number) => void): () => void {
 function reportNoPixelData(pinDIN: number): void {
   const message =
     `NeoPixel on DIN ${pinDIN}: no pixel data reached this part in the first ` +
-    `${NO_PIXEL_GRACE_MS / 1000} s of the run. The sketch may be fine — this ` +
-    `board's core can drive WS2812 through a hardware peripheral (RMT on ` +
-    `ESP32, PIO on RP2040) that this engine does not decode. Changing the ` +
-    `colour order, the supply pad or the data pin will not help.`;
+    `${NO_PIXEL_GRACE_MS / 1000} s of the run. The usual cause is that this ` +
+    `board's core drives WS2812 through a hardware peripheral (RMT on ESP32, ` +
+    `PIO on RP2040) that this engine does not decode, and then changing the ` +
+    `colour order, the supply pad or the data pin will not help. A board that ` +
+    `is merely slow to boot looks the same at this point; if that is what ` +
+    `happened, the line below corrects this one.`;
   try {
     window.dispatchEvent(
       new CustomEvent('velxio-circuit-fault', {
@@ -806,6 +808,32 @@ function reportNoPixelData(pinDIN: number): void {
     // No DOM (unit tests) — the console line below is the whole report.
   }
   console.warn(`[ws2812] ${message}`);
+}
+
+/**
+ * Correct a premature no-pixel-data report.
+ *
+ * The grace period cannot tell "this engine will never decode a pixel" from
+ * "this guest has not booted yet": an ESP32-P4 takes over a minute to reach
+ * its first show(), and the warning is already out by then. Rather than pick a
+ * grace long enough for the slowest board — which would make the warning
+ * useless on the fast ones it exists for — say so when the data does arrive.
+ */
+function reportPixelDataArrivedLate(pinDIN: number, msIntoRun: number): void {
+  const message =
+    `NeoPixel on DIN ${pinDIN}: pixel data did arrive, ${(msIntoRun / 1000).toFixed(1)} s ` +
+    `into the run. This board is slow to boot, not undecodable — disregard the ` +
+    `warning above.`;
+  try {
+    window.dispatchEvent(
+      new CustomEvent('velxio-circuit-fault', {
+        detail: { kind: 'pixel-data-late', message },
+      }),
+    );
+  } catch (_) {
+    // No DOM (unit tests) — the console line below is the whole report.
+  }
+  console.info(`[ws2812] ${message}`);
 }
 
 /**
@@ -858,7 +886,14 @@ function attachWs2812Part(
     };
   }
   let gotPixel = false;
+  // Set when the no-pixel warning has gone out for this run, so the first
+  // frame that turns up afterwards can correct it (see below).
+  let warnedAt: number | null = null;
   const paint = (index: number, r: number, g: number, b: number) => {
+    if (!gotPixel && warnedAt !== null) {
+      reportPixelDataArrivedLate(pinDIN, Date.now() - warnedAt + NO_PIXEL_GRACE_MS);
+      warnedAt = null;
+    }
     gotPixel = true;
     onPixel(index, r, g, b);
   };
@@ -900,11 +935,13 @@ function attachWs2812Part(
     if (epoch === lastEpoch) return;
     lastEpoch = epoch;
     gotPixel = false;
+    warnedAt = null;
     if (timer !== null) clearTimeout(timer);
     timer = setTimeout(() => {
       timer = null;
       if (gotPixel || warned) return;
       warned = true;
+      warnedAt = Date.now();
       reportNoPixelData(pinDIN);
     }, NO_PIXEL_GRACE_MS);
   });


### PR DESCRIPTION
The WS2812 liveness warning has a six-second grace, and that grace cannot tell *this engine will never decode a pixel* from *this guest has not booted yet*.

An ESP32-P4 needs well over a minute to reach its first show(). The warning is already out by then - and it does not hedge: it says the board drives WS2812 through a peripheral this engine does not decode, and that changing the colour order, the supply pad or the data pin will not help. On a board that then lights up perfectly, every word of that is wrong.

Raising the grace to cover the slowest board would blind the warning on the fast ones it exists for. So instead:

- the first frame that arrives after the warning posts a correction on the same channel, into the same Circuit check group the user is already reading;
- the warning itself now offers the peripheral explanation as the usual cause rather than as the verdict, and says a correction may follow.

Four tests, in a file of their own because they have to drive the simulator store the part subscribes to - the other sensor-part tests deliberately leave it inert, which is why this path had no coverage at all. Two of the four fail without the change.