### PR TITLE
fix(circuit-check): a heuristic, and the line retracting it, are not compile errors

### DIFF
--- a/frontend/src/__tests__/ws2812-liveness.test.ts
+++ b/frontend/src/__tests__/ws2812-liveness.test.ts
@@ -65,9 +65,13 @@ const pinMap =
     name in map ? map[name] : null;
 
 describe('WS2812 liveness report', () => {
-  let faults: Array<{ kind?: string; message?: string }>;
+  let faults: Array<{ kind?: string; message?: string; severity?: string }>;
   const onFault = (e: Event) =>
-    faults.push((e as CustomEvent).detail as { kind?: string; message?: string });
+    faults.push((e as CustomEvent).detail as {
+      kind?: string;
+      message?: string;
+      severity?: string;
+    });
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -126,6 +130,10 @@ describe('WS2812 liveness report', () => {
 
     const late = faults.find((f) => f.kind === 'pixel-data-late');
     expect(late).toBeDefined();
+    // Not a fault: the agent panel counts 'error' lines and would announce a
+    // failed compile over a build that worked.
+    expect(late!.severity).toBe('info');
+    expect(faults.find((f) => f.kind === 'no-pixel-data')!.severity).toBe('warning');
     expect(late!.message).toContain('DIN 6');
     expect(late!.message).toMatch(/disregard the warning above/);
   });

--- a/frontend/src/components/editor/EditorToolbar.tsx
+++ b/frontend/src/components/editor/EditorToolbar.tsx
@@ -290,12 +290,21 @@ export const EditorToolbar = ({
   // (on Run) opens it; this entry then lands in the already-open log.
   useEffect(() => {
     const onFault = (e: Event) => {
-      const detail = (e as CustomEvent).detail as { message?: string } | undefined;
+      const detail = (e as CustomEvent).detail as
+        | { message?: string; severity?: 'error' | 'warning' | 'info' }
+        | undefined;
       if (!detail?.message) return;
       const text = detail.message;
+      // Everything on this channel used to land as an ERROR, and the agent
+      // panel counts those: a heuristic that turned out to be wrong, or the
+      // line that says so, both read as "Compile failed with N errors" on a
+      // build that succeeded. Producers may now say what a line is worth;
+      // omitting it keeps the old behaviour for the solver and burnout
+      // reporters, which really are faults.
+      const type = detail.severity ?? 'error';
       setCompileLogs((prev) => [
         ...prev,
-        { timestamp: new Date(), type: 'error', message: text, target: CIRCUIT_CHECK_TARGET },
+        { timestamp: new Date(), type, message: text, target: CIRCUIT_CHECK_TARGET },
       ]);
     };
     window.addEventListener('velxio-circuit-fault', onFault);

--- a/frontend/src/simulation/parts/SensorParts.ts
+++ b/frontend/src/simulation/parts/SensorParts.ts
@@ -801,7 +801,9 @@ function reportNoPixelData(pinDIN: number): void {
   try {
     window.dispatchEvent(
       new CustomEvent('velxio-circuit-fault', {
-        detail: { kind: 'no-pixel-data', message },
+        // A heuristic, not a fault: the six-second grace can be wrong about a
+        // slow board, and the line below may retract this one.
+        detail: { kind: 'no-pixel-data', message, severity: 'warning' },
       }),
     );
   } catch (_) {
@@ -827,7 +829,7 @@ function reportPixelDataArrivedLate(pinDIN: number, msIntoRun: number): void {
   try {
     window.dispatchEvent(
       new CustomEvent('velxio-circuit-fault', {
-        detail: { kind: 'pixel-data-late', message },
+        detail: { kind: 'pixel-data-late', message, severity: 'info' },
       }),
     );
   } catch (_) {


### PR DESCRIPTION
Every line on the `velxio-circuit-fault` channel lands in the output console as an **error**, and the agent panel counts `type === error` to decide whether to say *Compile failed with N errors*.

So on an ESP32-P4 — which boots slowly, trips the WS2812 six-second grace, then lights its NeoPixel perfectly and prints the correction saying so — the user gets **Compile failed with 2 errors** over a build that succeeded, and neither line is a compile error at all.

Producers can now say what a line is worth via an optional `severity` on the event detail. Omitting it keeps the previous behaviour, so `solverFaultReporter`, `runtimeBurnout` and `BasicParts` are untouched — those really are faults.

The WS2812 grace warning becomes a **warning** (it is a heuristic, and it can be retracted); its retraction becomes **info**.

Verified in the browser on velxio.dev: both lines appear in the Circuit check group, in order, while the pixel cycles red/green.