### PR TITLE
feat(ir): the air between infrared parts, and two parts that were dead in it

### DIFF
--- a/backend/app/services/esp32_ir.py
+++ b/backend/app/services/esp32_ir.py
@@ -1,0 +1,200 @@
+"""Infrared for the QEMU ESP32 worker: the envelope a demodulator puts on its
+pin, paced in guest time.
+
+Why this is its own module, and why it does NOT reuse the DHT22 player. The
+two look alike — both are a list of (level, duration) phases on one pad — and
+the difference is the pacing rule, which is the whole of the problem:
+
+  * `esp32_dht22.Dht22Reply` credits at most `STALL_CAP_US` (2 us) of guest
+    time per GPIO_IN read, because the drivers it serves sit in a tight
+    busy-wait and a phase is really a number of READS. That is exactly right
+    there and catastrophic here. An IR library does not busy-wait: IRremote's
+    ESP32 backend samples the pin from a 50 us timer ISR. At 2 us credited per
+    50 us sample, the 9 ms NEC header would take 225 ms of guest time to play
+    out and every decoder would reject the frame.
+
+  * So an IR frame is paced by REAL guest time. `micros()` is what the guest
+    measures the envelope with, and the phases are microseconds of exactly
+    that clock.
+
+TWO THINGS ADVANCE THE FRAME, and it needs both:
+
+  * a GPIO_IN read, the way the DHT22 does. This covers every polling decoder
+    and gives the finest resolution available, because a read is the only
+    instant the guest can observe the pad anyway.
+  * a host-side ticker, under the BQL. This covers the decoder that uses a
+    pin-change interrupt and never reads the pin at all — which reads nothing
+    and would otherwise leave the frame frozen on its first phase forever.
+    Attaching an interrupt is a normal thing for an IR library to do, so a
+    model that only advanced on reads would be dead for a real share of
+    sketches with no way for the user to tell why.
+
+Both callers hold the BQL when they drive the pad, so `step()` needs no lock
+of its own; it is `advance()` that is called from either side.
+
+POLARITY. A demodulator's output is ACTIVE LOW and idles HIGH: it pulls the
+line down for the length of each carrier burst. The frame therefore always
+ends HIGH, whatever the last pulse was — a decoder waiting for the end of a
+transmission has to see the line come back to idle, and NEC's last pulse is a
+mark, so a train played out literally would strand it low forever.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Sequence
+
+Level = int
+Phase = tuple[Level, float]  # (level, duration in guest us)
+
+# Settling gap before the first edge, so a frame never starts on the very
+# instant it was armed.
+LEAD_US = 100.0
+# A frame nobody advances for this long of guest time is abandoned rather than
+# left holding the pad. Longer than any NEC frame (67.5 ms) by a wide margin.
+STUCK_TIMEOUT_US = 400_000.0
+
+
+def envelope_phases(pulses: Sequence[tuple[int, float]]) -> list[Phase]:
+    """Mark/space pairs to pad phases, active low, ending idle HIGH.
+
+    `pulses` are `(level, us)` with level 1 meaning the carrier is ON. Adjacent
+    pulses of the same kind are merged: two marks in a row are one longer mark
+    on the pin, and emitting them as two phases would put a zero-width edge
+    between them that a decoder could see as a bit.
+    """
+    phases: list[Phase] = [(1, LEAD_US)]
+    for level, us in pulses:
+        if us <= 0:
+            continue
+        want = 0 if level == 1 else 1     # a mark pulls the output LOW
+        if phases and phases[-1][0] == want:
+            phases[-1] = (want, phases[-1][1] + float(us))
+        else:
+            phases.append((want, float(us)))
+    if len(phases) <= 1:
+        return []
+    if phases[-1][0] == 0:
+        # The train ended on a mark. Idle is HIGH, so add the return to it.
+        phases.append((1, LEAD_US))
+    return phases
+
+
+def nec_pulses(address: int, command: int) -> list[tuple[int, float]]:
+    """The NEC train for an address and a command, as (level, us) pairs.
+
+    Mirror of `simulation/ir/necCodec.ts::necEncode`, the way this whole file
+    mirrors `simulation/line/models/ir-nec.ts` — one protocol, written once per
+    runtime, never twice per runtime. An address above 0xff is extended NEC:
+    16 bits, low byte first, no complement.
+    """
+    address &= 0xFFFF
+    command &= 0xFF
+    if address > 0xFF:
+        payload = [address & 0xFF, (address >> 8) & 0xFF, command, (~command) & 0xFF]
+    else:
+        payload = [address & 0xFF, (~address) & 0xFF, command, (~command) & 0xFF]
+    out: list[tuple[int, float]] = [(1, 9000.0), (0, 4500.0)]
+    for byte in payload:
+        for bit in range(8):                       # least significant first
+            out.append((1, 560.0))
+            out.append((0, 1690.0 if (byte >> bit) & 1 else 560.0))
+    out.append((1, 560.0))                         # stop mark
+    return out
+
+
+class IrReply:
+    """One envelope on one pad, advanced by real guest microseconds.
+
+    `set_level(level)` drives the pad (QEMU's GPIO_IN bit); `now_us()` is the
+    guest clock. `advance()` is called from a GPIO_IN read or from the host
+    ticker, both holding the BQL, and returns True once the frame is out and
+    the line is back at idle.
+    """
+
+    def __init__(
+        self,
+        phases: list[Phase],
+        set_level: Callable[[int], None],
+        now_us: Callable[[], float],
+    ) -> None:
+        if not phases:
+            raise ValueError('an IR frame has at least one phase')
+        self._phases = phases
+        self._set = set_level
+        self._now = now_us
+        self._idx = -1                 # -1: nothing driven yet
+        self._phase_started_us = 0.0
+        self.done = False
+        # Diagnostics.
+        self.advances = 0
+        self.started_at_us: float | None = None
+        self.finished_at_us: float | None = None
+
+    @property
+    def phase(self) -> int:
+        """Index of the phase on the wire, -1 before the first advance."""
+        return self._idx
+
+    def advance(self) -> bool:
+        if self.done:
+            return True
+        t = self._now()
+        self.advances += 1
+        if self._idx < 0:
+            self._idx = 0
+            self._phase_started_us = t
+            self.started_at_us = t
+            self._set(self._phases[0][0])
+            return False
+
+        if t < self._phase_started_us:
+            # The guest clock went backwards: it rebooted underneath us and
+            # everything measured against the old base is meaningless.
+            self._finish(t)
+            return True
+
+        # Cross as many boundaries as the elapsed time actually covers. A
+        # coarse advance (a 50 us ISR sample, a host tick) can span several
+        # 560 us phases if the guest ran ahead between two of them, and
+        # stepping one phase per call would stretch the frame by the number of
+        # phases it fell behind.
+        while True:
+            duration = self._phases[self._idx][1]
+            if t - self._phase_started_us < duration:
+                break
+            self._phase_started_us += duration
+            self._idx += 1
+            if self._idx >= len(self._phases):
+                self._finish(t)
+                return True
+            self._set(self._phases[self._idx][0])
+        # A frame nothing advances would hold the pad for the rest of the run.
+        if t - (self.started_at_us or t) > STUCK_TIMEOUT_US:
+            self._finish(t)
+            return True
+        return False
+
+    def settle(self) -> bool:
+        """Give the line back even though the frame has not run out — the
+        guest stopped looking, or the run is ending. True when it acted."""
+        if self.done:
+            return False
+        self._finish(self._now())
+        return True
+
+    def _finish(self, t: float) -> None:
+        self._set(1)                   # a demodulator idles HIGH
+        self.done = True
+        self.finished_at_us = t
+
+    def diag(self) -> dict:
+        span = (
+            None
+            if self.started_at_us is None or self.finished_at_us is None
+            else round(self.finished_at_us - self.started_at_us, 1)
+        )
+        return {
+            'phases': len(self._phases),
+            'advances': self.advances,
+            'span_us': span,
+        }

--- a/backend/app/services/esp32_worker.py
+++ b/backend/app/services/esp32_worker.py
@@ -71,6 +71,26 @@ except ImportError:
     _dht11_payload_bytes = _mod_dht.dht11_payload  # type: ignore[assignment]
     _dht22_phases = _mod_dht.dht22_phases        # type: ignore[assignment]
 
+# IR envelope model: the demodulator's output, paced in real guest time (the
+# DHT22 player's per-read cap is wrong for a 50 us sampling ISR — see
+# esp32_ir.py). Same fallback dance as above.
+try:
+    from app.services.esp32_ir import (
+        IrReply as _IrReply,
+        envelope_phases as _ir_envelope_phases,
+        nec_pulses as _ir_nec_pulses,
+    )
+except ImportError:
+    import importlib.util as _ilu_ir, pathlib as _pl_ir, sys as _sys_ir
+    _spec_ir = _ilu_ir.spec_from_file_location(
+        'esp32_ir', _pl_ir.Path(__file__).parent / 'esp32_ir.py')
+    _mod_ir = _ilu_ir.module_from_spec(_spec_ir)  # type: ignore[arg-type]
+    _sys_ir.modules['esp32_ir'] = _mod_ir
+    _spec_ir.loader.exec_module(_mod_ir)  # type: ignore[union-attr]
+    _IrReply = _mod_ir.IrReply                       # type: ignore[assignment]
+    _ir_envelope_phases = _mod_ir.envelope_phases    # type: ignore[assignment]
+    _ir_nec_pulses = _mod_ir.nec_pulses              # type: ignore[assignment]
+
 # I2C slave state machines — extracted to a standalone module for testability
 try:
     from app.services.esp32_i2c_slaves import (
@@ -405,7 +425,7 @@ class _RmtDecoder:
 # -icount off: the AP beacon timer runs on QEMU_CLOCK_REALTIME (issue #260).
 ICOUNT_SHIFT_C3 = 3
 ICOUNT_SHIFT_LINE_SENSORS = 4
-LINE_SENSOR_TYPES = ('dht22', 'dht11', 'hc-sr04')
+LINE_SENSOR_TYPES = ('dht22', 'dht11', 'hc-sr04', 'ir-nec')
 
 
 def icount_shift_for_run(machine: str, wifi_enabled: bool, sensors: list,
@@ -1039,6 +1059,126 @@ def main() -> None:  # noqa: C901  (complexity OK for inline worker)
         _sync_handlers.append(_Dht22Handler(reply, gpio, sensor, how))
         _dht22_settle_later(reply, sensor, gpio)
         _log(f'DHT22 armed ({how}) gpio={gpio} temp={temp} hum={hum} payload={payload}')
+
+    # ── Infrared ─────────────────────────────────────────────────────────────
+    # The model is esp32_ir.py (the envelope, paced on the guest clock). This is
+    # the glue: the pad, the sync-handler shape, and the host ticker that covers
+    # a decoder using a pin-change interrupt instead of reading the pin.
+    class _IrHandler:
+        """Sync-handler shape over an IrReply: one advance per GPIO_IN read."""
+
+        def __init__(self, reply, gpio: int, how: str) -> None:
+            self.reply = reply
+            self._gpio = gpio
+            self._how = how
+
+        def step(self) -> bool:
+            if self.reply.done:
+                self._finish()
+                return True
+            if self.reply.advance():
+                self._finish()
+                return True
+            return False
+
+        def _finish(self) -> None:
+            with _sensors_lock:
+                sensor = _sensors.get(self._gpio)
+                if sensor is not None and sensor.get('_ir_reply') is self.reply:
+                    sensor['responding'] = False
+            d = self.reply.diag()
+            _log(f'IR frame done gpio={self._gpio} ({self._how}) {d}')
+            _emit({'type': 'system', 'event': 'ir_frame', 'gpio': self._gpio,
+                   'status': 'ok', 'source': self._how, **d})
+
+    def _ir_tick_later(reply, gpio: int) -> None:
+        """Advance the frame from a host thread, under the BQL.
+
+        A polling decoder is already covered by the GPIO_IN read path, and it
+        is the better one — a read is the only instant the guest can observe
+        the pad. This exists for the decoder that attaches a pin-change
+        interrupt and never reads the pin at all: nothing would advance its
+        frame, the pad would sit on its first phase, and the sketch would wait
+        for an edge that never came. The BQL keeps this off the QEMU thread's
+        toes; `advance()` is idempotent about being called from both.
+        """
+        if _lock_iothread is None or _unlock_iothread is None:
+            return
+
+        def _tick() -> None:
+            if _stopped.is_set() or reply.done:
+                return
+            _lock_iothread(b'esp32_worker.py:ir_tick', 0)
+            try:
+                finished = reply.advance()
+            finally:
+                _unlock_iothread()
+            if finished:
+                with _sensors_lock:
+                    sensor = _sensors.get(gpio)
+                    if sensor is not None and sensor.get('_ir_reply') is reply:
+                        sensor['responding'] = False
+                _log(f'IR frame done gpio={gpio} (host tick) {reply.diag()}')
+                return
+            _later()
+
+        def _later() -> None:
+            # 1 ms of host time. A NEC bit is 560 us of GUEST time, and the
+            # guest runs at or below real time, so this never under-samples the
+            # envelope; when the guest polls, the read path is finer anyway.
+            t = threading.Timer(0.001, _tick)
+            t.daemon = True
+            t.start()
+
+        _later()
+
+    def _ir_arm(gpio: int, sensor: dict, pulses, how: str) -> None:
+        """Put one envelope on `gpio`. A frame still going out is left alone:
+        two transmissions on top of each other garble both, which is what
+        happens in the room too."""
+        slot = gpio + 1
+        old = sensor.get('_ir_reply')
+        if old is not None and not old.done:
+            _log(f'IR frame ignored gpio={gpio}: one is still going out')
+            return
+        phases = _ir_envelope_phases(pulses)
+        if not phases:
+            return
+        reply = _IrReply(
+            phases,
+            lambda level: lib.qemu_picsimlab_set_pin(slot, level),
+            _guest_now_us,
+        )
+        with _sensors_lock:
+            sensor['_ir_reply'] = reply
+            sensor['responding'] = True
+        _sync_handlers.append(_IrHandler(reply, gpio, how))
+        _ir_tick_later(reply, gpio)
+        _log(f'IR armed ({how}) gpio={gpio} phases={len(phases)}')
+
+    def _ir_pulses_for(sensor: dict):
+        """What to transmit: the train the canvas carried, else the sensor's
+        own address and command. Read fresh each time — an air frame carries
+        its own train and the NEXT press must not replay the last one."""
+        raw = sensor.pop('pulses', None)
+        if isinstance(raw, list) and raw:
+            out = []
+            for i, item in enumerate(raw):
+                if isinstance(item, dict):
+                    us = float(item.get('us', 0) or 0)
+                    level = 1 if int(item.get('level', 0)) == 1 else 0
+                else:
+                    # A flat [markUs, spaceUs, ...] array, mark first.
+                    us = float(item or 0)
+                    level = 1 if i % 2 == 0 else 0
+                if us > 0:
+                    out.append((level, us))
+            if out:
+                return out
+        return _ir_nec_pulses(
+            int(_dht22_num(sensor.get('address'), 0.0)),
+            int(_dht22_num(sensor.get('command'), 0x45)),
+        )
 
     class HCSR04SyncHandler:
         """Drives HC-SR04 ECHO pin synchronously from the QEMU GPIO_IN read callback.
@@ -2221,6 +2361,16 @@ def main() -> None:  # noqa: C901  (complexity OK for inline worker)
                 }
                 if sensor_type == 'matrix-keypad':
                     _keypad_install(gpio, sensor_data)
+                elif sensor_type == 'ir-nec':
+                    # A demodulator's output idles HIGH and the host owns it:
+                    # nothing on the canvas or in the guest may drive this pad.
+                    # Seeded here rather than on the first frame, because a
+                    # decoder samples the line from the moment it starts and a
+                    # pad left at 0 reads as a transmission that never ends.
+                    try:
+                        lib.qemu_picsimlab_set_pin(gpio + 1, 1)
+                    except Exception:
+                        pass
                 elif sensor_type == 'mpu6050':
                     i2c_addr = int(cmd.get('addr', 0x68))
                     slave = _MPU6050Slave(i2c_addr)
@@ -2329,6 +2479,11 @@ def main() -> None:  # noqa: C901  (complexity OK for inline worker)
 
         elif c == 'sensor_update':
             gpio = int(cmd['pin'])
+            # Frames to arm once the lock is back off. `_sensors_lock` is a
+            # plain Lock and `_ir_arm` takes it itself, so arming from inside
+            # the block below would deadlock the command thread on the first
+            # button press.
+            _ir_pending: list = []
             with _sensors_lock:
                 sensor = _sensors.get(gpio)
                 if sensor:
@@ -2337,7 +2492,23 @@ def main() -> None:  # noqa: C901  (complexity OK for inline worker)
                             sensor[k] = v
                     stype = sensor.get('type')
                     slave = sensor.get('slave')
-                    if stype == 'matrix-keypad':
+                    if stype == 'ir-nec':
+                        # A trigger key's VALUE CHANGING is the transmission,
+                        # whatever the new value is. It has to be a change and
+                        # not a presence: the frontend's hosted path merges the
+                        # whole record into every update, so the key is present
+                        # on every slider tick and a model that fired on
+                        # presence would transmit once per tick.
+                        fired = False
+                        for _k in ('seq', 'send'):
+                            if _k not in cmd:
+                                continue
+                            if cmd[_k] != sensor.get('_ir_seen_' + _k):
+                                fired = True
+                            sensor['_ir_seen_' + _k] = cmd[_k]
+                        if fired:
+                            _ir_pending.append((gpio, _ir_pulses_for(sensor)))
+                    elif stype == 'matrix-keypad':
                         kp = sensor.get('keypad')
                         if kp is not None and 'pressed' in cmd:
                             kp['pressed'] = {
@@ -2389,6 +2560,12 @@ def main() -> None:  # noqa: C901  (complexity OK for inline worker)
                                 })
                             except Exception as e:
                                 _log(f'[custom-chip] attr update failed: {e!r}')
+
+            for _g, _p in _ir_pending:
+                with _sensors_lock:
+                    _s = _sensors.get(_g)
+                if _s is not None:
+                    _ir_arm(_g, _s, _p, 'canvas')
 
         elif c == 'sensor_detach':
             gpio = int(cmd['pin'])

--- a/frontend/public/components-metadata.json
+++ b/frontend/public/components-metadata.json
@@ -4056,14 +4056,47 @@
       "name": "IR Receiver",
       "category": "passive",
       "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\">\n      <rect width=\"64\" height=\"64\" fill=\"#e0e0e0\" rx=\"4\"/>\n      <text x=\"50%\" y=\"50%\" text-anchor=\"middle\" dy=\".3em\" font-size=\"10\" fill=\"#666\">\n        IR-RECEIVER\n      </text>\n    </svg>",
-      "properties": [],
-      "defaultValues": {},
-      "pinCount": 0,
+      "properties": [
+        {
+          "name": "irAddress",
+          "type": "string",
+          "defaultValue": "0x00",
+          "control": "text",
+          "description": "NEC address this receiver transmits when clicked"
+        },
+        {
+          "name": "irCommand",
+          "type": "string",
+          "defaultValue": "0x45",
+          "control": "text",
+          "description": "NEC command this receiver transmits when clicked"
+        },
+        {
+          "name": "channel",
+          "type": "string",
+          "defaultValue": "",
+          "control": "text",
+          "description": "Leave empty to hear every IR emitter. Set a name to hear only emitters carrying the same one."
+        }
+      ],
+      "defaultValues": {
+        "irAddress": "0x00",
+        "irCommand": "0x45",
+        "channel": ""
+      },
+      "pinCount": 3,
       "tags": [
         "ir-receiver",
         "ir receiver",
         "ir",
-        "receiver"
+        "receiver",
+        "infrared",
+        "nec",
+        "remote",
+        "demodulator",
+        "vs1838b",
+        "tsop",
+        "38khz"
       ]
     },
     {
@@ -4072,14 +4105,37 @@
       "name": "IR Remote",
       "category": "passive",
       "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\">\n      <rect width=\"64\" height=\"64\" fill=\"#e0e0e0\" rx=\"4\"/>\n      <text x=\"50%\" y=\"50%\" text-anchor=\"middle\" dy=\".3em\" font-size=\"10\" fill=\"#666\">\n        IR-REMOTE\n      </text>\n    </svg>",
-      "properties": [],
-      "defaultValues": {},
+      "properties": [
+        {
+          "name": "irAddress",
+          "type": "string",
+          "defaultValue": "0x00",
+          "control": "text",
+          "description": "NEC address of this handset"
+        },
+        {
+          "name": "channel",
+          "type": "string",
+          "defaultValue": "",
+          "control": "text",
+          "description": "Leave empty to transmit into the room. Set a name to reach only receivers carrying the same one."
+        }
+      ],
+      "defaultValues": {
+        "irAddress": "0x00",
+        "channel": ""
+      },
       "pinCount": 0,
       "tags": [
         "ir-remote",
         "ir remote",
         "ir",
-        "remote"
+        "remote",
+        "infrared",
+        "nec",
+        "remote control",
+        "handset",
+        "transmitter"
       ]
     },
     {

--- a/frontend/src/__tests__/ir-air.test.ts
+++ b/frontend/src/__tests__/ir-air.test.ts
@@ -1,0 +1,440 @@
+/**
+ * The air, the codec, and the two line models — the layer under the parts.
+ *
+ * `protocol-parts.test.ts` covers the two canvas parts end to end. This file
+ * covers the pieces they stand on, and in particular the three things that are
+ * easy to get wrong and impossible to see on a canvas: the round trip through
+ * the codec, the polarity of the envelope, and the demodulation of a bit-banged
+ * 38 kHz carrier back into marks and spaces.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  channelHears,
+  emitIr,
+  irAirStats,
+  listenIr,
+  necDecode,
+  necEncode,
+  necEncodeRepeat,
+  resetIrAir,
+  type IrPulse,
+  NEC_HEADER_MARK_US,
+  NEC_HEADER_SPACE_US,
+  NEC_ONE_SPACE_US,
+  NEC_ZERO_SPACE_US,
+  NEC_BIT_MARK_US,
+} from '../simulation/ir';
+import { LineSensorHub } from '../simulation/line/LineSensorHub';
+import type { LineHostPort } from '../simulation/line/LineHost';
+import { INITIAL_PAD, type PadEvent, type PadState } from '../simulation/line/padEvent';
+import { CARRIER_GAP_US, FLUSH_DEBOUNCE_MS } from '../simulation/line/models/ir-tx';
+
+const CLOCK_HZ = 16e6;
+
+function makeHub() {
+  const listeners = new Map<number, Set<(e: PadEvent) => void>>();
+  const edges: Array<[number, boolean, number]> = [];
+  let cycle = 10_000;
+  const port: LineHostPort = {
+    now: () => cycle,
+    clockHz: () => CLOCK_HZ,
+    scheduleEdge: (pin, level, at) => edges.push([pin, level, at]),
+    onPad: (pin, cb) => {
+      if (!listeners.has(pin)) listeners.set(pin, new Set());
+      listeners.get(pin)!.add(cb);
+      return () => listeners.get(pin)!.delete(cb);
+    },
+    restPad: () => {},
+  };
+  const hub = new LineSensorHub(port);
+  return {
+    hub,
+    edges,
+    /**
+     * Drive the pad from the guest side and HOLD it for `us`.
+     *
+     * The order matters and getting it backwards is the classic way to write a
+     * test that measures the previous interval as the current one: a simulator
+     * reports the change at the instant it happens, so the level is announced
+     * FIRST and the clock advances after. A helper that advanced first shifted
+     * every duration one pulse along, which turned a 9 ms header into a 4.5 ms
+     * one and made a perfectly good decoder look broken.
+     */
+    hold(pin: number, drive: PadState['drive'], us: number, prev: PadState) {
+      const next: PadState = { drive, pull: 0, level: drive === 'high', cycle };
+      listeners.get(pin)?.forEach((cb) => cb({ pin, ...next, prev }));
+      cycle += Math.round((us * CLOCK_HZ) / 1e6);
+      return next;
+    },
+    at: () => cycle,
+  };
+}
+
+/** The mark/space train an edge list represents, on an active-low output. */
+function edgesToPulses(edges: Array<[number, boolean, number]>): IrPulse[] {
+  const out: IrPulse[] = [];
+  for (let i = 0; i + 1 < edges.length; i++) {
+    out.push({
+      level: edges[i][1] ? 0 : 1,
+      us: ((edges[i + 1][2] - edges[i][2]) / CLOCK_HZ) * 1e6,
+    });
+  }
+  return out;
+}
+
+describe('NEC codec', () => {
+  it('round-trips an address and a command', () => {
+    for (const [addr, cmd] of [
+      [0x00, 0x45],
+      [0xff, 0x00],
+      [0x04, 0x1c],
+      [0x7f, 0xa2],
+    ]) {
+      const f = necDecode(necEncode(addr, cmd));
+      expect([f.protocol, f.address, f.command, f.verified]).toEqual(['NEC', addr, cmd, true]);
+    }
+  });
+
+  it('sends the header, then 32 bits, then a stop mark', () => {
+    const p = necEncode(0x00, 0x45);
+    expect(p).toHaveLength(2 + 64 + 1);
+    expect(p[0]).toEqual({ level: 1, us: NEC_HEADER_MARK_US });
+    expect(p[1]).toEqual({ level: 0, us: NEC_HEADER_SPACE_US });
+    expect(p[p.length - 1]).toEqual({ level: 1, us: NEC_BIT_MARK_US });
+  });
+
+  it('a bit is in the SPACE, least significant first', () => {
+    // 0x01: only bit 0 set, so the first data space is long and the rest short.
+    const p = necEncode(0x01, 0x00);
+    expect(p[3].us).toBe(NEC_ONE_SPACE_US);
+    expect(p[5].us).toBe(NEC_ZERO_SPACE_US);
+  });
+
+  it('an address above 0xff goes out as extended NEC and comes back whole', () => {
+    const f = necDecode(necEncode(0x1234, 0x56));
+    expect(f.address).toBe(0x1234);
+    expect(f.command).toBe(0x56);
+  });
+
+  it('decodes a repeat frame as carrying no data', () => {
+    const f = necDecode(necEncodeRepeat());
+    expect(f.protocol).toBe('NEC-repeat');
+  });
+
+  it('tolerates the timing drift a guest running behind real time produces', () => {
+    const stretched = necEncode(0x04, 0x1c).map((p) => ({ ...p, us: p.us * 1.15 }));
+    expect(necDecode(stretched).command).toBe(0x1c);
+  });
+
+  it('reports a train it cannot parse as raw rather than as a wrong reading', () => {
+    expect(
+      necDecode([
+        { level: 1, us: 100 },
+        { level: 0, us: 100 },
+      ]).protocol,
+    ).toBe('raw');
+  });
+
+  it('skips the leading space a capture usually starts with', () => {
+    expect(necDecode([{ level: 0, us: 40_000 }, ...necEncode(0x04, 0x1c)]).command).toBe(0x1c);
+  });
+});
+
+describe('irAir — the medium', () => {
+  beforeEach(() => resetIrAir());
+
+  it('delivers to everyone and skips the source', () => {
+    const heard: string[] = [];
+    listenIr(
+      'a',
+      () => '',
+      () => (heard.push('a'), true),
+    );
+    listenIr(
+      'b',
+      () => '',
+      () => (heard.push('b'), true),
+    );
+    listenIr(
+      'c',
+      () => '',
+      () => (heard.push('c'), true),
+    );
+    expect(emitIr({ pulses: necEncode(0, 1), sourceId: 'b' })).toBe(2);
+    expect(heard.sort()).toEqual(['a', 'c']);
+  });
+
+  it('counts a delivery only when the receiver took it', () => {
+    listenIr(
+      'a',
+      () => '',
+      () => false,
+    );
+    expect(emitIr({ pulses: necEncode(0, 1), sourceId: 'x' })).toBe(0);
+    expect(irAirStats.emitted).toBe(1);
+  });
+
+  it('a thrown receiver does not stop the others', () => {
+    listenIr(
+      'bad',
+      () => '',
+      () => {
+        throw new Error('boom');
+      },
+    );
+    listenIr(
+      'good',
+      () => '',
+      () => true,
+    );
+    expect(emitIr({ pulses: necEncode(0, 1), sourceId: 'x' })).toBe(1);
+  });
+
+  it('decodes the frame once, for every listener and every indicator', () => {
+    let seen: { address: number; command: number } | null = null;
+    listenIr(
+      'a',
+      () => '',
+      (f) => ((seen = { address: f.address, command: f.command }), true),
+    );
+    emitIr({ pulses: necEncode(0x04, 0x1c), sourceId: 'x' });
+    expect(seen).toEqual({ address: 0x04, command: 0x1c });
+  });
+
+  it('the channel rule: empty hears all, set hears only its own, case and space folded', () => {
+    expect(channelHears('', 'anything')).toBe(true);
+    expect(channelHears('', '')).toBe(true);
+    expect(channelHears('left', 'left')).toBe(true);
+    expect(channelHears(' LEFT ', 'left')).toBe(true);
+    expect(channelHears('left', 'right')).toBe(false);
+    expect(channelHears('left', '')).toBe(false);
+  });
+
+  it('re-reads a listener channel at delivery, so retuning needs no resubscribe', () => {
+    let channel = 'left';
+    let hits = 0;
+    listenIr(
+      'a',
+      () => channel,
+      () => (hits++, true),
+    );
+    emitIr({ pulses: necEncode(0, 1), sourceId: 'x', channel: 'right' });
+    expect(hits).toBe(0);
+    channel = 'right';
+    emitIr({ pulses: necEncode(0, 1), sourceId: 'x', channel: 'right' });
+    expect(hits).toBe(1);
+  });
+
+  it('an empty train is not a transmission', () => {
+    listenIr(
+      'a',
+      () => '',
+      () => true,
+    );
+    expect(emitIr({ pulses: [], sourceId: 'x' })).toBe(0);
+    expect(irAirStats.emitted).toBe(0);
+  });
+
+  it('unsubscribing stops delivery', () => {
+    let hits = 0;
+    const off = listenIr(
+      'a',
+      () => '',
+      () => (hits++, true),
+    );
+    emitIr({ pulses: necEncode(0, 1), sourceId: 'x' });
+    off();
+    emitIr({ pulses: necEncode(0, 1), sourceId: 'x' });
+    expect(hits).toBe(1);
+  });
+});
+
+describe('ir-nec — the receive model', () => {
+  it('inverts the train: the pin is LOW for a mark', () => {
+    const { hub, edges } = makeHub();
+    hub.attach({ sensor_type: 'ir-nec', pin: 5 });
+    hub.update(5, { pulses: necEncode(0x04, 0x1c), seq: 1 });
+    expect(edges[0][1]).toBe(false);
+    expect(necDecode(edgesToPulses(edges))).toMatchObject({ address: 0x04, command: 0x1c });
+  });
+
+  it('ends HIGH even though a NEC train ends on a mark', () => {
+    const { hub, edges } = makeHub();
+    hub.attach({ sensor_type: 'ir-nec', pin: 5 });
+    hub.update(5, { pulses: necEncode(0, 1), seq: 1 });
+    // A decoder waiting for the end of the frame must see the line come back
+    // to idle; a train that ended low would strand it there forever.
+    expect(edges[edges.length - 1][1]).toBe(true);
+  });
+
+  it('fires on a trigger key CHANGING, not on it being present', () => {
+    const { hub, edges } = makeHub();
+    hub.attach({ sensor_type: 'ir-nec', pin: 5, address: 0, command: 0x45 });
+    hub.update(5, { address: 1 }); // a slider tick, no send
+    expect(edges).toHaveLength(0);
+    hub.update(5, { seq: 1 });
+    expect(edges.length).toBeGreaterThan(0);
+    const n = edges.length;
+    // The hosted path merges the record into every update, so the key is
+    // present again with the SAME value: that is not a second press.
+    hub.update(5, { seq: 1, address: 1 });
+    expect(edges).toHaveLength(n);
+  });
+
+  it('does not start a second frame on top of one still going out', () => {
+    const { hub, edges } = makeHub();
+    hub.attach({ sensor_type: 'ir-nec', pin: 5 });
+    hub.update(5, { seq: 1 });
+    const n = edges.length;
+    hub.update(5, { seq: 2 }); // the clock has not moved; the first is still on the wire
+    expect(edges).toHaveLength(n);
+  });
+
+  it('falls back to its own address and command when the air carried no train', () => {
+    const { hub, edges } = makeHub();
+    hub.attach({ sensor_type: 'ir-nec', pin: 5, address: 0x08, command: 0x22 });
+    hub.update(5, { seq: 1 });
+    expect(necDecode(edgesToPulses(edges))).toMatchObject({ address: 0x08, command: 0x22 });
+  });
+
+  it('never replays the last train it was handed', () => {
+    const { hub, edges } = makeHub();
+    hub.attach({ sensor_type: 'ir-nec', pin: 5, address: 0x08, command: 0x22 });
+    hub.update(5, { pulses: necEncode(0x01, 0x02), seq: 1 });
+    expect(necDecode(edgesToPulses(edges))).toMatchObject({ address: 0x01, command: 0x02 });
+    edges.length = 0;
+    hub.reset();
+    hub.update(5, { seq: 2 }); // a Send with nothing carried: its own code, not the last one
+    expect(necDecode(edgesToPulses(edges))).toMatchObject({ address: 0x08, command: 0x22 });
+  });
+
+  it('drives its pin and listens to none', () => {
+    const { hub } = makeHub();
+    hub.attach({ sensor_type: 'ir-nec', pin: 5 });
+    expect(hub.ownsPin(5)).toBe(true);
+  });
+});
+
+describe('ir-tx — the transmit model', () => {
+  beforeEach(() => {
+    resetIrAir();
+    vi.useFakeTimers();
+  });
+  afterEach(() => vi.useRealTimers());
+
+  /** Bit-bang `pulses` on a pad the way a sketch does: a 38 kHz square wave
+   *  through each mark, a flat low through each space. */
+  function bitBang(h: ReturnType<typeof makeHub>, pin: number, pulses: IrPulse[], carrierUs = 13) {
+    let prev: PadState = INITIAL_PAD;
+    for (const p of pulses) {
+      if (p.level === 1) {
+        for (let t = 0; t + carrierUs * 2 <= p.us; t += carrierUs * 2) {
+          prev = h.hold(pin, 'high', carrierUs, prev);
+          prev = h.hold(pin, 'low', carrierUs, prev);
+        }
+      } else {
+        prev = h.hold(pin, 'low', p.us, prev);
+      }
+    }
+    // The pin has to move once more for the last interval to be measurable.
+    return h.hold(pin, 'high', 100, prev);
+  }
+
+  it('demodulates a bit-banged 38 kHz carrier back to the frame that was sent', () => {
+    const h = makeHub();
+    h.hub.attach({ sensor_type: 'ir-tx', pin: 4, source_id: 'led-1' });
+    let got: { address: number; command: number } | null = null;
+    listenIr(
+      'rx',
+      () => '',
+      (f) => ((got = { address: f.address, command: f.command }), true),
+    );
+
+    bitBang(h, 4, necEncode(0x04, 0x1c));
+    vi.advanceTimersByTime(FLUSH_DEBOUNCE_MS + 10);
+
+    expect(got).toEqual({ address: 0x04, command: 0x1c });
+  });
+
+  it('reports the carrier it measured', () => {
+    const h = makeHub();
+    h.hub.attach({ sensor_type: 'ir-tx', pin: 4, source_id: 'led-1' });
+    bitBang(h, 4, necEncode(0x00, 0x45));
+    vi.advanceTimersByTime(FLUSH_DEBOUNCE_MS + 10);
+    // 13 us per half cycle is 38.5 kHz. Measured, not assumed.
+    expect(irAirStats.last!.carrierHz).toBeGreaterThan(30_000);
+    expect(irAirStats.last!.carrierHz).toBeLessThan(45_000);
+  });
+
+  it('also handles an unmodulated envelope, with no carrier at all', () => {
+    const h = makeHub();
+    h.hub.attach({ sensor_type: 'ir-tx', pin: 4, source_id: 'led-1' });
+    let got: number | null = null;
+    listenIr(
+      'rx',
+      () => '',
+      (f) => ((got = f.command), true),
+    );
+
+    let prev: PadState = INITIAL_PAD;
+    for (const p of necEncode(0x00, 0x45)) {
+      prev = h.hold(4, p.level === 1 ? 'high' : 'low', p.us, prev);
+    }
+    h.hold(4, 'low', 100, prev);
+    vi.advanceTimersByTime(FLUSH_DEBOUNCE_MS + 10);
+
+    expect(got).toBe(0x45);
+    expect(irAirStats.last!.carrierHz).toBe(0); // no transitions inside the marks
+  });
+
+  it('a low notch shorter than the carrier gap is carrier, not a space', () => {
+    const h = makeHub();
+    h.hub.attach({ sensor_type: 'ir-tx', pin: 4, source_id: 'led-1' });
+    listenIr(
+      'rx',
+      () => '',
+      () => true,
+    );
+    // Notches at half the gap must not split the 9 ms header into pieces.
+    bitBang(h, 4, necEncode(0x04, 0x1c), Math.floor(CARRIER_GAP_US / 2));
+    vi.advanceTimersByTime(FLUSH_DEBOUNCE_MS + 10);
+    expect(irAirStats.last!.command).toBe(0x1c);
+  });
+
+  it('owns no pad — the guest drives that pin', () => {
+    const h = makeHub();
+    h.hub.attach({ sensor_type: 'ir-tx', pin: 4, source_id: 'led-1' });
+    expect(h.hub.ownsPin(4)).toBe(false);
+  });
+
+  it('a stray edge or two is not a transmission', () => {
+    const h = makeHub();
+    h.hub.attach({ sensor_type: 'ir-tx', pin: 4, source_id: 'led-1' });
+    let prev: PadState = INITIAL_PAD;
+    prev = h.hold(4, 'high', 1000, prev);
+    h.hold(4, 'low', 1000, prev);
+    vi.advanceTimersByTime(FLUSH_DEBOUNCE_MS + 10);
+    expect(irAirStats.emitted).toBe(0);
+  });
+
+  it('transmits on its channel', () => {
+    const h = makeHub();
+    h.hub.attach({ sensor_type: 'ir-tx', pin: 4, source_id: 'led-1', channel: 'left' });
+    bitBang(h, 4, necEncode(0x00, 0x45));
+    vi.advanceTimersByTime(FLUSH_DEBOUNCE_MS + 10);
+    expect(irAirStats.last!.channel).toBe('left');
+  });
+
+  it('a reboot throws away a half-captured frame', () => {
+    const h = makeHub();
+    h.hub.attach({ sensor_type: 'ir-tx', pin: 4, source_id: 'led-1' });
+    let prev: PadState = INITIAL_PAD;
+    for (const p of necEncode(0x00, 0x45).slice(0, 20)) {
+      prev = h.hold(4, p.level === 1 ? 'high' : 'low', p.us, prev);
+    }
+    h.hub.reset();
+    vi.advanceTimersByTime(FLUSH_DEBOUNCE_MS + 10);
+    expect(irAirStats.emitted).toBe(0);
+  });
+});

--- a/frontend/src/__tests__/protocol-parts.test.ts
+++ b/frontend/src/__tests__/protocol-parts.test.ts
@@ -9,8 +9,8 @@
  *   mpu6050       — I2C IMU  (VirtualMPU6050)
  *   dht22         — single-wire temp/humidity
  *   hx711         — 2-wire load-cell ADC
- *   ir-receiver   — click → NEC pulse on OUT pin
- *   ir-remote     — button-press → ir-signal event
+ *   ir-receiver   — the air → a real NEC envelope on its DAT pin
+ *   ir-remote     — a button press → the air
  *   microsd-card  — SPI SD init handshake
  */
 
@@ -21,6 +21,14 @@ import type { LineHostPort } from '../simulation/line/LineHost';
 import { INITIAL_PAD, type PadEvent, type PadState } from '../simulation/line/padEvent';
 import { clearLineGaps, lineGaps } from '../simulation/line/requestLine';
 import { dispatchSensorUpdate } from '../simulation/SensorUpdateRegistry';
+import {
+  emitIr,
+  irAirStats,
+  necDecode,
+  necEncode,
+  resetIrAir,
+  NEC_REPEAT_PERIOD_MS,
+} from '../simulation/ir';
 import { useSimulatorStore } from '../store/useSimulatorStore';
 import '../simulation/parts/ProtocolParts';
 
@@ -348,41 +356,53 @@ describe('mpu6050 — I2C IMU', () => {
 
 // ─── dht22 ───────────────────────────────────────────────────────────────────
 
-describe('dht22 — single-wire sensor (the line contract)', () => {
-  /** A board that hosts line models itself, over a fake port. */
-  function makeLineSim() {
-    const listeners = new Map<number, Set<(e: PadEvent) => void>>();
-    const port: LineHostPort & { edges: Array<[number, boolean, number]>; rests: Array<[number, boolean, boolean]> } = {
-      edges: [],
-      rests: [],
-      now: () => 10_000,
-      clockHz: () => 16e6,
-      scheduleEdge: (pin, level, at) => port.edges.push([pin, level, at]),
-      onPad: (pin, cb) => {
-        if (!listeners.has(pin)) listeners.set(pin, new Set());
-        listeners.get(pin)!.add(cb);
-        return () => listeners.get(pin)!.delete(cb);
-      },
-      restPad: (pin, level, driven) => port.rests.push([pin, level, driven]),
-    };
-    const hub = new LineSensorHub(port);
-    const sim = {
-      ...makePinSim(),
-      lineSupport: () => ({ mode: 'local' as const }),
-      lineHub: () => hub,
-      /** Emit the guest's drive changes the way a simulator would. */
-      guest(pin: number, drives: Array<PadState['drive']>) {
-        let prev: PadState = INITIAL_PAD;
-        for (const drive of drives) {
-          const next: PadState = { drive, pull: drive === 'z' ? 1 : 0, level: drive !== 'low', cycle: 10_000 };
-          listeners.get(pin)?.forEach((cb) => cb({ pin, ...next, prev }));
-          prev = next;
-        }
-      },
-    };
-    return { sim, hub, port };
-  }
+/**
+ * A board that hosts line models itself, over a fake port. At module scope
+ * because the dht22 section and the infrared one both need it — the two
+ * devices differ only in which model they attach.
+ */
+function makeLineSim() {
+  const listeners = new Map<number, Set<(e: PadEvent) => void>>();
+  const port: LineHostPort & {
+    edges: Array<[number, boolean, number]>;
+    rests: Array<[number, boolean, boolean]>;
+  } = {
+    edges: [],
+    rests: [],
+    now: () => 10_000,
+    clockHz: () => 16e6,
+    scheduleEdge: (pin, level, at) => port.edges.push([pin, level, at]),
+    onPad: (pin, cb) => {
+      if (!listeners.has(pin)) listeners.set(pin, new Set());
+      listeners.get(pin)!.add(cb);
+      return () => listeners.get(pin)!.delete(cb);
+    },
+    restPad: (pin, level, driven) => port.rests.push([pin, level, driven]),
+  };
+  const hub = new LineSensorHub(port);
+  const sim = {
+    ...makePinSim(),
+    lineSupport: () => ({ mode: 'local' as const }),
+    lineHub: () => hub,
+    /** Emit the guest's drive changes the way a simulator would. */
+    guest(pin: number, drives: Array<PadState['drive']>) {
+      let prev: PadState = INITIAL_PAD;
+      for (const drive of drives) {
+        const next: PadState = {
+          drive,
+          pull: drive === 'z' ? 1 : 0,
+          level: drive !== 'low',
+          cycle: 10_000,
+        };
+        listeners.get(pin)?.forEach((cb) => cb({ pin, ...next, prev }));
+        prev = next;
+      }
+    },
+  };
+  return { sim, hub, port };
+}
 
+describe('dht22 — single-wire sensor (the line contract)', () => {
   it('asks the board to host it and rests DATA released on its pull-up', () => {
     const { sim, hub, port } = makeLineSim();
     const logic = PartSimulationRegistry.get('dht22')!;
@@ -395,7 +415,12 @@ describe('dht22 — single-wire sensor (the line contract)', () => {
   it('answers the start signal (LOW, then release) with the 84-edge frame', () => {
     const { sim, port } = makeLineSim();
     const logic = PartSimulationRegistry.get('dht22')!;
-    logic.attachEvents!(makeElement({ temperature: 25.0, humidity: 50.0 }), sim as any, pinMap({ DATA: 7 }), 'dht-2');
+    logic.attachEvents!(
+      makeElement({ temperature: 25.0, humidity: 50.0 }),
+      sim as any,
+      pinMap({ DATA: 7 }),
+      'dht-2',
+    );
     sim.guest(7, ['high', 'low', 'z']);
     expect(port.edges).toHaveLength(84);
     expect(port.edges[0]).toEqual([7, false, 10_000 + 16 * 20]);
@@ -439,7 +464,12 @@ describe('dht22 — single-wire sensor (the line contract)', () => {
     const cleanup = logic.attachEvents!(makeElement(), sim as any, pinMap({ DATA: 7 }), 'dht-6');
     expect(sim.setPinState).not.toHaveBeenCalled();
     expect(sim.pinManager.onPinChange).not.toHaveBeenCalled();
-    expect(lineGaps()).toContainEqual({ sensorType: 'dht22', pin: 7, why: expect.any(String), componentId: 'dht-6' });
+    expect(lineGaps()).toContainEqual({
+      sensorType: 'dht22',
+      pin: 7,
+      why: expect.any(String),
+      componentId: 'dht-6',
+    });
     expect(warn).toHaveBeenCalled();
     expect(() => cleanup()).not.toThrow();
     warn.mockRestore();
@@ -524,138 +554,274 @@ describe('hx711 — load cell amplifier', () => {
   });
 });
 
-// ─── ir-receiver ─────────────────────────────────────────────────────────────
+// ─── Infrared ────────────────────────────────────────────────────────────────
 
-describe('ir-receiver — NEC click simulation', () => {
-  it('sets OUT pin HIGH (idle) on attach', () => {
-    const sim = makePinSim();
+/**
+ * These two parts were both dead, and every test in this file's previous IR
+ * section passed anyway — they asserted that a click made `setPinState` calls
+ * and that a listener got registered, which is true of code that transmits
+ * nothing anybody can decode on a pin nobody is watching. So the assertions
+ * here are about the LINK: a press on one part reaches another part's pin, and
+ * what lands there decodes back to the button that was pressed.
+ */
+
+/** The pin levels an edge frame produces, as mark/space microseconds. */
+function edgesToPulses(
+  edges: Array<[number, boolean, number]>,
+  clockHz: number,
+): Array<{ level: 0 | 1; us: number }> {
+  const out: Array<{ level: 0 | 1; us: number }> = [];
+  for (let i = 0; i + 1 < edges.length; i++) {
+    const us = ((edges[i + 1][2] - edges[i][2]) / clockHz) * 1e6;
+    // The pin is active LOW: it is low for a mark.
+    out.push({ level: edges[i][1] ? 0 : 1, us });
+  }
+  return out;
+}
+
+describe('ir-receiver — the demodulator', () => {
+  beforeEach(() => resetIrAir());
+
+  it('resolves DAT, the pin the element actually declares', () => {
+    const { sim, hub } = makeLineSim();
     const logic = PartSimulationRegistry.get('ir-receiver')!;
-    logic.attachEvents!(makeElement(), sim as any, pinMap({ OUT: 5 }));
-    expect(sim.setPinState).toHaveBeenCalledWith(5, true);
+    logic.attachEvents!(makeElement(), sim as any, pinMap({ DAT: 5 }), 'rx-1');
+    expect(hub.size).toBe(1);
+    expect(hub.ownsPin(5)).toBe(true);
   });
 
-  it('registers a click listener on the element', () => {
-    const sim = makePinSim();
-    const el = makeElement();
+  it('rests its output HIGH, driven — a demodulator idles high and owns the line', () => {
+    const { sim, port } = makeLineSim();
     const logic = PartSimulationRegistry.get('ir-receiver')!;
-    logic.attachEvents!(el, sim as any, pinMap({ OUT: 5 }));
-    expect(el.addEventListener).toHaveBeenCalledWith('click', expect.any(Function));
+    logic.attachEvents!(makeElement(), sim as any, pinMap({ DAT: 5 }), 'rx-2');
+    expect(port.rests).toEqual([[5, true, true]]);
   });
 
-  it('click drives OUT LOW (IR burst start) and later HIGH via setTimeout', () => {
-    const sim = makePinSim();
-    const el = makeElement();
+  it('puts a frame from the air on its pin, active low and back to idle', () => {
+    const { sim, port } = makeLineSim();
     const logic = PartSimulationRegistry.get('ir-receiver')!;
-    logic.attachEvents!(el, sim as any, pinMap({ OUT: 5 }));
+    logic.attachEvents!(makeElement(), sim as any, pinMap({ DAT: 5 }), 'rx-3');
+    port.edges.length = 0;
 
-    const clickCb = (el.addEventListener as ReturnType<typeof vi.fn>).mock.calls.find(
-      ([event]) => event === 'click',
-    )?.[1] as (() => void) | undefined;
-    expect(clickCb).toBeDefined();
+    emitIr({ pulses: necEncode(0x00, 0x45), sourceId: 'somebody-else' });
 
-    sim.setPinState.mockClear();
-    clickCb!();
-
-    // First call should drive pin LOW (beginning of 9 ms preamble burst)
-    const firstLow = (sim.setPinState as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(firstLow).toEqual([5, false]);
+    expect(port.edges.length).toBeGreaterThan(60); // 32 bits, two edges each
+    expect(port.edges[0][1]).toBe(false); // the 9 ms header mark pulls it LOW
+    expect(port.edges[port.edges.length - 1][1]).toBe(true); // and it ends idle
   });
 
-  it('NEC sequence produces more than 60 setPinState calls (35+ transitions)', () => {
-    const sim = makePinSim();
+  it('what lands on the pin decodes back to the address and command sent', () => {
+    const { sim, port } = makeLineSim();
+    const logic = PartSimulationRegistry.get('ir-receiver')!;
+    logic.attachEvents!(makeElement(), sim as any, pinMap({ DAT: 5 }), 'rx-4');
+    port.edges.length = 0;
+
+    emitIr({ pulses: necEncode(0x04, 0x1c), sourceId: 'remote-x' });
+
+    const decoded = necDecode(edgesToPulses(port.edges, 16e6));
+    expect(decoded.protocol).toBe('NEC');
+    expect(decoded.address).toBe(0x04);
+    expect(decoded.command).toBe(0x1c);
+    expect(decoded.verified).toBe(true);
+  });
+
+  it('the timing is real: a NEC header mark is 9 ms on the guest clock', () => {
+    const { sim, port } = makeLineSim();
+    const logic = PartSimulationRegistry.get('ir-receiver')!;
+    logic.attachEvents!(makeElement(), sim as any, pinMap({ DAT: 5 }), 'rx-5');
+    port.edges.length = 0;
+
+    emitIr({ pulses: necEncode(0x00, 0x45), sourceId: 'remote-x' });
+
+    // 16 MHz: 9 ms is 144 000 cycles. The old setTimeout(0.562) could not
+    // express this at all, which is why no IR library ever decoded it.
+    const headerCycles = port.edges[1][2] - port.edges[0][2];
+    expect(headerCycles).toBe(Math.round(9000 * 16));
+  });
+
+  it('does not hear its own transmission', () => {
+    const { sim, port } = makeLineSim();
     const el = makeElement();
     const logic = PartSimulationRegistry.get('ir-receiver')!;
-    logic.attachEvents!(el, sim as any, pinMap({ OUT: 5 }));
+    logic.attachEvents!(el, sim as any, pinMap({ DAT: 5 }), 'rx-6');
+    port.edges.length = 0;
 
-    const clickCb = (el.addEventListener as ReturnType<typeof vi.fn>).mock.calls.find(
+    const click = (el.addEventListener as ReturnType<typeof vi.fn>).mock.calls.find(
       ([ev]) => ev === 'click',
     )?.[1] as () => void;
+    click();
 
-    sim.setPinState.mockClear();
-    clickCb();
-    // Run all queued timeouts to exhaust the chain
-    vi.runAllTimers();
-
-    expect((sim.setPinState as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(60);
+    expect(irAirStats.emitted).toBe(1);
+    expect(port.edges).toHaveLength(0);
   });
 
-  it('cleanup removes click listener and sets pin HIGH', () => {
-    const sim = makePinSim();
-    const el = makeElement();
+  it('two receivers both hear one transmission', () => {
+    const a = makeLineSim();
+    const b = makeLineSim();
     const logic = PartSimulationRegistry.get('ir-receiver')!;
-    const cleanup = logic.attachEvents!(el, sim as any, pinMap({ OUT: 5 }));
-    sim.setPinState.mockClear();
+    logic.attachEvents!(makeElement(), a.sim as any, pinMap({ DAT: 5 }), 'rx-a');
+    logic.attachEvents!(makeElement(), b.sim as any, pinMap({ DAT: 9 }), 'rx-b');
+    a.port.edges.length = 0;
+    b.port.edges.length = 0;
+
+    emitIr({ pulses: necEncode(0x00, 0x45), sourceId: 'remote-x' });
+
+    expect(a.port.edges.length).toBeGreaterThan(60);
+    expect(b.port.edges.length).toBeGreaterThan(60);
+    expect(b.port.edges[0][0]).toBe(9); // on its own pin, not the other's
+  });
+
+  it('a channel isolates a pair; an unset channel still hears everything', () => {
+    const tuned = makeLineSim();
+    const open = makeLineSim();
+    const logic = PartSimulationRegistry.get('ir-receiver')!;
+    logic.attachEvents!(
+      makeElement({ channel: 'left' }),
+      tuned.sim as any,
+      pinMap({ DAT: 5 }),
+      'rx-l',
+    );
+    logic.attachEvents!(makeElement(), open.sim as any, pinMap({ DAT: 6 }), 'rx-open');
+    tuned.port.edges.length = 0;
+    open.port.edges.length = 0;
+
+    emitIr({ pulses: necEncode(0x00, 0x45), sourceId: 'remote-r', channel: 'right' });
+    expect(tuned.port.edges).toHaveLength(0);
+    expect(open.port.edges.length).toBeGreaterThan(60);
+
+    tuned.port.edges.length = 0;
+    emitIr({ pulses: necEncode(0x00, 0x45), sourceId: 'remote-l', channel: 'LEFT' });
+    expect(tuned.port.edges.length).toBeGreaterThan(60); // matched case-insensitively
+  });
+
+  it('stops listening after cleanup', () => {
+    const { sim, port } = makeLineSim();
+    const logic = PartSimulationRegistry.get('ir-receiver')!;
+    const cleanup = logic.attachEvents!(makeElement(), sim as any, pinMap({ DAT: 5 }), 'rx-7');
     cleanup();
-    expect(el.removeEventListener).toHaveBeenCalledWith('click', expect.any(Function));
-    expect(sim.setPinState).toHaveBeenCalledWith(5, true);
+    port.edges.length = 0;
+    emitIr({ pulses: necEncode(0x00, 0x45), sourceId: 'remote-x' });
+    expect(port.edges).toHaveLength(0);
   });
 
-  it('no-op when no pin connected (no throw)', () => {
-    const sim = makePinSim();
+  it('records a gap, and takes no frame, on a board that cannot host it', () => {
+    clearLineGaps();
+    const sim = {
+      ...makePinSim(),
+      lineSupport: () => ({ mode: 'none' as const, why: 'no timed edges' }),
+    };
     const logic = PartSimulationRegistry.get('ir-receiver')!;
-    expect(() => {
-      const c = logic.attachEvents!(makeElement(), sim as any, noPins);
-      c();
-    }).not.toThrow();
+    logic.attachEvents!(makeElement(), sim as any, pinMap({ DAT: 5 }), 'rx-8');
+    expect(lineGaps().map((g) => g.sensorType)).toContain('ir-nec');
+    // The user gets a reason in the circuit check rather than a silent pad.
+    expect(() => emitIr({ pulses: necEncode(0, 0x45), sourceId: 'remote-x' })).not.toThrow();
+  });
+
+  it('no-op when nothing is wired to it (no throw)', () => {
+    const { sim } = makeLineSim();
+    const logic = PartSimulationRegistry.get('ir-receiver')!;
+    expect(() => logic.attachEvents!(makeElement(), sim as any, noPins, 'rx-9')()).not.toThrow();
   });
 });
 
-// ─── ir-remote ───────────────────────────────────────────────────────────────
+describe('ir-remote — the handset', () => {
+  beforeEach(() => resetIrAir());
 
-describe('ir-remote — button dispatch', () => {
-  it('registers button-press listener on element', () => {
-    const sim = makePinSim();
-    const el = makeElement();
-    const logic = PartSimulationRegistry.get('ir-remote')!;
-    logic.attachEvents!(el, sim as any, noPins);
-    const events = (el.addEventListener as ReturnType<typeof vi.fn>).mock.calls.map(([e]) => e);
-    expect(events).toContain('button-press');
-  });
-
-  it('button-press fires ir-signal CustomEvent with address and command', () => {
-    const sim = makePinSim();
-    const el = makeElement();
-    const logic = PartSimulationRegistry.get('ir-remote')!;
-    logic.attachEvents!(el, sim as any, noPins);
-
-    const onButtonPress = (el.addEventListener as ReturnType<typeof vi.fn>).mock.calls.find(
-      ([ev]) => ev === 'button-press',
-    )?.[1] as ((e: Event) => void) | undefined;
-    expect(onButtonPress).toBeDefined();
-
-    const fakeEvent = new CustomEvent('button-press', { detail: { key: 'power' } });
-    onButtonPress!(fakeEvent);
-
-    expect(el.dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'ir-signal' }));
-    const dispatched = (el.dispatchEvent as ReturnType<typeof vi.fn>).mock
-      .calls[0][0] as CustomEvent;
-    expect(dispatched.detail.command).toBe(0x45); // POWER key
-  });
-
-  it('drives IR pin if connected', () => {
-    const sim = makePinSim();
-    const el = makeElement();
-    const logic = PartSimulationRegistry.get('ir-remote')!;
-    logic.attachEvents!(el, sim as any, pinMap({ IR: 4 }));
-
-    const onButtonPress = (el.addEventListener as ReturnType<typeof vi.fn>).mock.calls.find(
+  /** The element's own listener, as the part registered it. */
+  function pressOn(el: HTMLElement, irCode: number, key = 'k'): void {
+    const cb = (el.addEventListener as ReturnType<typeof vi.fn>).mock.calls.find(
       ([ev]) => ev === 'button-press',
     )?.[1] as (e: Event) => void;
+    cb({ detail: { key, irCode } } as unknown as Event);
+  }
 
-    sim.setPinState.mockClear();
-    onButtonPress(new CustomEvent('button-press', { detail: { key: 'power' } }));
-
-    // Should start the NEC pulse sequence (first edge LOW)
-    expect(sim.setPinState).toHaveBeenCalledWith(4, false);
+  it('asks for no pin at all — it is a remote control', () => {
+    const logic = PartSimulationRegistry.get('ir-remote')!;
+    const getPin = vi.fn(() => null);
+    logic.attachEvents!(makeElement(), makePinSim() as any, getPin, 'tx-1');
+    expect(getPin).not.toHaveBeenCalled();
   });
 
-  it('cleanup removes all listeners', () => {
-    const sim = makePinSim();
+  it('a press transmits the code the ELEMENT reports, not a table of our own', () => {
     const el = makeElement();
     const logic = PartSimulationRegistry.get('ir-remote')!;
-    const cleanup = logic.attachEvents!(el, sim as any, noPins);
+    logic.attachEvents!(el, makePinSim() as any, noPins, 'tx-2');
+
+    // 0x30 is what wokwi's element sends for "1". The old table said 0x0c.
+    pressOn(el, 0x30, '1');
+    expect(irAirStats.last?.command).toBe(0x30);
+    expect(irAirStats.last?.protocol).toBe('NEC');
+    expect(irAirStats.last?.verified).toBe(true);
+  });
+
+  it('reaches a receiver on another board, with no wire between them', () => {
+    const rx = makeLineSim();
+    PartSimulationRegistry.get('ir-receiver')!.attachEvents!(
+      makeElement(),
+      rx.sim as any,
+      pinMap({ DAT: 5 }),
+      'rx-far',
+    );
+    rx.port.edges.length = 0;
+
+    const el = makeElement({ irAddress: 0x04 });
+    PartSimulationRegistry.get('ir-remote')!.attachEvents!(el, makePinSim() as any, noPins, 'tx-3');
+    pressOn(el, 0x1c, '5');
+
+    const decoded = necDecode(edgesToPulses(rx.port.edges, 16e6));
+    expect(decoded.address).toBe(0x04);
+    expect(decoded.command).toBe(0x1c);
+  });
+
+  it('a held key repeats, and releasing stops it', () => {
+    const el = makeElement();
+    PartSimulationRegistry.get('ir-remote')!.attachEvents!(el, makePinSim() as any, noPins, 'tx-4');
+
+    pressOn(el, 0x30);
+    expect(irAirStats.emitted).toBe(1);
+    vi.advanceTimersByTime(NEC_REPEAT_PERIOD_MS * 3 + 10);
+    expect(irAirStats.emitted).toBe(4);
+    expect(irAirStats.last?.protocol).toBe('NEC-repeat');
+
+    const release = (el.addEventListener as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([ev]) => ev === 'button-release',
+    )?.[1] as () => void;
+    release();
+    vi.advanceTimersByTime(NEC_REPEAT_PERIOD_MS * 5);
+    expect(irAirStats.emitted).toBe(4);
+  });
+
+  it('cleanup stops a repeat that is still running', () => {
+    const el = makeElement();
+    const cleanup = PartSimulationRegistry.get('ir-remote')!.attachEvents!(
+      el,
+      makePinSim() as any,
+      noPins,
+      'tx-5',
+    );
+    pressOn(el, 0x30);
     cleanup();
-    expect(el.removeEventListener).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(NEC_REPEAT_PERIOD_MS * 5);
+    expect(irAirStats.emitted).toBe(1);
+  });
+
+  it('says so when it transmitted and nothing was listening', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const el = makeElement();
+    PartSimulationRegistry.get('ir-remote')!.attachEvents!(el, makePinSim() as any, noPins, 'tx-6');
+    pressOn(el, 0x30);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('no receiver took it'));
+    warn.mockRestore();
+  });
+
+  it('ignores a press with no code on it', () => {
+    const el = makeElement();
+    PartSimulationRegistry.get('ir-remote')!.attachEvents!(el, makePinSim() as any, noPins, 'tx-7');
+    const cb = (el.addEventListener as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([ev]) => ev === 'button-press',
+    )?.[1] as (e: Event) => void;
+    cb({ detail: {} } as unknown as Event);
+    expect(irAirStats.emitted).toBe(0);
   });
 });
 
@@ -1041,11 +1207,7 @@ describe('microsd-card — SD-over-SPI storage', () => {
   const at = (block: number): number => block * 512;
 
   /** Read a 512-byte block via CMD17 and return its data bytes. */
-  function readSdBlock(
-    send: (b: number[]) => void,
-    replies: number[],
-    block: number,
-  ): number[] {
+  function readSdBlock(send: (b: number[]) => void, replies: number[], block: number): number[] {
     replies.length = 0;
     send(cmd(17, at(block)));
     send(FF(520));

--- a/frontend/src/data/examples-infrared.ts
+++ b/frontend/src/data/examples-infrared.ts
@@ -32,7 +32,15 @@ const UNO_CODE = `// IR remote -> IR receiver, with no wire between them.
 // Click a button on the remote (or click the receiver itself, which sends its
 // own configured code). Open the Serial Monitor at 9600 baud to see what
 // arrived. The receiver's DAT pin carries a real NEC envelope on the board's
-// own clock, so IRremote decodes it exactly as it would a physical remote.
+// own clock, so IRremote decodes it exactly as it would a physical remote --
+// measured on this build: a 9000 us header mark, a 4496 us space, 560 us bit
+// marks and 1688 us one-spaces.
+//
+// DISABLE_LED_FEEDBACK is deliberate. With feedback on, IRremote's ISR also
+// toggles pin 13 on every mark, and on this emulated Uno that extra work
+// inside the 50 us interrupt makes its state machine complete frames out of
+// nothing: the sketch prints a stream of undecodable results with no remote
+// anywhere near it. Turning it off costs the blink and nothing else.
 //
 // Wiring: DAT -> 2   VCC -> 5V   GND -> GND
 #include <IRremote.hpp>
@@ -41,94 +49,113 @@ const int RECV_PIN = 2;
 
 void setup() {
   Serial.begin(9600);
-  IrReceiver.begin(RECV_PIN, ENABLE_LED_FEEDBACK);
+  IrReceiver.begin(RECV_PIN, DISABLE_LED_FEEDBACK);
   Serial.println(F("Point the remote at the receiver and press a button."));
 }
 
 void loop() {
   if (IrReceiver.decode()) {
-    if (IrReceiver.decodedIRData.protocol == NEC) {
-      Serial.print(F("address 0x"));
+    if (IrReceiver.decodedIRData.protocol == UNKNOWN) {
+      Serial.println(F("received something this build cannot name"));
+    } else if (IrReceiver.decodedIRData.flags & IRDATA_FLAGS_IS_REPEAT) {
+      Serial.println(F("(key held)"));
+    } else {
+      Serial.print(F("protocol "));
+      Serial.print(getProtocolString(IrReceiver.decodedIRData.protocol));
+      Serial.print(F("  address 0x"));
       Serial.print(IrReceiver.decodedIRData.address, HEX);
       Serial.print(F("  command 0x"));
       Serial.println(IrReceiver.decodedIRData.command, HEX);
-    } else if (IrReceiver.decodedIRData.protocol == NEC && IrReceiver.decodedIRData.flags) {
-      Serial.println(F("(repeat)"));
-    } else {
-      Serial.println(F("unknown protocol"));
     }
     IrReceiver.resume();
   }
 }
 `;
 
-const UNO_TWO_CODE = `// One remote, two receivers — which is what infrared does and what no wire
+const UNO_TWO_CODE = `// One remote, two receivers -- which is what infrared does and what no wire
 // could express. Both are on their own pin; both hear every button press.
 //
+// IRremote drives one receiver per sketch, so this times the envelope on each
+// pin itself. That is also the honest demonstration: the pins really are
+// carrying NEC timing, not a value handed over out of band.
+//
 // Wiring: receiver A DAT -> 2, receiver B DAT -> 3, both VCC -> 5V, GND -> GND
-#include <IRremote.hpp>
+#include <Arduino.h>
 
-// IRremote drives one receiver at a time, so this reads the two pins directly
-// and measures the envelope itself. That is also the honest demonstration:
-// the pin really is carrying NEC timing, not a value handed over out of band.
 const int PIN_A = 2;
 const int PIN_B = 3;
 
-// Wait for the line to reach \`level\`, up to \`timeout\` us. Returns the time
-// spent waiting, or 0 on timeout.
-unsigned long waitFor(int pin, int level, unsigned long timeout) {
-  unsigned long start = micros();
-  while (digitalRead(pin) != level) {
-    if (micros() - start > timeout) return 0;
-  }
-  return micros() - start;
-}
+// A demodulator's output is active low: it pulls the line down for each mark.
+// So a MARK is the time spent LOW, and the bit value is in the SPACE that
+// follows it -- 560 us for a zero, 1690 us for a one.
+struct Rx {
+  int pin;
+  const char *name;
+  int lastLevel;
+  unsigned long lastEdgeUs;
+  unsigned int spaces[34];
+  byte n;
+  bool inFrame;
+};
 
-// One NEC frame off \`pin\`, or -1. Active low: a mark pulls the line down.
-long readNec(int pin) {
-  if (digitalRead(pin) != LOW) return -1;
-  unsigned long header = waitFor(pin, HIGH, 12000);      // the 9 ms mark
-  if (header < 7000) return -1;
-  if (waitFor(pin, LOW, 6000) < 3500) return -1;         // the 4.5 ms space
+Rx rxs[2];
 
+void report(Rx &r) {
   unsigned long bits = 0;
-  for (int i = 0; i < 32; i++) {
-    if (waitFor(pin, HIGH, 2000) == 0) return -1;        // the 560 us mark
-    unsigned long space = waitFor(pin, LOW, 3000);       // its length is the bit
-    if (space == 0) return -1;
-    if (space > 1000) bits |= (1UL << i);                // least significant first
+  for (byte i = 0; i < 32; i++) {
+    if (r.spaces[i + 1] > 1000) bits |= (1UL << i);   // least significant first
   }
-  return (long)bits;
+  Serial.print(r.name);
+  Serial.print(F(": address 0x"));
+  Serial.print((uint8_t)(bits & 0xFF), HEX);
+  Serial.print(F("  command 0x"));
+  Serial.println((uint8_t)((bits >> 16) & 0xFF), HEX);
 }
 
-void report(const char *name, long frame) {
-  uint8_t address = frame & 0xFF;
-  uint8_t command = (frame >> 16) & 0xFF;
-  Serial.print(name);
-  Serial.print(F(": address 0x"));
-  Serial.print(address, HEX);
-  Serial.print(F("  command 0x"));
-  Serial.println(command, HEX);
+void poll(Rx &r) {
+  int now = digitalRead(r.pin);
+  if (now == r.lastLevel) return;
+  unsigned long t = micros();
+  unsigned int w = (unsigned int)(t - r.lastEdgeUs);
+  r.lastEdgeUs = t;
+  if (now == HIGH) {
+    // A LOW that long was the 9 ms header mark: the frame starts here.
+    if (!r.inFrame && w > 7000 && w < 11000) {
+      r.inFrame = true;
+      r.n = 0;
+    }
+  } else if (r.inFrame) {
+    if (r.n < 34) r.spaces[r.n] = w;
+    r.n++;
+    if (r.n >= 33) {                                  // header space + 32 bits
+      report(r);
+      r.inFrame = false;
+    }
+  }
+  r.lastLevel = now;
 }
 
 void setup() {
   Serial.begin(9600);
-  pinMode(PIN_A, INPUT);
-  pinMode(PIN_B, INPUT);
+  rxs[0] = { PIN_A, "A", HIGH, 0, {}, 0, false };
+  rxs[1] = { PIN_B, "B", HIGH, 0, {}, 0, false };
+  for (byte i = 0; i < 2; i++) {
+    pinMode(rxs[i].pin, INPUT);
+    rxs[i].lastLevel = digitalRead(rxs[i].pin);
+    rxs[i].lastEdgeUs = micros();
+  }
   Serial.println(F("Press a button. Both receivers hear it."));
 }
 
 void loop() {
-  long a = readNec(PIN_A);
-  if (a >= 0) report("A", a);
-  long b = readNec(PIN_B);
-  if (b >= 0) report("B", b);
+  poll(rxs[0]);
+  poll(rxs[1]);
 }
 `;
 
-const ESP32_CODE = `// IR remote -> IR receiver on an ESP32. Same sketch shape as the Uno one:
-// the link is the air, not a wire, and the envelope is real NEC timing on the
-// guest's own clock — in the browser engine and under QEMU alike.
+const ESP32_CODE = `// IR remote -> IR receiver on an ESP32. Same link as the Uno example: the
+// medium is the air, not a wire, and the envelope is real NEC timing on the
+// guest's own clock -- in the browser engine and under QEMU alike.
 //
 // Wiring: DAT -> GPIO 15   VCC -> 3V3   GND -> GND
 #include <IRremote.hpp>
@@ -137,15 +164,22 @@ const int RECV_PIN = 15;
 
 void setup() {
   Serial.begin(115200);
-  IrReceiver.begin(RECV_PIN, ENABLE_LED_FEEDBACK);
+  IrReceiver.begin(RECV_PIN, DISABLE_LED_FEEDBACK);
   Serial.println("Point the remote at the receiver and press a button.");
 }
 
 void loop() {
   if (IrReceiver.decode()) {
-    Serial.printf("address 0x%02X  command 0x%02X\\n",
-                  IrReceiver.decodedIRData.address,
-                  IrReceiver.decodedIRData.command);
+    if (IrReceiver.decodedIRData.protocol == UNKNOWN) {
+      Serial.println("received something this build cannot name");
+    } else if (IrReceiver.decodedIRData.flags & IRDATA_FLAGS_IS_REPEAT) {
+      Serial.println("(key held)");
+    } else {
+      Serial.printf("protocol %s  address 0x%02X  command 0x%02X\\n",
+                    getProtocolString(IrReceiver.decodedIRData.protocol),
+                    IrReceiver.decodedIRData.address,
+                    IrReceiver.decodedIRData.command);
+    }
     IrReceiver.resume();
   }
 }
@@ -171,13 +205,40 @@ export const infraredExamples: ExampleProject[] = [
     tags: IR_TAGS,
     code: UNO_CODE,
     components: [
-      { type: 'ir-receiver', id: 'ir1', x: 440, y: 140, properties: { irAddress: '0x00', irCommand: '0x45', channel: '' } },
-      { type: 'ir-remote', id: 'remote1', x: 640, y: 60, properties: { irAddress: '0x00', channel: '' } },
+      {
+        type: 'ir-receiver',
+        id: 'ir1',
+        x: 440,
+        y: 140,
+        properties: { irAddress: '0x00', irCommand: '0x45', channel: '' },
+      },
+      {
+        type: 'ir-remote',
+        id: 'remote1',
+        x: 640,
+        y: 60,
+        properties: { irAddress: '0x00', channel: '' },
+      },
     ],
     wires: [
-      { id: 'w-dat', start: { componentId: 'arduino-uno', pinName: '2' }, end: { componentId: 'ir1', pinName: 'DAT' }, color: '#ffaa00' },
-      { id: 'w-vcc', start: { componentId: 'arduino-uno', pinName: '5V' }, end: { componentId: 'ir1', pinName: 'VCC' }, color: '#ff4444' },
-      { id: 'w-gnd', start: { componentId: 'arduino-uno', pinName: 'GND.1' }, end: { componentId: 'ir1', pinName: 'GND' }, color: '#000000' },
+      {
+        id: 'w-dat',
+        start: { componentId: 'arduino-uno', pinName: '2' },
+        end: { componentId: 'ir1', pinName: 'DAT' },
+        color: '#ffaa00',
+      },
+      {
+        id: 'w-vcc',
+        start: { componentId: 'arduino-uno', pinName: '5V' },
+        end: { componentId: 'ir1', pinName: 'VCC' },
+        color: '#ff4444',
+      },
+      {
+        id: 'w-gnd',
+        start: { componentId: 'arduino-uno', pinName: 'GND.1' },
+        end: { componentId: 'ir1', pinName: 'GND' },
+        color: '#000000',
+      },
     ],
   },
   {
@@ -187,8 +248,8 @@ export const infraredExamples: ExampleProject[] = [
       'One press, both receivers. This is the thing a wire cannot express: ' +
       'infrared is a room, not a connection, so every receiver hears every ' +
       'remote. The sketch times the envelope on each pin itself, which is also ' +
-      'the proof that the pin really is carrying NEC timing. Serial Monitor at ' +
-      '9600 baud.',
+      'the proof that the pins really are carrying NEC timing. Serial Monitor ' +
+      'at 9600 baud.',
     category: 'communication',
     difficulty: 'intermediate',
     boardType: 'arduino-uno',
@@ -196,17 +257,65 @@ export const infraredExamples: ExampleProject[] = [
     tags: [...IR_TAGS, 'two receivers'],
     code: UNO_TWO_CODE,
     components: [
-      { type: 'ir-receiver', id: 'irA', x: 440, y: 100, properties: { irAddress: '0x00', irCommand: '0x45', channel: '' } },
-      { type: 'ir-receiver', id: 'irB', x: 440, y: 260, properties: { irAddress: '0x00', irCommand: '0x45', channel: '' } },
-      { type: 'ir-remote', id: 'remote1', x: 660, y: 60, properties: { irAddress: '0x00', channel: '' } },
+      {
+        type: 'ir-receiver',
+        id: 'irA',
+        x: 440,
+        y: 100,
+        properties: { irAddress: '0x00', irCommand: '0x45', channel: '' },
+      },
+      {
+        type: 'ir-receiver',
+        id: 'irB',
+        x: 440,
+        y: 260,
+        properties: { irAddress: '0x00', irCommand: '0x45', channel: '' },
+      },
+      {
+        type: 'ir-remote',
+        id: 'remote1',
+        x: 660,
+        y: 60,
+        properties: { irAddress: '0x00', channel: '' },
+      },
     ],
     wires: [
-      { id: 'wa-dat', start: { componentId: 'arduino-uno', pinName: '2' }, end: { componentId: 'irA', pinName: 'DAT' }, color: '#ffaa00' },
-      { id: 'wa-vcc', start: { componentId: 'arduino-uno', pinName: '5V' }, end: { componentId: 'irA', pinName: 'VCC' }, color: '#ff4444' },
-      { id: 'wa-gnd', start: { componentId: 'arduino-uno', pinName: 'GND.1' }, end: { componentId: 'irA', pinName: 'GND' }, color: '#000000' },
-      { id: 'wb-dat', start: { componentId: 'arduino-uno', pinName: '3' }, end: { componentId: 'irB', pinName: 'DAT' }, color: '#ffcc44' },
-      { id: 'wb-vcc', start: { componentId: 'arduino-uno', pinName: '5V' }, end: { componentId: 'irB', pinName: 'VCC' }, color: '#ff4444' },
-      { id: 'wb-gnd', start: { componentId: 'arduino-uno', pinName: 'GND.2' }, end: { componentId: 'irB', pinName: 'GND' }, color: '#000000' },
+      {
+        id: 'wa-dat',
+        start: { componentId: 'arduino-uno', pinName: '2' },
+        end: { componentId: 'irA', pinName: 'DAT' },
+        color: '#ffaa00',
+      },
+      {
+        id: 'wa-vcc',
+        start: { componentId: 'arduino-uno', pinName: '5V' },
+        end: { componentId: 'irA', pinName: 'VCC' },
+        color: '#ff4444',
+      },
+      {
+        id: 'wa-gnd',
+        start: { componentId: 'arduino-uno', pinName: 'GND.1' },
+        end: { componentId: 'irA', pinName: 'GND' },
+        color: '#000000',
+      },
+      {
+        id: 'wb-dat',
+        start: { componentId: 'arduino-uno', pinName: '3' },
+        end: { componentId: 'irB', pinName: 'DAT' },
+        color: '#ffcc44',
+      },
+      {
+        id: 'wb-vcc',
+        start: { componentId: 'arduino-uno', pinName: '5V' },
+        end: { componentId: 'irB', pinName: 'VCC' },
+        color: '#ff4444',
+      },
+      {
+        id: 'wb-gnd',
+        start: { componentId: 'arduino-uno', pinName: 'GND.2' },
+        end: { componentId: 'irB', pinName: 'GND' },
+        color: '#000000',
+      },
     ],
   },
   {
@@ -225,13 +334,40 @@ export const infraredExamples: ExampleProject[] = [
     tags: [...IR_TAGS, 'esp32'],
     code: ESP32_CODE,
     components: [
-      { type: 'ir-receiver', id: 'ir1', x: 460, y: 150, properties: { irAddress: '0x00', irCommand: '0x45', channel: '' } },
-      { type: 'ir-remote', id: 'remote1', x: 660, y: 60, properties: { irAddress: '0x00', channel: '' } },
+      {
+        type: 'ir-receiver',
+        id: 'ir1',
+        x: 460,
+        y: 150,
+        properties: { irAddress: '0x00', irCommand: '0x45', channel: '' },
+      },
+      {
+        type: 'ir-remote',
+        id: 'remote1',
+        x: 660,
+        y: 60,
+        properties: { irAddress: '0x00', channel: '' },
+      },
     ],
     wires: [
-      { id: 'w-dat', start: { componentId: 'esp32', pinName: '15' }, end: { componentId: 'ir1', pinName: 'DAT' }, color: '#ffaa00' },
-      { id: 'w-vcc', start: { componentId: 'esp32', pinName: '3V3' }, end: { componentId: 'ir1', pinName: 'VCC' }, color: '#ff4444' },
-      { id: 'w-gnd', start: { componentId: 'esp32', pinName: 'GND.1' }, end: { componentId: 'ir1', pinName: 'GND' }, color: '#000000' },
+      {
+        id: 'w-dat',
+        start: { componentId: 'esp32', pinName: '15' },
+        end: { componentId: 'ir1', pinName: 'DAT' },
+        color: '#ffaa00',
+      },
+      {
+        id: 'w-vcc',
+        start: { componentId: 'esp32', pinName: '3V3' },
+        end: { componentId: 'ir1', pinName: 'VCC' },
+        color: '#ff4444',
+      },
+      {
+        id: 'w-gnd',
+        start: { componentId: 'esp32', pinName: 'GND.1' },
+        end: { componentId: 'ir1', pinName: 'GND' },
+        color: '#000000',
+      },
     ],
   },
 ];

--- a/frontend/src/data/examples-infrared.ts
+++ b/frontend/src/data/examples-infrared.ts
@@ -1,0 +1,237 @@
+/**
+ * Infrared gallery examples — the link the simulator did not have.
+ *
+ * Both parts on this canvas were dead before `simulation/ir/irAir`: the remote
+ * dispatched a DOM event nothing listened for, and the receiver asked for a
+ * pin its element does not have. So there was nothing to put in a gallery, and
+ * a user who dragged the two parts out and wired them found that neither did
+ * anything at all.
+ *
+ * What these show, and what makes them worth loading:
+ *
+ *  - THERE IS NO WIRE between the remote and the receiver, and there is not
+ *    meant to be. A remote points across a room. Put the two parts anywhere on
+ *    the canvas, at any angle, and the link works — the medium is a bus, not a
+ *    geometry.
+ *  - THE TIMING IS REAL. The envelope on the receiver's DAT pin is a genuine
+ *    NEC waveform placed on the board's own cycle counter, so IRremote decodes
+ *    it exactly as it decodes a physical remote. That is the whole reason the
+ *    receiver is a line-owning model rather than a part poking a pin from a
+ *    timer.
+ *  - TWO RECEIVERS BOTH HEAR ONE REMOTE, which is what infrared does and what
+ *    no wire could express.
+ *
+ * The Uno runs on avr8js in the browser; the ESP32 example runs on the
+ * in-browser engine or the QEMU worker (`backend/app/services/esp32_ir.py`)
+ * with no change to the sketch.
+ */
+import type { ExampleProject } from './examples';
+
+const UNO_CODE = `// IR remote -> IR receiver, with no wire between them.
+//
+// Click a button on the remote (or click the receiver itself, which sends its
+// own configured code). Open the Serial Monitor at 9600 baud to see what
+// arrived. The receiver's DAT pin carries a real NEC envelope on the board's
+// own clock, so IRremote decodes it exactly as it would a physical remote.
+//
+// Wiring: DAT -> 2   VCC -> 5V   GND -> GND
+#include <IRremote.hpp>
+
+const int RECV_PIN = 2;
+
+void setup() {
+  Serial.begin(9600);
+  IrReceiver.begin(RECV_PIN, ENABLE_LED_FEEDBACK);
+  Serial.println(F("Point the remote at the receiver and press a button."));
+}
+
+void loop() {
+  if (IrReceiver.decode()) {
+    if (IrReceiver.decodedIRData.protocol == NEC) {
+      Serial.print(F("address 0x"));
+      Serial.print(IrReceiver.decodedIRData.address, HEX);
+      Serial.print(F("  command 0x"));
+      Serial.println(IrReceiver.decodedIRData.command, HEX);
+    } else if (IrReceiver.decodedIRData.protocol == NEC && IrReceiver.decodedIRData.flags) {
+      Serial.println(F("(repeat)"));
+    } else {
+      Serial.println(F("unknown protocol"));
+    }
+    IrReceiver.resume();
+  }
+}
+`;
+
+const UNO_TWO_CODE = `// One remote, two receivers — which is what infrared does and what no wire
+// could express. Both are on their own pin; both hear every button press.
+//
+// Wiring: receiver A DAT -> 2, receiver B DAT -> 3, both VCC -> 5V, GND -> GND
+#include <IRremote.hpp>
+
+// IRremote drives one receiver at a time, so this reads the two pins directly
+// and measures the envelope itself. That is also the honest demonstration:
+// the pin really is carrying NEC timing, not a value handed over out of band.
+const int PIN_A = 2;
+const int PIN_B = 3;
+
+// Wait for the line to reach \`level\`, up to \`timeout\` us. Returns the time
+// spent waiting, or 0 on timeout.
+unsigned long waitFor(int pin, int level, unsigned long timeout) {
+  unsigned long start = micros();
+  while (digitalRead(pin) != level) {
+    if (micros() - start > timeout) return 0;
+  }
+  return micros() - start;
+}
+
+// One NEC frame off \`pin\`, or -1. Active low: a mark pulls the line down.
+long readNec(int pin) {
+  if (digitalRead(pin) != LOW) return -1;
+  unsigned long header = waitFor(pin, HIGH, 12000);      // the 9 ms mark
+  if (header < 7000) return -1;
+  if (waitFor(pin, LOW, 6000) < 3500) return -1;         // the 4.5 ms space
+
+  unsigned long bits = 0;
+  for (int i = 0; i < 32; i++) {
+    if (waitFor(pin, HIGH, 2000) == 0) return -1;        // the 560 us mark
+    unsigned long space = waitFor(pin, LOW, 3000);       // its length is the bit
+    if (space == 0) return -1;
+    if (space > 1000) bits |= (1UL << i);                // least significant first
+  }
+  return (long)bits;
+}
+
+void report(const char *name, long frame) {
+  uint8_t address = frame & 0xFF;
+  uint8_t command = (frame >> 16) & 0xFF;
+  Serial.print(name);
+  Serial.print(F(": address 0x"));
+  Serial.print(address, HEX);
+  Serial.print(F("  command 0x"));
+  Serial.println(command, HEX);
+}
+
+void setup() {
+  Serial.begin(9600);
+  pinMode(PIN_A, INPUT);
+  pinMode(PIN_B, INPUT);
+  Serial.println(F("Press a button. Both receivers hear it."));
+}
+
+void loop() {
+  long a = readNec(PIN_A);
+  if (a >= 0) report("A", a);
+  long b = readNec(PIN_B);
+  if (b >= 0) report("B", b);
+}
+`;
+
+const ESP32_CODE = `// IR remote -> IR receiver on an ESP32. Same sketch shape as the Uno one:
+// the link is the air, not a wire, and the envelope is real NEC timing on the
+// guest's own clock — in the browser engine and under QEMU alike.
+//
+// Wiring: DAT -> GPIO 15   VCC -> 3V3   GND -> GND
+#include <IRremote.hpp>
+
+const int RECV_PIN = 15;
+
+void setup() {
+  Serial.begin(115200);
+  IrReceiver.begin(RECV_PIN, ENABLE_LED_FEEDBACK);
+  Serial.println("Point the remote at the receiver and press a button.");
+}
+
+void loop() {
+  if (IrReceiver.decode()) {
+    Serial.printf("address 0x%02X  command 0x%02X\\n",
+                  IrReceiver.decodedIRData.address,
+                  IrReceiver.decodedIRData.command);
+    IrReceiver.resume();
+  }
+}
+`;
+
+const IR_TAGS = ['ir', 'infrared', 'remote', 'nec', 'irremote', 'receiver', 'vs1838b'];
+
+export const infraredExamples: ExampleProject[] = [
+  {
+    id: 'ir-remote-uno',
+    title: 'IR Remote (Arduino Uno)',
+    description:
+      'Press a button on the IR remote and the Uno decodes it with IRremote. ' +
+      'There is no wire between the remote and the receiver, and there is not ' +
+      'meant to be one — a remote points across a room, so the two parts are ' +
+      'linked wherever you put them on the canvas. Open the Serial Monitor at ' +
+      '9600 baud.',
+    libraries: ['IRremote'],
+    category: 'communication',
+    difficulty: 'beginner',
+    boardType: 'arduino-uno',
+    boardFilter: 'arduino-uno',
+    tags: IR_TAGS,
+    code: UNO_CODE,
+    components: [
+      { type: 'ir-receiver', id: 'ir1', x: 440, y: 140, properties: { irAddress: '0x00', irCommand: '0x45', channel: '' } },
+      { type: 'ir-remote', id: 'remote1', x: 640, y: 60, properties: { irAddress: '0x00', channel: '' } },
+    ],
+    wires: [
+      { id: 'w-dat', start: { componentId: 'arduino-uno', pinName: '2' }, end: { componentId: 'ir1', pinName: 'DAT' }, color: '#ffaa00' },
+      { id: 'w-vcc', start: { componentId: 'arduino-uno', pinName: '5V' }, end: { componentId: 'ir1', pinName: 'VCC' }, color: '#ff4444' },
+      { id: 'w-gnd', start: { componentId: 'arduino-uno', pinName: 'GND.1' }, end: { componentId: 'ir1', pinName: 'GND' }, color: '#000000' },
+    ],
+  },
+  {
+    id: 'ir-two-receivers-uno',
+    title: 'IR: one remote, two receivers',
+    description:
+      'One press, both receivers. This is the thing a wire cannot express: ' +
+      'infrared is a room, not a connection, so every receiver hears every ' +
+      'remote. The sketch times the envelope on each pin itself, which is also ' +
+      'the proof that the pin really is carrying NEC timing. Serial Monitor at ' +
+      '9600 baud.',
+    category: 'communication',
+    difficulty: 'intermediate',
+    boardType: 'arduino-uno',
+    boardFilter: 'arduino-uno',
+    tags: [...IR_TAGS, 'two receivers'],
+    code: UNO_TWO_CODE,
+    components: [
+      { type: 'ir-receiver', id: 'irA', x: 440, y: 100, properties: { irAddress: '0x00', irCommand: '0x45', channel: '' } },
+      { type: 'ir-receiver', id: 'irB', x: 440, y: 260, properties: { irAddress: '0x00', irCommand: '0x45', channel: '' } },
+      { type: 'ir-remote', id: 'remote1', x: 660, y: 60, properties: { irAddress: '0x00', channel: '' } },
+    ],
+    wires: [
+      { id: 'wa-dat', start: { componentId: 'arduino-uno', pinName: '2' }, end: { componentId: 'irA', pinName: 'DAT' }, color: '#ffaa00' },
+      { id: 'wa-vcc', start: { componentId: 'arduino-uno', pinName: '5V' }, end: { componentId: 'irA', pinName: 'VCC' }, color: '#ff4444' },
+      { id: 'wa-gnd', start: { componentId: 'arduino-uno', pinName: 'GND.1' }, end: { componentId: 'irA', pinName: 'GND' }, color: '#000000' },
+      { id: 'wb-dat', start: { componentId: 'arduino-uno', pinName: '3' }, end: { componentId: 'irB', pinName: 'DAT' }, color: '#ffcc44' },
+      { id: 'wb-vcc', start: { componentId: 'arduino-uno', pinName: '5V' }, end: { componentId: 'irB', pinName: 'VCC' }, color: '#ff4444' },
+      { id: 'wb-gnd', start: { componentId: 'arduino-uno', pinName: 'GND.2' }, end: { componentId: 'irB', pinName: 'GND' }, color: '#000000' },
+    ],
+  },
+  {
+    id: 'ir-remote-esp32',
+    title: 'IR Remote (ESP32)',
+    description:
+      'The same link on an ESP32: press a button on the remote and the sketch ' +
+      'decodes it with IRremote. Works on the in-browser engine and under QEMU ' +
+      'with no change — the envelope is placed on the guest clock either way. ' +
+      'Serial Monitor at 115200 baud.',
+    libraries: ['IRremote'],
+    category: 'communication',
+    difficulty: 'intermediate',
+    boardType: 'esp32',
+    boardFilter: 'esp32',
+    tags: [...IR_TAGS, 'esp32'],
+    code: ESP32_CODE,
+    components: [
+      { type: 'ir-receiver', id: 'ir1', x: 460, y: 150, properties: { irAddress: '0x00', irCommand: '0x45', channel: '' } },
+      { type: 'ir-remote', id: 'remote1', x: 660, y: 60, properties: { irAddress: '0x00', channel: '' } },
+    ],
+    wires: [
+      { id: 'w-dat', start: { componentId: 'esp32', pinName: '15' }, end: { componentId: 'ir1', pinName: 'DAT' }, color: '#ffaa00' },
+      { id: 'w-vcc', start: { componentId: 'esp32', pinName: '3V3' }, end: { componentId: 'ir1', pinName: 'VCC' }, color: '#ff4444' },
+      { id: 'w-gnd', start: { componentId: 'esp32', pinName: 'GND.1' }, end: { componentId: 'ir1', pinName: 'GND' }, color: '#000000' },
+    ],
+  },
+];

--- a/frontend/src/data/examples.ts
+++ b/frontend/src/data/examples.ts
@@ -18,6 +18,7 @@ import { epaperExamples } from './examples-displays-epaper';
 import { retroIntelExamples } from './examples-retro-intel';
 import { robotDesktopExamples } from './examples-robot-desktop';
 import { microsdExamples } from './examples-storage-microsd';
+import { infraredExamples } from './examples-infrared';
 import { esp32MqttExamples } from './examples-esp32-mqtt';
 import { esp32s3TftExamples } from './examples-esp32s3-tft';
 import { jsemuChipExamples } from './examples-jsemu-chips';
@@ -11719,6 +11720,7 @@ export const exampleProjects: ExampleProject[] = [
   ...retroIntelExamples,
   ...robotDesktopExamples,
   ...microsdExamples,
+  ...infraredExamples,
   ...esp32MqttExamples,
   ...esp32s3TftExamples,
   ...jsemuChipExamples,

--- a/frontend/src/simulation/Esp32Bridge.ts
+++ b/frontend/src/simulation/Esp32Bridge.ts
@@ -728,7 +728,7 @@ export class Esp32Bridge {
    * bridge that runs the models in the browser overrides this with the
    * registry's own list.
    */
-  static readonly WORKER_LINE_MODELS: readonly string[] = ['dht22', 'hc-sr04'];
+  static readonly WORKER_LINE_MODELS: readonly string[] = ['dht22', 'hc-sr04', 'ir-nec'];
 
   /** What this board can host under the line contract (simulation/line). */
   lineSupport(): LineSupport {

--- a/frontend/src/simulation/ir/index.ts
+++ b/frontend/src/simulation/ir/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Infrared: the codec and the medium. Import this module rather than its
+ * files, the way `simulation/line` is imported — a part needs both halves and
+ * neither one alone means anything.
+ */
+
+export * from './necCodec';
+export * from './irAir';

--- a/frontend/src/simulation/ir/irAir.ts
+++ b/frontend/src/simulation/ir/irAir.ts
@@ -1,0 +1,169 @@
+/**
+ * irAir — the air between infrared parts. The medium the simulator never had.
+ *
+ * WHAT WAS MISSING. Every other link on the canvas is a wire, and a wire is a
+ * thing the user draws between two pads. Infrared is the one link with no
+ * wire: a remote points at a receiver across the room and the two share
+ * nothing but the room. So there was no layer for it, and both IR parts were
+ * dead in the way that follows from that — the remote dispatched a DOM event
+ * nothing listened to, and the receiver drove a pin it could never resolve.
+ * The Grove emitter's own documentation said it out loud: it models the
+ * emitter, not the link.
+ *
+ * WHAT THIS IS. One process-wide bus. An emitter publishes a mark/space train;
+ * every listening receiver gets it. There is no geometry: not distance, not
+ * angle, not line of sight, not which board a part is wired to. Two parts at
+ * opposite corners of the canvas are as connected as two parts touching, which
+ * is the point — a user placing a remote and a receiver has already expressed
+ * the only intent that matters, and asking them to also aim it would be a
+ * puzzle, not a simulation.
+ *
+ * MICROSECONDS, NOT CYCLES. The bus carries durations in real microseconds.
+ * Each receiver converts them to ITS OWN board's guest cycles when it puts the
+ * envelope on its pin. That is the whole reason a remote can fire a receiver
+ * on an Uno and another on an ESP32 in the same run: the two boards count in
+ * different units and neither one's clock is the air's.
+ *
+ * CHANNELS. By default every receiver hears every emitter, which is what a
+ * room does. A part may also carry a `channel` — any short string — to build
+ * isolated pairs when a project has several links that must not cross:
+ *
+ *   a receiver with NO channel hears everything;
+ *   a receiver WITH a channel hears only emitters carrying the same one.
+ *
+ * So the default costs nothing and the escape hatch is one property. Matching
+ * is on the trimmed, lower-cased string, because a user typing "Link A" in one
+ * dialog and "link a" in the other meant the same link.
+ *
+ * AN EMITTER NEVER HEARS ITSELF. `sourceId` is the emitting component, and it
+ * is skipped on delivery. A board with an IR diode and an IR receiver on the
+ * same pad is a real thing to build, and its own transmission is the one frame
+ * it must not decode.
+ */
+
+import { necDecode, type IrPulse, NEC_CARRIER_HZ } from './necCodec';
+
+/** One transmission, as it crosses the room. */
+export interface IrAirFrame {
+  /** Mark/space durations in microseconds. `level` 1 = carrier on. */
+  pulses: readonly IrPulse[];
+  /** The carrier the emitter modulated onto, for a receiver that cares. */
+  carrierHz: number;
+  /** The emitting component, so it is skipped on delivery. */
+  sourceId: string;
+  /** Empty = the room. See the channel rule above. */
+  channel: string;
+  /** Wall clock at emission, for the UI only — never for timing a waveform. */
+  atMs: number;
+  /** What the train decodes to, carried alongside so every listener and every
+   *  indicator agrees on one reading instead of decoding it again. */
+  protocol: 'NEC' | 'NEC-repeat' | 'raw';
+  address: number;
+  command: number;
+  verified: boolean;
+}
+
+/** What a receiver is handed. Returning true means it took the frame. */
+export type IrAirSink = (frame: IrAirFrame) => boolean;
+
+interface Listener {
+  id: string;
+  /** Read at delivery, so retuning a receiver needs no resubscribe. */
+  channel: () => string;
+  sink: IrAirSink;
+}
+
+const listeners = new Set<Listener>();
+
+/** Counters for the console and the conformance tests. Never load-bearing. */
+export const irAirStats = {
+  emitted: 0,
+  delivered: 0,
+  listeners: 0,
+  lastAtMs: 0,
+  /** The last frame that crossed, for a quick look from the console. */
+  last: null as IrAirFrame | null,
+};
+if (typeof globalThis !== 'undefined') {
+  (globalThis as Record<string, unknown>)['__velxioIrAir'] = irAirStats;
+}
+
+const normalizeChannel = (c: string | null | undefined): string =>
+  typeof c === 'string' ? c.trim().toLowerCase() : '';
+
+/**
+ * A receiver with no channel hears everything; one with a channel hears only
+ * its own. Stated in one place so the two parts cannot drift apart.
+ */
+export function channelHears(receiverChannel: string, frameChannel: string): boolean {
+  const rx = normalizeChannel(receiverChannel);
+  return rx === '' || rx === normalizeChannel(frameChannel);
+}
+
+/**
+ * Listen for transmissions. `channel` is a getter, not a value: a receiver's
+ * channel is a component property the user can change while the simulation
+ * runs, and re-reading it at delivery is cheaper and more honest than tearing
+ * the subscription down and building it again.
+ */
+export function listenIr(id: string, channel: () => string, sink: IrAirSink): () => void {
+  const entry: Listener = { id, channel, sink };
+  listeners.add(entry);
+  irAirStats.listeners = listeners.size;
+  return () => {
+    listeners.delete(entry);
+    irAirStats.listeners = listeners.size;
+  };
+}
+
+/**
+ * Send a transmission. Returns how many receivers took it — zero is the
+ * answer a caller should say out loud, because "the button did nothing" and
+ * "nothing was listening" look identical on a canvas and only one of them is
+ * the user's mistake.
+ */
+export function emitIr(tx: {
+  pulses: readonly IrPulse[];
+  sourceId: string;
+  channel?: string;
+  carrierHz?: number;
+}): number {
+  if (!tx.pulses.length) return 0;
+  const nec = necDecode(tx.pulses);
+  const frame: IrAirFrame = {
+    pulses: tx.pulses,
+    carrierHz: tx.carrierHz ?? NEC_CARRIER_HZ,
+    sourceId: tx.sourceId,
+    channel: normalizeChannel(tx.channel),
+    atMs: Date.now(),
+    protocol: nec.protocol,
+    address: nec.address,
+    command: nec.command,
+    verified: nec.verified,
+  };
+  irAirStats.emitted++;
+  irAirStats.lastAtMs = frame.atMs;
+  irAirStats.last = frame;
+
+  let taken = 0;
+  for (const l of listeners) {
+    if (l.id === frame.sourceId) continue;
+    if (!channelHears(l.channel(), frame.channel)) continue;
+    try {
+      if (l.sink(frame)) taken++;
+    } catch {
+      // One broken receiver must not stop the others.
+    }
+  }
+  irAirStats.delivered += taken;
+  return taken;
+}
+
+/** Drop every listener. Tests only — a part releases its own subscription. */
+export function resetIrAir(): void {
+  listeners.clear();
+  irAirStats.emitted = 0;
+  irAirStats.delivered = 0;
+  irAirStats.listeners = 0;
+  irAirStats.last = null;
+}

--- a/frontend/src/simulation/ir/necCodec.ts
+++ b/frontend/src/simulation/ir/necCodec.ts
@@ -1,0 +1,161 @@
+/**
+ * NEC infrared, both directions: an address and a command to a mark/space
+ * train, and a mark/space train back to an address and a command.
+ *
+ * The protocol: a 9 ms mark and a 4.5 ms space, then 32 bits, each a 560 us
+ * mark followed by a space that is 560 us for a 0 and 1690 us for a 1, then a
+ * final stop mark. The 32 bits are address, its complement, command, its
+ * complement — least significant bit first within each byte. Extended NEC
+ * keeps a 16-bit address instead of address plus complement, which is why the
+ * address check only warns rather than rejects.
+ *
+ * A held-down key repeats as 9 ms + 2.25 ms + a stop mark, carrying no data.
+ *
+ * A "mark" is the interval the 38 kHz carrier is ON. What a demodulator puts
+ * on its output pin is the INVERSE of that (active low), and what an emitter
+ * puts on its LED is the carrier itself — so neither polarity belongs here.
+ * This module speaks marks and spaces; the two line models do the inverting,
+ * each on its own side of the air.
+ */
+
+/** One interval of a transmission. `level` 1 = carrier on (a mark), 0 = off. */
+export interface IrPulse {
+  level: 0 | 1;
+  us: number;
+}
+
+export interface NecFrame {
+  protocol: 'NEC' | 'NEC-repeat' | 'raw';
+  address: number;
+  command: number;
+  /** True when address/command each matched their complement byte. */
+  verified: boolean;
+  /** How many pulses were consumed — the rest, if any, is another frame. */
+  used: number;
+}
+
+export const NEC_HEADER_MARK_US = 9000;
+export const NEC_HEADER_SPACE_US = 4500;
+export const NEC_REPEAT_SPACE_US = 2250;
+export const NEC_BIT_MARK_US = 560;
+export const NEC_ZERO_SPACE_US = 560;
+export const NEC_ONE_SPACE_US = 1690;
+/** What a remote actually modulates onto. Carried on the air so a receiver
+ *  tuned to another carrier could one day refuse a frame it cannot demodulate. */
+export const NEC_CARRIER_HZ = 38000;
+
+/**
+ * Timings drift with the sending library's delay loop and, here, with how the
+ * emulator paces the guest, so everything is matched proportionally. A quarter
+ * is loose enough for both and still keeps 560 and 1690 well apart.
+ */
+const TOLERANCE = 0.25;
+
+const near = (actual: number, expected: number): boolean =>
+  Math.abs(actual - expected) <= expected * TOLERANCE;
+
+/**
+ * The pulse train for one NEC frame, ending on its stop mark.
+ *
+ * `address` above 0xff is sent as extended NEC: the 16 bits go out low byte
+ * first and no complement is computed, which is what every remote that needs
+ * more than 256 addresses does.
+ */
+export function necEncode(address: number, command: number): IrPulse[] {
+  const extended = (address & 0xffff) > 0xff;
+  const bytes = extended
+    ? [address & 0xff, (address >> 8) & 0xff, command & 0xff, ~command & 0xff]
+    : [address & 0xff, ~address & 0xff, command & 0xff, ~command & 0xff];
+
+  const pulses: IrPulse[] = [
+    { level: 1, us: NEC_HEADER_MARK_US },
+    { level: 0, us: NEC_HEADER_SPACE_US },
+  ];
+  for (const byte of bytes) {
+    for (let b = 0; b < 8; b++) {
+      // Least significant bit first, within each byte.
+      pulses.push({ level: 1, us: NEC_BIT_MARK_US });
+      pulses.push({ level: 0, us: (byte >> b) & 1 ? NEC_ONE_SPACE_US : NEC_ZERO_SPACE_US });
+    }
+  }
+  pulses.push({ level: 1, us: NEC_BIT_MARK_US });
+  return pulses;
+}
+
+/** How often a held-down key repeats, in milliseconds. Real remotes send the
+ *  first frame and then a repeat frame at this period for as long as the key is
+ *  down; it is what makes a volume key ramp instead of stepping once. */
+export const NEC_REPEAT_PERIOD_MS = 108;
+
+/** The frame a held-down key sends every 108 ms: a header, a short space, a stop mark. */
+export function necEncodeRepeat(): IrPulse[] {
+  return [
+    { level: 1, us: NEC_HEADER_MARK_US },
+    { level: 0, us: NEC_REPEAT_SPACE_US },
+    { level: 1, us: NEC_BIT_MARK_US },
+  ];
+}
+
+/**
+ * Decode one NEC frame from the front of a pulse train.
+ *
+ * Leading spaces are skipped: a capture usually begins in the gap before the
+ * first mark, and a bare space at the front is not part of any frame.
+ */
+export function necDecode(pulses: readonly IrPulse[]): NecFrame {
+  const fail: NecFrame = {
+    protocol: 'raw',
+    address: 0,
+    command: 0,
+    verified: false,
+    used: pulses.length,
+  };
+  let i = 0;
+  while (i < pulses.length && pulses[i].level === 0) i++;
+  if (pulses.length - i < 3) return fail;
+  if (!near(pulses[i].us, NEC_HEADER_MARK_US)) return fail;
+  if (!near(pulses[i + 1].us, NEC_HEADER_SPACE_US)) {
+    // The only other thing a NEC header can introduce is a repeat.
+    if (near(pulses[i + 1].us, NEC_REPEAT_SPACE_US)) {
+      return { protocol: 'NEC-repeat', address: 0, command: 0, verified: true, used: i + 3 };
+    }
+    return fail;
+  }
+  i += 2;
+
+  const bits: number[] = [];
+  while (bits.length < 32) {
+    if (i + 1 >= pulses.length) return fail;
+    if (!near(pulses[i].us, NEC_BIT_MARK_US)) return fail;
+    const space = pulses[i + 1].us;
+    if (near(space, NEC_ONE_SPACE_US)) bits.push(1);
+    else if (near(space, NEC_ZERO_SPACE_US)) bits.push(0);
+    else return fail;
+    i += 2;
+  }
+
+  const byteAt = (n: number): number => {
+    let v = 0;
+    for (let b = 0; b < 8; b++) v |= bits[n * 8 + b] << b;
+    return v;
+  };
+  const addrLow = byteAt(0);
+  const addrHigh = byteAt(1);
+  const command = byteAt(2);
+  const commandInv = byteAt(3);
+
+  const commandOk = ((command ^ commandInv) & 0xff) === 0xff;
+  // Classic NEC sends the address twice, inverted; extended NEC uses both bytes
+  // as a 16-bit address, so a mismatch there is normal and not an error.
+  const classicAddr = ((addrLow ^ addrHigh) & 0xff) === 0xff;
+  const address = classicAddr ? addrLow : addrLow | (addrHigh << 8);
+
+  return {
+    protocol: 'NEC',
+    address,
+    command,
+    verified: commandOk,
+    // The trailing stop mark, when the capture includes it.
+    used: Math.min(pulses.length, i + 1),
+  };
+}

--- a/frontend/src/simulation/line/models/index.ts
+++ b/frontend/src/simulation/line/models/index.ts
@@ -6,3 +6,5 @@
  */
 import './dht22';
 import './hc-sr04';
+import './ir-nec';
+import './ir-tx';

--- a/frontend/src/simulation/line/models/ir-nec.ts
+++ b/frontend/src/simulation/line/models/ir-nec.ts
@@ -1,0 +1,161 @@
+/**
+ * An infrared demodulator's output pin — a TSOP-series can, the thing behind
+ * the lens on every IR receiver module.
+ *
+ * The part is not a sensor of anything physical. It listens to the air
+ * (`simulation/ir/irAir`) and puts what it heard on its pin: the carrier
+ * stripped off, the envelope left, ACTIVE LOW, idle HIGH. That inversion is
+ * the whole device, and it is why the air carries marks and spaces rather than
+ * pin levels — the emitter's LED is on during a mark and this pin is low
+ * during the same mark.
+ *
+ * It is a line model and not a WASM chip for one reason: a NEC bit is 560 us
+ * and the difference between a zero and a one is 1.1 ms. `clock.us` converts
+ * against the guest's OWN configured clock and the edges land on the guest's
+ * cycle counter, so IRremote's 50 us sampling ISR and its pin-change decoder
+ * both read exactly what a real remote would have given them. Nothing driven
+ * from an animation frame can resolve 560 us, which is precisely how the old
+ * `setTimeout(next, 0.562)` implementation managed to be undecodable by every
+ * IR library in existence.
+ *
+ * Nothing the guest does starts a frame, so `listens` is empty and `update`
+ * is where the work happens — the contract's own documented case of a device
+ * that speaks unprompted.
+ */
+
+import type { HostEdge, HostEdgeFrame } from '../LineTimeline';
+import { necEncode, type IrPulse } from '../../ir/necCodec';
+import { numberField, registerLineModel, type LineClock, type LineModel } from '../lineModels';
+
+/** Settling gap before the first edge, so a frame never lands on the cycle it was queued at. */
+const LEAD_US = 100;
+
+/**
+ * The envelope of a pulse train as the demodulator's pin carries it.
+ *
+ * `pulses` are marks and spaces in microseconds; the pin is LOW for a mark and
+ * HIGH for a space. The frame always ends HIGH: a decoder waiting for the end
+ * of a transmission has to see the line come back to idle, and a train that
+ * ends on a mark (NEC's stop mark does) would otherwise leave it low forever.
+ */
+export function envelopeFrame(
+  pin: number,
+  startCycle: number,
+  pulses: readonly IrPulse[],
+  us: (n: number) => number,
+): HostEdgeFrame | null {
+  if (!pulses.length) return null;
+  const edges: HostEdge[] = [];
+  let t = startCycle + us(LEAD_US);
+  let level: boolean | null = null;
+  for (const p of pulses) {
+    if (p.us <= 0) continue;
+    const want = p.level === 1 ? false : true; // a mark pulls the output LOW
+    if (want !== level) {
+      edges.push({ level: want, atCycle: t });
+      level = want;
+    }
+    t += us(p.us);
+  }
+  if (!edges.length) return null;
+  if (level === false) edges.push({ level: true, atCycle: t }); // back to idle
+
+  // No `releaseAtCycle`. Release is for a line the GUEST also drives — a DHT's
+  // open-drain bus. A demodulator's output is host-only and idles HIGH, so
+  // handing the pad back would drop it to whatever the pull gives, and a
+  // decoder waiting for the end of the frame would see the line go low and
+  // stay there. The host keeps driving; the last edge leaves it high.
+  return { pin, edges, selfTimed: true };
+}
+
+/** The NEC frame for an address and a command, as the pin carries it. */
+export function necFrame(
+  pin: number,
+  startCycle: number,
+  address: number,
+  command: number,
+  us: (n: number) => number,
+): HostEdgeFrame | null {
+  return envelopeFrame(pin, startCycle, necEncode(address, command), us);
+}
+
+/**
+ * A raw train off the wire protocol. The air carries `IrPulse[]`; a backend
+ * worker and a JSON round-trip may deliver the same thing as a flat array of
+ * numbers (`[markUs, spaceUs, ...]`, mark first), so both are accepted rather
+ * than making every caller agree on one.
+ */
+export function toPulses(value: unknown): IrPulse[] | null {
+  if (!Array.isArray(value) || !value.length) return null;
+  if (typeof value[0] === 'number') {
+    return (value as number[])
+      .map((us, i) => ({ level: (i % 2 === 0 ? 1 : 0) as 0 | 1, us: Number(us) }))
+      .filter((p) => Number.isFinite(p.us) && p.us > 0);
+  }
+  const out: IrPulse[] = [];
+  for (const p of value as Array<Record<string, unknown>>) {
+    const us = Number(p?.['us']);
+    if (!Number.isFinite(us) || us <= 0) continue;
+    out.push({ level: Number(p?.['level']) === 1 ? 1 : 0, us });
+  }
+  return out.length ? out : null;
+}
+
+/**
+ * Keys whose VALUE CHANGING is the transmission, whatever the new value is.
+ *
+ * It has to be a change and not a presence, because the hosted path merges
+ * every update into the record it registered with (`requestLine`, the
+ * `{ ...props, ...p }` line): on an ESP32 the trigger key is therefore present
+ * in every update a slider produces, and a model that fired on presence
+ * transmitted once per slider tick.
+ */
+const TRIGGER_KEYS = ['seq', 'send'] as const;
+
+registerLineModel('ir-nec', (rec) => {
+  const pin = rec.pin;
+  let address = numberField(rec.address, 0x00);
+  let command = numberField(rec.command, 0x16);
+  /** The last value seen for each trigger key, seeded from the record so the
+   *  registration itself is not read as a press. */
+  const seen = new Map<string, unknown>(TRIGGER_KEYS.map((k) => [k, rec[k]]));
+  /** Cycle the frame on the wire finishes at: a second one on top of it would
+   *  garble both, which is what happens in the room too. */
+  let busyUntil = -Infinity;
+
+  const model: LineModel = {
+    listens: [],
+    drives: [pin],
+    rest: () => [{ pin, level: true, driven: true }],
+    onPad: () => null,
+    update(props, clock?: LineClock) {
+      if ('address' in props) address = numberField(props.address, address);
+      if ('command' in props) command = numberField(props.command, command);
+      // Read per update and never remembered: an air frame carries its own
+      // train, and the NEXT transmission — a Send button on the panel, say —
+      // must not replay the last one the room happened to deliver.
+      const carried = 'pulses' in props ? toPulses(props.pulses) : null;
+
+      let fired = false;
+      for (const k of TRIGGER_KEYS) {
+        if (!(k in props)) continue;
+        if (props[k] !== seen.get(k)) fired = true;
+        seen.set(k, props[k]);
+      }
+      if (!fired || !clock) return null;
+
+      const now = clock.now();
+      if (now < busyUntil) return null; // still emitting the previous frame
+      const frame = carried
+        ? envelopeFrame(pin, now, carried, clock.us)
+        : necFrame(pin, now, address, command, clock.us);
+      if (!frame) return null;
+      busyUntil = frame.edges[frame.edges.length - 1].atCycle;
+      return frame;
+    },
+    reset() {
+      busyUntil = -Infinity;
+    },
+  };
+  return model;
+});

--- a/frontend/src/simulation/line/models/ir-tx.ts
+++ b/frontend/src/simulation/line/models/ir-tx.ts
@@ -1,0 +1,188 @@
+/**
+ * An infrared LED the sketch drives — the transmit half of the link.
+ *
+ * WHAT IT LISTENS FOR. There is no IR protocol in the hardware: a remote is a
+ * plain LED and everything a remote does is TIMING the firmware produces on
+ * one pin. So this model owns no pad and answers nothing. It only listens, on
+ * the guest's own cycle counter, and turns what the pin did into the mark and
+ * space train that crosses the air.
+ *
+ * DEMODULATION, BOTH SHAPES. Sketches produce two different waveforms and both
+ * have to work:
+ *
+ *   modulated    the classic. The pin is toggled at 38 kHz for the length of
+ *                each mark and held low through each space. Edges inside a
+ *                mark are ~13 us apart.
+ *   unmodulated  the pin is simply held high for the mark and low for the
+ *                space. Common in sketches written against a simulator, and
+ *                the shape a hardware carrier produces when the engine reports
+ *                the peripheral's gate rather than its individual pulses.
+ *
+ * One rule covers both. An interval the pin spent HIGH is always carrier
+ * energy. An interval it spent LOW is carrier energy too when it is shorter
+ * than {@link CARRIER_GAP_US} — that is the off half of a carrier cycle, not a
+ * space — and a space when it is longer. Nothing here has to know which shape
+ * it is looking at, or what the carrier frequency was.
+ *
+ * WHEN A FRAME IS OVER. Nothing announces it: the pin simply stops moving, and
+ * a model with no clock of its own cannot notice silence. So the frame is
+ * closed the way the S3 bridge's IR capture already closes one — when the NEXT
+ * burst begins, or when it grows past any plausible length — plus a wall-clock
+ * debounce for the last frame of a run, which no later burst will ever flush.
+ * The debounce is deliberately long: the guest may run slower than real time,
+ * and a short one would cut a frame in half.
+ */
+
+import type { PadEvent } from '../padEvent';
+import { emitIr } from '../../ir/irAir';
+import type { IrPulse } from '../../ir/necCodec';
+import { registerLineModel, type LineClock, type LineModel } from '../lineModels';
+
+/** A LOW interval shorter than this is the off half of a carrier cycle, not a
+ *  space. A 38 kHz half period is 13 us and a 30 kHz one 17; the shortest
+ *  space any remote protocol sends is NEC's 560 us, so there is a wide gap to
+ *  sit in and this value never has to be tuned per protocol. */
+export const CARRIER_GAP_US = 60;
+/** A space longer than this ends the transmission. NEC's longest space inside
+ *  a frame is the 4.5 ms header; the gap between frames is 40 ms and up. */
+export const FRAME_GAP_US = 20_000;
+/** Nothing shorter is a transmission — it is a stray edge or a boot glitch. */
+export const MIN_SEGMENTS = 4;
+/** A guard against a pin toggling forever (a PWM output, a blink loop): flush
+ *  and start over rather than growing an unbounded array. */
+export const MAX_SEGMENTS = 600;
+/** Wall-clock fallback for the last frame of a run. Long, because the guest
+ *  may be running well behind real time. */
+export const FLUSH_DEBOUNCE_MS = 250;
+
+const stringField = (v: unknown, dflt: string): string => (typeof v === 'string' ? v : dflt);
+
+registerLineModel('ir-tx', (rec) => {
+  const pin = rec.pin;
+  const sourceId = stringField(rec.source_id, `ir-tx@${pin}`);
+  let channel = stringField(rec.channel, '');
+
+  let segments: IrPulse[] = [];
+  /** The open segment: what kind it is and how long it has run. */
+  let segMark = false;
+  let segUs = 0;
+  let open = false;
+  /** Carrier estimate: completed carrier cycles inside marks, over the marks'
+   *  total length. A cycle has two transitions but only ONE of them ends a low
+   *  notch, so counting those counts cycles directly — halving them again put
+   *  a bit-banged 38 kHz carrier at 19 kHz. */
+  let carrierCycles = 0;
+  let markUs = 0;
+
+  let lastCycle = -1;
+  let lastLevel = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  function clearTimer(): void {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  }
+
+  function closeSegment(): void {
+    if (open && segUs > 0) segments.push({ level: segMark ? 1 : 0, us: segUs });
+    open = false;
+    segUs = 0;
+  }
+
+  function discard(): void {
+    segments = [];
+    open = false;
+    segUs = 0;
+    carrierCycles = 0;
+    markUs = 0;
+  }
+
+  function flush(): void {
+    clearTimer();
+    closeSegment();
+    // A capture starts and ends in silence more often than not; a leading or
+    // trailing space is the room, not the message.
+    while (segments.length && segments[0].level === 0) segments.shift();
+    while (segments.length && segments[segments.length - 1].level === 0) segments.pop();
+    const pulses = segments;
+    const cycles = carrierCycles;
+    const marks = markUs;
+    discard();
+    if (pulses.length < MIN_SEGMENTS) return;
+    emitIr({
+      pulses,
+      sourceId,
+      channel,
+      // No notches inside the marks means the sketch sent the envelope with no
+      // carrier at all, which is reported as 0 rather than guessed at.
+      carrierHz: cycles >= 2 && marks > 0 ? Math.round((cycles / marks) * 1e6) : 0,
+    });
+  }
+
+  function accumulate(mark: boolean, us: number): void {
+    if (open && mark === segMark) {
+      segUs += us;
+      return;
+    }
+    closeSegment();
+    segMark = mark;
+    segUs = us;
+    open = true;
+  }
+
+  const model: LineModel = {
+    listens: [pin],
+    drives: [],
+    rest: () => [],
+    onPad(e: PadEvent, clock: LineClock) {
+      const level = e.level;
+      if (lastCycle < 0 || e.cycle < lastCycle) {
+        // First edge, or the guest rebooted inside the engine and its counter
+        // went backwards: everything measured against the old base is gone.
+        discard();
+        lastCycle = e.cycle;
+        lastLevel = level;
+        return null;
+      }
+      if (level === lastLevel) return null; // a pull or direction event, no edge
+
+      const perUs = clock.us(1000) / 1000;
+      const dtUs = perUs > 0 ? (e.cycle - lastCycle) / perUs : 0;
+      lastCycle = e.cycle;
+      lastLevel = level;
+      if (dtUs <= 0) return null;
+
+      // The interval that just ENDED was spent at the previous level.
+      const wasMark = !level ? true : dtUs <= CARRIER_GAP_US;
+      if (wasMark) {
+        markUs += dtUs;
+        if (level) carrierCycles++; // a low notch inside a mark ends one carrier cycle
+      }
+
+      if (!wasMark && dtUs > FRAME_GAP_US) {
+        // The transmission ended somewhere back there. The gap itself is the
+        // room between frames and belongs to neither.
+        flush();
+      } else {
+        accumulate(wasMark, dtUs);
+        if (segments.length >= MAX_SEGMENTS) flush();
+      }
+
+      clearTimer();
+      timer = setTimeout(flush, FLUSH_DEBOUNCE_MS);
+      return null; // this model never puts anything on a wire
+    },
+    update(props) {
+      if ('channel' in props) channel = stringField(props.channel, channel);
+    },
+    reset() {
+      clearTimer();
+      discard();
+      lastCycle = -1;
+      lastLevel = false;
+    },
+  };
+  return model;
+});

--- a/frontend/src/simulation/parts/ProtocolParts.ts
+++ b/frontend/src/simulation/parts/ProtocolParts.ts
@@ -8,14 +8,16 @@
  *  mpu6050      — I2C 6-axis IMU (0x68/0x69). Full register map simulation.
  *  dht22        — Single-wire temp/humidity. Drives DATA pin after start signal.
  *  hx711        — 2-wire load cell amplifier. Clocks out 24-bit ADC value.
- *  ir-receiver  — NEC IR receiver. Click generates active-low pulse train.
- *  ir-remote    — NEC IR remote. Button click dispatches ir-signal event.
+ *  ir-receiver  — IR demodulator. Owns its pin through the line contract and
+ *                 puts what crosses simulation/ir/irAir on it, at real timing.
+ *  ir-remote    — IR handset. No pins: it transmits into the air.
  *  microsd-card — SPI SD card. Responds to CMD0/CMD8/ACMD41/CMD58 init.
  *
- * NOTE — timing-sensitive protocols (dht22, ir-receiver, ir-remote):
- *   Full µs-accuracy requires CPU-loop integration. These simulate protocol
- *   intent and work with polling-based Arduino code; hardware-interrupt-based
- *   libraries (e.g. IRremote) need the exact cycle counts not available here.
+ * NOTE — the timing-sensitive parts (dht22, ir-receiver) do NOT live here any
+ *   more. They are line-owning models under simulation/line/models, which place
+ *   edges on the guest's own cycle counter, so a µs-accurate protocol is exact
+ *   and an interrupt-driven library (IRremote, Adafruit DHT) decodes it. What
+ *   is left in this file drives pins from host time and is fine with that.
  */
 
 import { PartSimulationRegistry } from './PartSimulationRegistry';
@@ -24,6 +26,15 @@ import { VirtualDS1307, VirtualBMP280, VirtualDS3231, VirtualPCF8574 } from '../
 import type { I2CDevice } from '../I2CBusManager';
 import { HD44780Decoder } from '../HD44780Decoder';
 import { registerSensorUpdate, unregisterSensorUpdate } from '../SensorUpdateRegistry';
+import {
+  emitIr,
+  listenIr,
+  necEncode,
+  necEncodeRepeat,
+  NEC_REPEAT_PERIOD_MS,
+  type IrAirFrame,
+  type IrPulse,
+} from '../ir';
 import { useSimulatorStore } from '../../store/useSimulatorStore';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -615,12 +626,16 @@ PartSimulationRegistry.register('dht22', {
     if (pin === null) return () => {};
 
     const el = element as { temperature?: number; humidity?: number };
-    const answer = requestLine(simulator, {
-      sensor_type: 'dht22',
-      pin,
-      temperature: el.temperature ?? 25.0,
-      humidity: el.humidity ?? 50.0,
-    }, { componentId });
+    const answer = requestLine(
+      simulator,
+      {
+        sensor_type: 'dht22',
+        pin,
+        temperature: el.temperature ?? 25.0,
+        humidity: el.humidity ?? 50.0,
+      },
+      { componentId },
+    );
 
     // SensorControlPanel: update temperature / humidity on the element, and
     // tell the host when there is one.
@@ -713,178 +728,198 @@ PartSimulationRegistry.register('hx711', {
   },
 });
 
-// ─── IR Receiver ─────────────────────────────────────────────────────────────
+// ─── Infrared ────────────────────────────────────────────────────────────────
 
 /**
- * IR receiver (e.g. VS1838B) — responds to clicks by generating an NEC
- * protocol pulse train on the DATA/OUT pin (active-low: LOW = IR burst).
+ * The two IR parts, and the air between them.
  *
- * NEC frame on the demodulated output:
- *   9 ms LOW  + 4.5 ms HIGH  (preamble)
- *   8-bit address (MSB first) + 8-bit ~address
- *   8-bit command (MSB first) + 8-bit ~command
- *   Final 562 µs LOW  ("end burst")
+ * WHAT WAS WRONG. Both were dead, each in its own way, and neither failure
+ * looked like a failure on the canvas:
  *
- * Default: address 0x00, command 0x45 (NEC remote "POWER" button equivalent).
- * Change by setting `element.irAddress` and `element.irCommand`.
+ *  - the receiver asked for a pin named `OUT` or `DATA`. `wokwi-ir-receiver`
+ *    calls it `DAT`, so the lookup returned null and `attachEvents` returned
+ *    an empty cleanup on its second line. Wired or not, the part did nothing.
+ *  - the remote asked for a pin too. It is a remote control: it has no pins
+ *    and never had. All it did was dispatch an `ir-signal` DOM event that
+ *    nothing in the codebase listened for, with a command from a hand-written
+ *    key table whose names the element never emits — while the element itself
+ *    was already carrying the correct NEC code in `detail.irCode`.
+ *  - and the pulse train was built out of `setTimeout(next, 0.562)`. A NEC
+ *    mark is 560 us; setTimeout's floor is a millisecond and its nested clamp
+ *    is four. No IR library could ever have decoded it.
  *
- * TIMING: Each ms-level delay is implemented via setTimeout. This chains
- * ~70 callbacks (35 bits × 2 edges each). Because the simulation runs in
- * requestAnimationFrame batches (~16 ms), the timing will be stretched but
- * the logical transitions are correct for polling-based IR decoders.
+ * WHAT THEY ARE NOW. The remote transmits into `simulation/ir/irAir` — the
+ * medium, with no wire and no geometry — and the receiver is a line-owning
+ * model (`simulation/line/models/ir-nec`) that puts the envelope of whatever
+ * it hears on its pin, on the guest's own cycle counter, at real NEC timing.
+ * Several remotes and several receivers work at once, on any mix of boards,
+ * because the air carries microseconds and each receiver converts them to its
+ * own board's clock.
  */
 
-function necBitSequence(address: number, command: number): number[] {
-  /* Returns interleaved [duration_ms, level, ...] pairs for NEC frame.
-     level: 1 = LINE HIGH (no IR / space), 0 = LINE LOW (IR burst / mark) */
-  const frames: number[] = [];
-
-  function push(duration: number, level: number) {
-    frames.push(duration, level);
-  }
-
-  // Preamble
-  push(9, 0); // 9 ms mark
-  push(4.5, 1); // 4.5 ms space
-
-  // Build 32 bits: addr, ~addr, cmd, ~cmd
-  const bytes = [address & 0xff, ~address & 0xff, command & 0xff, ~command & 0xff];
-  for (const byte of bytes) {
-    for (let b = 0; b < 8; b++) {
-      // LSB first for NEC
-      const bit = (byte >> b) & 1;
-      push(0.562, 0); // 562 µs mark (same for 0 and 1)
-      push(bit ? 1.687 : 0.562, 1); // space: 1687 µs=1, 562 µs=0
+/** A component property that may arrive as a number or as a typed string. */
+function numProp(el: Record<string, unknown>, keys: string[], dflt: number): number {
+  for (const k of keys) {
+    const v = el[k];
+    if (typeof v === 'number' && Number.isFinite(v)) return v;
+    if (typeof v === 'string' && v.trim() !== '') {
+      const n = v.trim().toLowerCase().startsWith('0x') ? parseInt(v, 16) : parseFloat(v);
+      if (Number.isFinite(n)) return n;
     }
   }
-
-  // Final burst
-  push(0.562, 0);
-
-  return frames;
+  return dflt;
 }
 
-function driveNECSequence(simulator: any, pin: number, address: number, command: number): void {
-  const frames = necBitSequence(address, command);
-  let i = 0;
-
-  function next(): void {
-    if (i >= frames.length) {
-      simulator.setPinState(pin, true); // idle HIGH
-      return;
-    }
-    const duration = frames[i++];
-    const level = frames[i++];
-    simulator.setPinState(pin, level === 1); // active-low: LOW=burst, HIGH=space
-    setTimeout(next, duration);
-  }
-
-  next();
+function textProp(el: Record<string, unknown>, key: string): string {
+  const v = el[key];
+  return typeof v === 'string' ? v : '';
 }
 
+/**
+ * IR receiver — the demodulator can (a VS1838B, a TSOP38238) behind the lens.
+ *
+ * It owns its output pin through the line contract, so the board that hosts it
+ * answers honestly: the model runs in the browser (AVR, RP2040, RP2350, the
+ * esp32*js engines), it runs in the backend worker, or this board cannot host
+ * it and the circuit check says why. A click on the part still transmits, as a
+ * convenience for a canvas with no remote on it — the part IS the remote then,
+ * sending its configured address and command.
+ */
 PartSimulationRegistry.register('ir-receiver', {
-  attachEvents: (element, simulator, getPin) => {
-    const pin = getPin('OUT') ?? getPin('DATA');
+  attachEvents: (element, simulator, getPin, componentId) => {
+    // `DAT` is what the element declares. The other two are accepted because
+    // modules in the wild silk-screen them, and a saved project may carry
+    // either spelling.
+    const pin = getPin('DAT') ?? getPin('OUT') ?? getPin('DATA');
     if (pin === null) return () => {};
 
-    // Idle: pin HIGH (no IR)
-    simulator.setPinState(pin, true);
+    const el = element as unknown as Record<string, unknown>;
+    const channel = () => textProp(el, 'channel');
+    /** Bumped on every transmission: the model fires on the CHANGE, so two
+     *  identical presses in a row are still two frames. */
+    let seq = 0;
 
-    const onClick = () => {
-      const el = element as any;
-      const address = (el.irAddress ?? 0x00) & 0xff;
-      const command = (el.irCommand ?? 0x45) & 0xff;
-      driveNECSequence(simulator, pin, address, command);
+    const answer = requestLine(
+      simulator,
+      {
+        sensor_type: 'ir-nec',
+        pin,
+        address: numProp(el, ['irAddress', 'address'], 0x00),
+        command: numProp(el, ['irCommand', 'command'], 0x45),
+        channel: channel(),
+      },
+      { componentId },
+    );
+
+    /** Put a train on the pin. The air already decoded it; this only has to
+     *  reproduce the envelope, so the raw pulses go over untouched — a remote
+     *  speaking a protocol nothing here parses still reaches the sketch. */
+    const deliver = (pulses: readonly IrPulse[]): boolean => {
+      if (answer.mode === 'none') return false;
+      answer.update({ pulses, seq: ++seq });
+      return true;
     };
 
+    const unlisten = listenIr(componentId, channel, (f: IrAirFrame) => deliver(f.pulses));
+
+    // Clicking the receiver transmits its own configured code, so a canvas
+    // with no remote on it is still testable. It goes through the air like
+    // anything else, which is also what makes a second receiver hear it.
+    const onClick = () => {
+      emitIr({
+        pulses: necEncode(
+          numProp(el, ['irAddress', 'address'], 0x00),
+          numProp(el, ['irCommand', 'command'], 0x45),
+        ),
+        sourceId: componentId,
+        channel: channel(),
+      });
+    };
     element.addEventListener('click', onClick);
+
+    // The sensor panel edits the SAME two values the element carries, so a
+    // slider and the hex property in the inspector cannot drift apart and the
+    // click path below reads whatever was set last.
+    registerSensorUpdate(componentId, (values) => {
+      if ('address' in values) el.irAddress = values.address;
+      if ('command' in values) el.irCommand = values.command;
+      // The panel's Send button transmits into the room rather than straight
+      // onto the pin, so every OTHER receiver on this channel hears it too.
+      if ('send' in values) onClick();
+    });
+
     return () => {
+      unlisten();
       element.removeEventListener('click', onClick);
-      simulator.setPinState(pin, true);
+      if (answer.mode !== 'none') answer.release();
+      else releaseLineGap(componentId);
+      unregisterSensorUpdate(componentId);
     };
   },
 });
 
-// ─── IR Remote ───────────────────────────────────────────────────────────────
-
 /**
- * IR remote control — each button click:
- *  1. Fires an `ir-signal` CustomEvent on the element with {address, command}
- *  2. Drives the IR output pin (if connected) with the NEC pulse sequence
+ * IR remote control — a handset. It has no pins and connects to nothing; it
+ * transmits into the room and whatever is listening hears it.
  *
- * Button → command mapping (NEC standard SHARP-style remote):
- *   0–9 → commands 0x16, 0x0C, 0x18, 0x5E, 0x08, 0x1C, 0x5A, 0x42, 0x52, 0x4A
- *   VOL+→0x40, VOL-→0x00, CH+→0x48, CH-→0x0D, POWER→0x45, MUTE→0x09
+ * The element already computes the NEC code for the button that was pressed
+ * (`detail.irCode`) and it is the authority: the codes belong to the artwork
+ * printed on its keys. The old hand-written table here disagreed with it on
+ * every single key and was keyed on button names the element never emits.
  *
- * The element should dispatch `button-press` events with `detail.key` naming
- * the button (matches typical wokwi IR remote element events). We listen for
- * both 'button-press' from the element model and 'click' as fallback.
+ * Holding a button repeats, exactly as a real remote does — a NEC repeat frame
+ * every 108 ms, which is what makes a volume key ramp instead of stepping once.
  */
-const IR_REMOTE_COMMANDS: Record<string, number> = {
-  '0': 0x16,
-  '1': 0x0c,
-  '2': 0x18,
-  '3': 0x5e,
-  '4': 0x08,
-  '5': 0x1c,
-  '6': 0x5a,
-  '7': 0x42,
-  '8': 0x52,
-  '9': 0x4a,
-  'vol+': 0x40,
-  'vol-': 0x00,
-  'ch+': 0x48,
-  'ch-': 0x0d,
-  power: 0x45,
-  mute: 0x09,
-  ok: 0x1b,
-  up: 0x46,
-  down: 0x15,
-  left: 0x44,
-  right: 0x43,
-};
-
 PartSimulationRegistry.register('ir-remote', {
-  attachEvents: (element, simulator, getPin) => {
-    const pin = getPin('IR') ?? getPin('OUT');
+  attachEvents: (element, _simulator, _getPin, componentId) => {
+    const el = element as unknown as Record<string, unknown>;
+    const channel = () => textProp(el, 'channel');
+    /** The address the handset sends. NEC remotes each have their own; the
+     *  element models one physical remote, so the property is on the part. */
+    const address = () => numProp(el, ['irAddress', 'address'], 0x00);
 
-    // Idle HIGH if pin connected
-    if (pin !== null) simulator.setPinState(pin, true);
+    let repeatTimer: ReturnType<typeof setInterval> | null = null;
+    const stopRepeat = () => {
+      if (repeatTimer !== null) {
+        clearInterval(repeatTimer);
+        repeatTimer = null;
+      }
+    };
 
-    const el = element as any;
-    const address = (el.irAddress ?? 0x00) & 0xff;
+    const send = (pulses: readonly IrPulse[]) => {
+      const taken = emitIr({ pulses, sourceId: componentId, channel: channel() });
+      if (taken === 0) {
+        // "The button does nothing" and "nothing was listening" look the same
+        // on a canvas, and only one of them is the user's mistake.
+        console.warn(
+          `[ir] ${componentId} transmitted and no receiver took it` +
+            (channel() ? ` on channel '${channel()}'` : ''),
+        );
+      }
+    };
 
     const onButtonPress = (e: Event) => {
-      const key = ((e as CustomEvent).detail?.key ?? '').toLowerCase();
-      const command = (IR_REMOTE_COMMANDS[key] ?? 0x45) & 0xff;
-      element.dispatchEvent(
-        new CustomEvent('ir-signal', {
-          bubbles: true,
-          detail: { address, command, key },
-        }),
-      );
-      if (pin !== null) driveNECSequence(simulator, pin, address, command);
+      const detail = (e as CustomEvent).detail ?? {};
+      const irCode = Number(detail.irCode);
+      if (!Number.isFinite(irCode)) return;
+      stopRepeat();
+      send(necEncode(address(), irCode & 0xff));
+      // A held key sends repeat frames, carrying no data, every 108 ms.
+      repeatTimer = setInterval(() => send(necEncodeRepeat()), NEC_REPEAT_PERIOD_MS);
     };
-
-    const onClick = () => {
-      // Fallback for plain click — send POWER code
-      const command = 0x45;
-      element.dispatchEvent(
-        new CustomEvent('ir-signal', {
-          bubbles: true,
-          detail: { address, command, key: 'power' },
-        }),
-      );
-      if (pin !== null) driveNECSequence(simulator, pin, address, command);
-    };
+    const onButtonRelease = () => stopRepeat();
 
     element.addEventListener('button-press', onButtonPress);
-    element.addEventListener('click', onClick);
+    element.addEventListener('button-release', onButtonRelease);
+    // A button-press with no release (the element focuses and blurs, a pointer
+    // leaves the SVG) must not repeat forever.
+    element.addEventListener('mouseleave', onButtonRelease);
 
     return () => {
+      stopRepeat();
       element.removeEventListener('button-press', onButtonPress);
-      element.removeEventListener('click', onClick);
-      if (pin !== null) simulator.setPinState(pin, true);
+      element.removeEventListener('button-release', onButtonRelease);
+      element.removeEventListener('mouseleave', onButtonRelease);
     };
   },
 });
@@ -927,8 +962,7 @@ PartSimulationRegistry.register('microsd-card', {
 
     // ── Backing store: sparse map of blockIndex -> 512-byte sector ──────────
     const store = new Map<number, Uint8Array>();
-    const readBlock = (idx: number): Uint8Array =>
-      store.get(idx) ?? new Uint8Array(SD_BLOCK_SIZE); // unwritten = zeros
+    const readBlock = (idx: number): Uint8Array => store.get(idx) ?? new Uint8Array(SD_BLOCK_SIZE); // unwritten = zeros
     const writeBlock = (idx: number, data: ArrayLike<number>): void => {
       const blk = new Uint8Array(SD_BLOCK_SIZE);
       blk.set(Array.from(data).slice(0, SD_BLOCK_SIZE));
@@ -941,10 +975,13 @@ PartSimulationRegistry.register('microsd-card', {
       const raw = el.sdImageData;
       if (!raw) return;
       const bytes: Uint8Array | null =
-        raw instanceof Uint8Array ? raw
-        : raw instanceof ArrayBuffer ? new Uint8Array(raw)
-        : Array.isArray(raw) ? Uint8Array.from(raw)
-        : null;
+        raw instanceof Uint8Array
+          ? raw
+          : raw instanceof ArrayBuffer
+            ? new Uint8Array(raw)
+            : Array.isArray(raw)
+              ? Uint8Array.from(raw)
+              : null;
       if (!bytes) return;
       for (let i = 0; i * SD_BLOCK_SIZE < bytes.length; i++) {
         const slice = bytes.subarray(i * SD_BLOCK_SIZE, (i + 1) * SD_BLOCK_SIZE);
@@ -956,14 +993,41 @@ PartSimulationRegistry.register('microsd-card', {
 
     // ── 16-byte CSD (v2.0, high-capacity) reflecting SD_CARD_BYTES ──────────
     const buildCSD = (): number[] => [
-      0x40, 0x0e, 0x00, 0x32, 0x5b, 0x59, 0x00,
-      (SD_C_SIZE >> 16) & 0x3f, (SD_C_SIZE >> 8) & 0xff, SD_C_SIZE & 0xff,
-      0x7f, 0x80, 0x0a, 0x40, 0x00, 0x01,
+      0x40,
+      0x0e,
+      0x00,
+      0x32,
+      0x5b,
+      0x59,
+      0x00,
+      (SD_C_SIZE >> 16) & 0x3f,
+      (SD_C_SIZE >> 8) & 0xff,
+      SD_C_SIZE & 0xff,
+      0x7f,
+      0x80,
+      0x0a,
+      0x40,
+      0x00,
+      0x01,
     ];
     // ── 16-byte CID (manufacturer info; values are cosmetic) ────────────────
     const buildCID = (): number[] => [
-      0x01, 0x56, 0x58, 0x56, 0x45, 0x4c, 0x58, 0x53, // mfr, "VX", "VELXS"
-      0x10, 0x00, 0x00, 0x00, 0x01, 0x01, 0x60, 0x01,
+      0x01,
+      0x56,
+      0x58,
+      0x56,
+      0x45,
+      0x4c,
+      0x58,
+      0x53, // mfr, "VX", "VELXS"
+      0x10,
+      0x00,
+      0x00,
+      0x00,
+      0x01,
+      0x01,
+      0x60,
+      0x01,
     ];
 
     // ── SD SPI protocol state machine ───────────────────────────────────────
@@ -998,39 +1062,77 @@ PartSimulationRegistry.register('microsd-card', {
       expectingAcmd = false;
 
       if (isAcmd) {
-        if (cmd === 41) { respQueue.push(0x00); return; } // ACMD41 — ready
-        if (cmd === 13) { respQueue.push(0x00, 0x00); return; } // ACMD13 SD status (R2)
+        if (cmd === 41) {
+          respQueue.push(0x00);
+          return;
+        } // ACMD41 — ready
+        if (cmd === 13) {
+          respQueue.push(0x00, 0x00);
+          return;
+        } // ACMD13 SD status (R2)
         // fall through for other ACMDs
       }
 
       switch (cmd) {
-        case 0: respQueue.push(0x01); break; // GO_IDLE -> idle
-        case 8: respQueue.push(0x01, 0x00, 0x00, 0x01, 0xaa); break; // SEND_IF_COND (R7)
-        case 9: pushShortData(buildCSD()); break; // SEND_CSD
-        case 10: pushShortData(buildCID()); break; // SEND_CID
-        case 12: multiRead = false; respQueue.push(0x00, 0x00, 0xff); break; // STOP_TRANSMISSION
-        case 13: respQueue.push(0x00, 0x00); break; // SEND_STATUS (R2)
-        case 16: respQueue.push(0x00); break; // SET_BLOCKLEN (fixed 512)
+        case 0:
+          respQueue.push(0x01);
+          break; // GO_IDLE -> idle
+        case 8:
+          respQueue.push(0x01, 0x00, 0x00, 0x01, 0xaa);
+          break; // SEND_IF_COND (R7)
+        case 9:
+          pushShortData(buildCSD());
+          break; // SEND_CSD
+        case 10:
+          pushShortData(buildCID());
+          break; // SEND_CID
+        case 12:
+          multiRead = false;
+          respQueue.push(0x00, 0x00, 0xff);
+          break; // STOP_TRANSMISSION
+        case 13:
+          respQueue.push(0x00, 0x00);
+          break; // SEND_STATUS (R2)
+        case 16:
+          respQueue.push(0x00);
+          break; // SET_BLOCKLEN (fixed 512)
         // Standard-capacity (SDSC) byte addressing: CMD17/18/24/25 args are BYTE
         // offsets (block*512), not block indices. The Arduino SD library uses
         // this even when the card advertises SDHC, so we present SDSC (CMD58
         // CCS=0) and translate `arg >> 9` -> block. SDSC covers up to 2 GB,
         // plenty for our small card; every SD library supports it.
-        case 17: respQueue.push(0x00); pushDataBlock(readBlock(arg >> 9)); break; // READ_SINGLE
+        case 17:
+          respQueue.push(0x00);
+          pushDataBlock(readBlock(arg >> 9));
+          break; // READ_SINGLE
         case 18: // READ_MULTIPLE — stream until CMD12
           respQueue.push(0x00);
-          readAddr = arg >> 9; multiRead = true;
-          pushDataBlock(readBlock(readAddr)); readAddr++;
+          readAddr = arg >> 9;
+          multiRead = true;
+          pushDataBlock(readBlock(readAddr));
+          readAddr++;
           break;
         case 24: // WRITE_SINGLE — data block follows
-          respQueue.push(0x00); writeAddr = arg >> 9; multiWrite = false; phase = 'wait-token';
+          respQueue.push(0x00);
+          writeAddr = arg >> 9;
+          multiWrite = false;
+          phase = 'wait-token';
           break;
         case 25: // WRITE_MULTIPLE — data blocks follow until stop token
-          respQueue.push(0x00); writeAddr = arg >> 9; multiWrite = true; phase = 'wait-token';
+          respQueue.push(0x00);
+          writeAddr = arg >> 9;
+          multiWrite = true;
+          phase = 'wait-token';
           break;
-        case 55: respQueue.push(0x01); expectingAcmd = true; break; // APP_CMD prefix
-        case 58: respQueue.push(0x00, 0x80, 0xff, 0x80, 0x00); break; // READ_OCR (powered, CCS=0 SDSC)
-        default: respQueue.push(0x00); // accept unhandled commands
+        case 55:
+          respQueue.push(0x01);
+          expectingAcmd = true;
+          break; // APP_CMD prefix
+        case 58:
+          respQueue.push(0x00, 0x80, 0xff, 0x80, 0x00);
+          break; // READ_OCR (powered, CCS=0 SDSC)
+        default:
+          respQueue.push(0x00); // accept unhandled commands
       }
     };
 
@@ -1051,20 +1153,33 @@ PartSimulationRegistry.register('microsd-card', {
             cmdBuf = [byte]; // command start (bit7=0, bit6=1)
           } else if (cmdBuf.length > 0) {
             cmdBuf.push(byte);
-            if (cmdBuf.length === 6) { processCmd(cmdBuf); cmdBuf = []; }
+            if (cmdBuf.length === 6) {
+              processCmd(cmdBuf);
+              cmdBuf = [];
+            }
           } else if (multiRead && respQueue.length === 0) {
             // Continuous read: refill the next block while the host clocks 0xFF.
-            pushDataBlock(readBlock(readAddr)); readAddr++;
+            pushDataBlock(readBlock(readAddr));
+            readAddr++;
           }
           break;
         case 'wait-token':
-          if (byte === 0xfe || byte === 0xfc) { phase = 'recv-data'; dataBuf = []; }
-          else if (byte === 0xfd) { multiWrite = false; phase = 'cmd'; respQueue.push(0x00); }
+          if (byte === 0xfe || byte === 0xfc) {
+            phase = 'recv-data';
+            dataBuf = [];
+          } else if (byte === 0xfd) {
+            multiWrite = false;
+            phase = 'cmd';
+            respQueue.push(0x00);
+          }
           // else 0xFF gap — keep waiting
           break;
         case 'recv-data':
           dataBuf.push(byte);
-          if (dataBuf.length === SD_BLOCK_SIZE) { phase = 'recv-crc'; crcLeft = 2; }
+          if (dataBuf.length === SD_BLOCK_SIZE) {
+            phase = 'recv-crc';
+            crcLeft = 2;
+          }
           break;
         case 'recv-crc':
           if (--crcLeft === 0) {
@@ -1117,7 +1232,11 @@ PartSimulationRegistry.register('bmp280', {
       const dev = new VirtualBMP280(addr);
       dev.temperatureC = initTemp;
       dev.pressureHPa = initPressure;
-      sim.registerSensor('bmp280', virtualPin, { addr, temperature: initTemp, pressure: initPressure });
+      sim.registerSensor('bmp280', virtualPin, {
+        addr,
+        temperature: initTemp,
+        pressure: initPressure,
+      });
       sim.addI2CDevice?.(dev);
 
       registerSensorUpdate(componentId, (values) => {

--- a/frontend/src/simulation/sensorControlConfig.ts
+++ b/frontend/src/simulation/sensorControlConfig.ts
@@ -42,6 +42,9 @@ export interface SensorControlDef {
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 const oneDecimal = (v: number) => v.toFixed(1);
+/** NEC address/command as every decoder prints them: 0x and two hex digits. */
+const hex8 = (v: number) =>
+  `0x${(Math.round(v) & 0xff).toString(16).toUpperCase().padStart(2, '0')}`;
 const twoDecimal = (v: number) => v.toFixed(2);
 
 /** Resolution of the position axis for log-scale sliders. */
@@ -348,6 +351,41 @@ export const SENSOR_CONTROLS: Record<string, SensorControlDef> = {
     defaultValues: {},
   },
 
+  // ── IR receiver ───────────────────────────────────────────────────────────
+  // The panel IS the remote, for a canvas with no handset on it. Send
+  // transmits into simulation/ir/irAir rather than straight onto this part's
+  // pin, so a second receiver in the project hears it too — which is the whole
+  // point of there being an air at all.
+  'ir-receiver': {
+    title: 'IR remote',
+    controls: [
+      {
+        type: 'slider',
+        key: 'address',
+        label: 'Address',
+        min: 0,
+        max: 255,
+        step: 1,
+        unit: '',
+        defaultValue: 0,
+        formatValue: hex8,
+      },
+      {
+        type: 'slider',
+        key: 'command',
+        label: 'Command',
+        min: 0,
+        max: 255,
+        step: 1,
+        unit: '',
+        defaultValue: 0x45,
+        formatValue: hex8,
+      },
+      { type: 'button', key: 'send', label: 'Send' },
+    ],
+    defaultValues: { address: 0, command: 0x45 },
+  },
+
   // ── NTC Temperature Sensor ────────────────────────────────────────────────
   'ntc-temperature-sensor': {
     title: 'NTC Temperature Sensor',
@@ -515,9 +553,7 @@ export type InstanceSensorControlResolver = (component: {
 
 let instanceResolver: InstanceSensorControlResolver | null = null;
 
-export function registerInstanceSensorControlResolver(
-  fn: InstanceSensorControlResolver,
-): void {
+export function registerInstanceSensorControlResolver(fn: InstanceSensorControlResolver): void {
   instanceResolver = fn;
 }
 

--- a/frontend/src/simulation/sensorModels.ts
+++ b/frontend/src/simulation/sensorModels.ts
@@ -34,6 +34,15 @@ export interface SensorModelSpec {
   /** Component properties forwarded to the model (temperature, distance, …). */
   propertyKeys: string[];
   /**
+   * Which of `propertyKeys` carry TEXT. Everything a sensor reports has been a
+   * number until now, so the pre-registration walk parsed every property as
+   * one — and an IR receiver's `channel` (a name the user types, matched as a
+   * string by the air) came out of that walk as NaN. Listed here rather than
+   * sniffed from the value, because an empty channel and a channel named "5"
+   * are both legitimate and neither looks like text.
+   */
+  textPropertyKeys?: string[];
+  /**
    * Extra pins the model also drives, as `record field -> component pin name`.
    * The field name is what reaches the backend (`echo_pin`), and the same
    * fields are what `ownsPin` walks — so a model that gains a second line only
@@ -54,6 +63,18 @@ export const SINGLE_WIRE_SENSOR_MODELS: Readonly<Record<string, SensorModelSpec>
     dataPinName: 'TRIG',
     propertyKeys: ['distance'],
     extraPins: { echo_pin: 'ECHO' },
+  },
+  // The demodulator can behind an IR receiver's lens. Not a sensor of anything
+  // physical: it listens to `simulation/ir/irAir` and puts the envelope of
+  // whatever crossed the room on its pin. It is here for the same two reasons
+  // the others are — the pad is the model's and no other layer may drive it,
+  // and the pre-registration walk has to resolve that pad through the wires
+  // before the firmware starts.
+  'ir-receiver': {
+    sensorType: 'ir-nec',
+    dataPinName: 'DAT',
+    propertyKeys: ['address', 'command', 'channel'],
+    textPropertyKeys: ['channel'],
   },
 };
 

--- a/frontend/src/store/useSimulatorStore.ts
+++ b/frontend/src/store/useSimulatorStore.ts
@@ -2633,9 +2633,14 @@ export const useSimulatorStore = create<SimulatorState>((set, get) => {
               sensor_type: sensorDef.sensorType,
               pin: gpioPin,
             };
+            const textKeys = new Set(sensorDef.textPropertyKeys ?? []);
             for (const key of sensorDef.propertyKeys) {
               const val = comp.properties[key];
-              if (val !== undefined) props[key] = typeof val === 'string' ? parseFloat(val) : val;
+              if (val === undefined) continue;
+              // A text property goes over as it was typed. Everything else is
+              // a number the dialog stored as a string.
+              props[key] =
+                textKeys.has(key) || typeof val !== 'string' ? val : parseFloat(val);
             }
             // Extra pins (e.g. echo_pin for HC-SR04) resolve the same way
             if (sensorDef.extraPins) {

--- a/scripts/component-overrides.json
+++ b/scripts/component-overrides.json
@@ -27,7 +27,7 @@
       "tagName": "velxio-logic-and",
       "name": "AND Gate",
       "category": "logic",
-      "description": "2-input AND logic gate. Output Y = A · B.",
+      "description": "2-input AND logic gate. Output Y = A \u00b7 B.",
       "properties": [],
       "defaultValues": {},
       "pinCount": 3,
@@ -43,7 +43,7 @@
       "tagName": "velxio-logic-nand",
       "name": "NAND Gate",
       "category": "logic",
-      "description": "2-input NAND logic gate. Output Y = NOT(A · B).",
+      "description": "2-input NAND logic gate. Output Y = NOT(A \u00b7 B).",
       "properties": [],
       "defaultValues": {},
       "pinCount": 3,
@@ -91,7 +91,7 @@
       "tagName": "velxio-logic-xor",
       "name": "XOR Gate",
       "category": "logic",
-      "description": "2-input XOR logic gate. Output Y = A ⊕ B.",
+      "description": "2-input XOR logic gate. Output Y = A \u2295 B.",
       "properties": [],
       "defaultValues": {},
       "pinCount": 3,
@@ -107,7 +107,7 @@
       "tagName": "velxio-logic-xnor",
       "name": "XNOR Gate",
       "category": "logic",
-      "description": "2-input XNOR logic gate. Output Y = NOT(A ⊕ B).",
+      "description": "2-input XNOR logic gate. Output Y = NOT(A \u2295 B).",
       "properties": [],
       "defaultValues": {},
       "pinCount": 3,
@@ -226,7 +226,7 @@
       "tagName": "wokwi-mosfet-2n7000",
       "name": "2N7000 (N-MOSFET)",
       "category": "analog",
-      "description": "Logic-level N-channel MOSFET. Vth ≈ 1.6 V, fully enhanced at 3.3 V — perfect for GPIO-driven load switching.",
+      "description": "Logic-level N-channel MOSFET. Vth \u2248 1.6 V, fully enhanced at 3.3 V \u2014 perfect for GPIO-driven load switching.",
       "properties": [],
       "defaultValues": {},
       "pinCount": 3,
@@ -245,7 +245,7 @@
       "tagName": "wokwi-mosfet-irf540",
       "name": "IRF540 (N-MOSFET Power)",
       "category": "analog",
-      "description": "Power N-channel MOSFET. Vth ≈ 3 V (needs 10 V for full enhancement), 33 A / 100 V, R_DS(on) ≈ 77 mΩ. Classic motor / solenoid driver.",
+      "description": "Power N-channel MOSFET. Vth \u2248 3 V (needs 10 V for full enhancement), 33 A / 100 V, R_DS(on) \u2248 77 m\u03a9. Classic motor / solenoid driver.",
       "properties": [],
       "defaultValues": {},
       "pinCount": 3,
@@ -352,7 +352,7 @@
       "tagName": "wokwi-opamp-tl072",
       "name": "TL072 (JFET Op-Amp)",
       "category": "analog",
-      "description": "JFET-input dual op-amp. Very high input impedance, low noise — audio and instrumentation.",
+      "description": "JFET-input dual op-amp. Very high input impedance, low noise \u2014 audio and instrumentation.",
       "properties": [],
       "defaultValues": {},
       "pinCount": 3,
@@ -388,7 +388,7 @@
       "tagName": "wokwi-reg-7805",
       "name": "7805 (+5V Linear Regulator)",
       "category": "analog",
-      "description": "Fixed +5V linear regulator, 1A, TO-220. Dropout ≈ 2V. Classic MCU power supply.",
+      "description": "Fixed +5V linear regulator, 1A, TO-220. Dropout \u2248 2V. Classic MCU power supply.",
       "properties": [],
       "defaultValues": {},
       "pinCount": 3,
@@ -406,7 +406,7 @@
       "tagName": "wokwi-reg-7812",
       "name": "7812 (+12V Linear Regulator)",
       "category": "analog",
-      "description": "Fixed +12V linear regulator, 1A, TO-220. Dropout ≈ 2V. Motor drivers, fan supplies.",
+      "description": "Fixed +12V linear regulator, 1A, TO-220. Dropout \u2248 2V. Motor drivers, fan supplies.",
       "properties": [],
       "defaultValues": {},
       "pinCount": 3,
@@ -422,9 +422,9 @@
     {
       "id": "reg-7905",
       "tagName": "wokwi-reg-7905",
-      "name": "7905 (−5V Linear Regulator)",
+      "name": "7905 (\u22125V Linear Regulator)",
       "category": "analog",
-      "description": "Fixed −5V linear regulator, 1A, TO-220. Negative-rail complement of the 7805.",
+      "description": "Fixed \u22125V linear regulator, 1A, TO-220. Negative-rail complement of the 7805.",
       "properties": [],
       "defaultValues": {},
       "pinCount": 3,
@@ -443,7 +443,7 @@
       "tagName": "wokwi-reg-lm317",
       "name": "LM317 (Adjustable Linear Regulator)",
       "category": "analog",
-      "description": "Adjustable +1.25V to +37V linear regulator. V_out = 1.25·(1 + R2/R1). Versatile workhorse.",
+      "description": "Adjustable +1.25V to +37V linear regulator. V_out = 1.25\u00b7(1 + R2/R1). Versatile workhorse.",
       "properties": [],
       "defaultValues": {},
       "pinCount": 3,
@@ -460,7 +460,7 @@
       "tagName": "wokwi-battery-9v",
       "name": "9V Battery",
       "category": "analog",
-      "description": "PP3 / 6LR61 9V alkaline battery. Modelled as 9V DC with ~1.5Ω internal resistance.",
+      "description": "PP3 / 6LR61 9V alkaline battery. Modelled as 9V DC with ~1.5\u03a9 internal resistance.",
       "properties": [],
       "defaultValues": {},
       "pinCount": 2,
@@ -477,7 +477,7 @@
       "tagName": "wokwi-battery-aa",
       "name": "AA Battery (1.5V)",
       "category": "analog",
-      "description": "AA alkaline cell. 1.5V, low ESR (~0.15Ω). Pair up for 3V/4.5V/6V packs.",
+      "description": "AA alkaline cell. 1.5V, low ESR (~0.15\u03a9). Pair up for 3V/4.5V/6V packs.",
       "properties": [],
       "defaultValues": {},
       "pinCount": 2,
@@ -494,7 +494,7 @@
       "tagName": "wokwi-battery-coin-cell",
       "name": "Coin Cell (CR2032, 3V)",
       "category": "analog",
-      "description": "Lithium coin cell. 3V, high ESR (~10Ω) — limits peak current.",
+      "description": "Lithium coin cell. 3V, high ESR (~10\u03a9) \u2014 limits peak current.",
       "properties": [],
       "defaultValues": {},
       "pinCount": 2,
@@ -512,7 +512,7 @@
       "tagName": "velxio-logic-and-3",
       "name": "AND Gate (3-input)",
       "category": "logic",
-      "description": "3-input AND gate. Output Y = A · B · C.",
+      "description": "3-input AND gate. Output Y = A \u00b7 B \u00b7 C.",
       "properties": [],
       "defaultValues": {},
       "pinCount": 4,
@@ -648,7 +648,7 @@
       "tagName": "wokwi-diode",
       "name": "Diode (generic)",
       "category": "analog",
-      "description": "Generic silicon diode. Vf ≈ 0.7 V. Use for textbook rectification examples.",
+      "description": "Generic silicon diode. Vf \u2248 0.7 V. Use for textbook rectification examples.",
       "properties": [],
       "defaultValues": {},
       "pinCount": 2,
@@ -714,7 +714,7 @@
       "tagName": "wokwi-diode-1n5817",
       "name": "1N5817 (Schottky 20V)",
       "category": "analog",
-      "description": "Schottky diode, 1 A / 20 V. Vf ≈ 0.32 V at 1 A. Used in low-drop rectification and reverse-polarity protection.",
+      "description": "Schottky diode, 1 A / 20 V. Vf \u2248 0.32 V at 1 A. Used in low-drop rectification and reverse-polarity protection.",
       "properties": [],
       "defaultValues": {},
       "pinCount": 2,
@@ -767,7 +767,7 @@
       "tagName": "velxio-flip-flop-d",
       "name": "D Flip-Flop",
       "category": "logic",
-      "description": "Edge-triggered D-type flip-flop. On rising edge of CLK, Q ← D. Digital simulation only (SPICE cannot do edge detection in .op analysis).",
+      "description": "Edge-triggered D-type flip-flop. On rising edge of CLK, Q \u2190 D. Digital simulation only (SPICE cannot do edge detection in .op analysis).",
       "properties": [],
       "defaultValues": {},
       "pinCount": 4,
@@ -786,7 +786,7 @@
       "tagName": "velxio-flip-flop-t",
       "name": "T Flip-Flop",
       "category": "logic",
-      "description": "Toggle flip-flop. On rising CLK, Q ← Q ⊕ T (toggles when T=1). Useful for frequency dividers and counters.",
+      "description": "Toggle flip-flop. On rising CLK, Q \u2190 Q \u2295 T (toggles when T=1). Useful for frequency dividers and counters.",
       "properties": [],
       "defaultValues": {},
       "pinCount": 4,
@@ -899,7 +899,7 @@
       "tagName": "wokwi-ic-74hc14",
       "name": "74HC14 (Hex Schmitt Inverter)",
       "category": "logic",
-      "description": "Six Schmitt-trigger inverters in one 14-pin DIP package. Provides input hysteresis — essential for debouncing noisy signals.",
+      "description": "Six Schmitt-trigger inverters in one 14-pin DIP package. Provides input hysteresis \u2014 essential for debouncing noisy signals.",
       "properties": [],
       "defaultValues": {},
       "pinCount": 14,
@@ -958,7 +958,7 @@
       "tagName": "velxio-opto-4n25",
       "name": "4N25 (Optocoupler)",
       "category": "analog",
-      "description": "Single-channel optocoupler with IR LED + phototransistor. CTR ≈ 50%. Provides galvanic isolation between two circuits.",
+      "description": "Single-channel optocoupler with IR LED + phototransistor. CTR \u2248 50%. Provides galvanic isolation between two circuits.",
       "properties": [],
       "defaultValues": {},
       "pinCount": 4,
@@ -975,7 +975,7 @@
       "tagName": "velxio-opto-pc817",
       "name": "PC817 (Optocoupler)",
       "category": "analog",
-      "description": "Single-channel optocoupler. CTR 80–600% (typ. 100%). Higher drive than 4N25, commonly used for MCU-to-mains isolation.",
+      "description": "Single-channel optocoupler. CTR 80\u2013600% (typ. 100%). Higher drive than 4N25, commonly used for MCU-to-mains isolation.",
       "properties": [],
       "defaultValues": {},
       "pinCount": 4,
@@ -1011,7 +1011,7 @@
           "type": "number",
           "defaultValue": 70,
           "control": "text",
-          "description": "Coil resistance (Ω)"
+          "description": "Coil resistance (\u03a9)"
         },
         {
           "name": "include_flyback",
@@ -1071,7 +1071,7 @@
       "name": "Regulated Power Supply",
       "category": "analog",
       "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\">\n      <rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n      <rect x=\"10\" y=\"14\" width=\"44\" height=\"30\" fill=\"#2a3548\" rx=\"3\" stroke=\"#4a5878\"/>\n      <text x=\"32\" y=\"30\" text-anchor=\"middle\" font-size=\"9\" font-family=\"monospace\" fill=\"#4ade80\" font-weight=\"bold\">5.00V</text>\n      <text x=\"32\" y=\"40\" text-anchor=\"middle\" font-size=\"7\" font-family=\"monospace\" fill=\"#fbbf24\">1.00A</text>\n      <circle cx=\"18\" cy=\"52\" r=\"3\" fill=\"#dc2626\"/>\n      <circle cx=\"46\" cy=\"52\" r=\"3\" fill=\"#0f172a\" stroke=\"#64748b\"/>\n      <text x=\"32\" y=\"60\" text-anchor=\"middle\" font-size=\"6\" fill=\"#9d9d9d\">PSU</text>\n    </svg>",
-      "description": "Bench DC/AC power supply with optional current limit. DC mode for fixed rails (5V, 12V, etc.); AC mode for sine sources. Visually shares the signal-generator chassis so no new Web Component is needed. The current limit is enforced by the circuit verifier — if any load pulls more than the configured amperage, Run is blocked with a 'source-overload' warning, mimicking a real bench supply's foldback behavior.",
+      "description": "Bench DC/AC power supply with optional current limit. DC mode for fixed rails (5V, 12V, etc.); AC mode for sine sources. Visually shares the signal-generator chassis so no new Web Component is needed. The current limit is enforced by the circuit verifier \u2014 if any load pulls more than the configured amperage, Run is blocked with a 'source-overload' warning, mimicking a real bench supply's foldback behavior.",
       "properties": [
         {
           "name": "mode",
@@ -1186,7 +1186,7 @@
       "tagName": "wokwi-capacitor",
       "name": "Cap. ceramic (custom)",
       "category": "passive",
-      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <ellipse cx=\"32\" cy=\"30\" rx=\"14\" ry=\"9\" fill=\"#165696\"/>\n    <ellipse cx=\"28\" cy=\"26\" rx=\"5\" ry=\"3\" fill=\"#3a7cc8\" opacity=\"0.5\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">?µF</text></svg>",
+      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <ellipse cx=\"32\" cy=\"30\" rx=\"14\" ry=\"9\" fill=\"#165696\"/>\n    <ellipse cx=\"28\" cy=\"26\" rx=\"5\" ry=\"3\" fill=\"#3a7cc8\" opacity=\"0.5\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">?\u00b5F</text></svg>",
       "properties": [
         {
           "name": "value",
@@ -1231,9 +1231,9 @@
     {
       "id": "resistor-220",
       "tagName": "wokwi-resistor",
-      "name": "Resistor 220 Ω",
+      "name": "Resistor 220 \u03a9",
       "category": "passive",
-      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"22\" width=\"36\" height=\"17\" rx=\"3\" fill=\"#d5b597\" stroke=\"#a37b4f\" stroke-width=\"0.6\"/>\n    <rect x=\"20\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FB0000\"/>\n    <rect x=\"26\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FB0000\"/>\n    <rect x=\"32\" y=\"22\" width=\"3\" height=\"17\" fill=\"#8F4814\"/>\n    <rect x=\"42\" y=\"22\" width=\"3\" height=\"17\" fill=\"#F1D863\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">220 Ω</text></svg>",
+      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"22\" width=\"36\" height=\"17\" rx=\"3\" fill=\"#d5b597\" stroke=\"#a37b4f\" stroke-width=\"0.6\"/>\n    <rect x=\"20\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FB0000\"/>\n    <rect x=\"26\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FB0000\"/>\n    <rect x=\"32\" y=\"22\" width=\"3\" height=\"17\" fill=\"#8F4814\"/>\n    <rect x=\"42\" y=\"22\" width=\"3\" height=\"17\" fill=\"#F1D863\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">220 \u03a9</text></svg>",
       "properties": [
         {
           "name": "value",
@@ -1249,15 +1249,15 @@
       "tags": [
         "resistor",
         "preset",
-        "220ω"
+        "220\u03c9"
       ]
     },
     {
       "id": "resistor-330",
       "tagName": "wokwi-resistor",
-      "name": "Resistor 330 Ω",
+      "name": "Resistor 330 \u03a9",
       "category": "passive",
-      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"22\" width=\"36\" height=\"17\" rx=\"3\" fill=\"#d5b597\" stroke=\"#a37b4f\" stroke-width=\"0.6\"/>\n    <rect x=\"20\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FC9700\"/>\n    <rect x=\"26\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FC9700\"/>\n    <rect x=\"32\" y=\"22\" width=\"3\" height=\"17\" fill=\"#8F4814\"/>\n    <rect x=\"42\" y=\"22\" width=\"3\" height=\"17\" fill=\"#F1D863\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">330 Ω</text></svg>",
+      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"22\" width=\"36\" height=\"17\" rx=\"3\" fill=\"#d5b597\" stroke=\"#a37b4f\" stroke-width=\"0.6\"/>\n    <rect x=\"20\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FC9700\"/>\n    <rect x=\"26\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FC9700\"/>\n    <rect x=\"32\" y=\"22\" width=\"3\" height=\"17\" fill=\"#8F4814\"/>\n    <rect x=\"42\" y=\"22\" width=\"3\" height=\"17\" fill=\"#F1D863\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">330 \u03a9</text></svg>",
       "properties": [
         {
           "name": "value",
@@ -1273,15 +1273,15 @@
       "tags": [
         "resistor",
         "preset",
-        "330ω"
+        "330\u03c9"
       ]
     },
     {
       "id": "resistor-470",
       "tagName": "wokwi-resistor",
-      "name": "Resistor 470 Ω",
+      "name": "Resistor 470 \u03a9",
       "category": "passive",
-      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"22\" width=\"36\" height=\"17\" rx=\"3\" fill=\"#d5b597\" stroke=\"#a37b4f\" stroke-width=\"0.6\"/>\n    <rect x=\"20\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FCF800\"/>\n    <rect x=\"26\" y=\"22\" width=\"3\" height=\"17\" fill=\"#A803D6\"/>\n    <rect x=\"32\" y=\"22\" width=\"3\" height=\"17\" fill=\"#8F4814\"/>\n    <rect x=\"42\" y=\"22\" width=\"3\" height=\"17\" fill=\"#F1D863\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">470 Ω</text></svg>",
+      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"22\" width=\"36\" height=\"17\" rx=\"3\" fill=\"#d5b597\" stroke=\"#a37b4f\" stroke-width=\"0.6\"/>\n    <rect x=\"20\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FCF800\"/>\n    <rect x=\"26\" y=\"22\" width=\"3\" height=\"17\" fill=\"#A803D6\"/>\n    <rect x=\"32\" y=\"22\" width=\"3\" height=\"17\" fill=\"#8F4814\"/>\n    <rect x=\"42\" y=\"22\" width=\"3\" height=\"17\" fill=\"#F1D863\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">470 \u03a9</text></svg>",
       "properties": [
         {
           "name": "value",
@@ -1297,15 +1297,15 @@
       "tags": [
         "resistor",
         "preset",
-        "470ω"
+        "470\u03c9"
       ]
     },
     {
       "id": "resistor-1k",
       "tagName": "wokwi-resistor",
-      "name": "Resistor 1 kΩ",
+      "name": "Resistor 1 k\u03a9",
       "category": "passive",
-      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"22\" width=\"36\" height=\"17\" rx=\"3\" fill=\"#d5b597\" stroke=\"#a37b4f\" stroke-width=\"0.6\"/>\n    <rect x=\"20\" y=\"22\" width=\"3\" height=\"17\" fill=\"#8F4814\"/>\n    <rect x=\"26\" y=\"22\" width=\"3\" height=\"17\" fill=\"#000\"/>\n    <rect x=\"32\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FB0000\"/>\n    <rect x=\"42\" y=\"22\" width=\"3\" height=\"17\" fill=\"#F1D863\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">1 kΩ</text></svg>",
+      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"22\" width=\"36\" height=\"17\" rx=\"3\" fill=\"#d5b597\" stroke=\"#a37b4f\" stroke-width=\"0.6\"/>\n    <rect x=\"20\" y=\"22\" width=\"3\" height=\"17\" fill=\"#8F4814\"/>\n    <rect x=\"26\" y=\"22\" width=\"3\" height=\"17\" fill=\"#000\"/>\n    <rect x=\"32\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FB0000\"/>\n    <rect x=\"42\" y=\"22\" width=\"3\" height=\"17\" fill=\"#F1D863\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">1 k\u03a9</text></svg>",
       "properties": [
         {
           "name": "value",
@@ -1321,15 +1321,15 @@
       "tags": [
         "resistor",
         "preset",
-        "1kω"
+        "1k\u03c9"
       ]
     },
     {
       "id": "resistor-2k2",
       "tagName": "wokwi-resistor",
-      "name": "Resistor 2.2 kΩ",
+      "name": "Resistor 2.2 k\u03a9",
       "category": "passive",
-      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"22\" width=\"36\" height=\"17\" rx=\"3\" fill=\"#d5b597\" stroke=\"#a37b4f\" stroke-width=\"0.6\"/>\n    <rect x=\"20\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FB0000\"/>\n    <rect x=\"26\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FB0000\"/>\n    <rect x=\"32\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FB0000\"/>\n    <rect x=\"42\" y=\"22\" width=\"3\" height=\"17\" fill=\"#F1D863\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">2.2 kΩ</text></svg>",
+      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"22\" width=\"36\" height=\"17\" rx=\"3\" fill=\"#d5b597\" stroke=\"#a37b4f\" stroke-width=\"0.6\"/>\n    <rect x=\"20\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FB0000\"/>\n    <rect x=\"26\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FB0000\"/>\n    <rect x=\"32\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FB0000\"/>\n    <rect x=\"42\" y=\"22\" width=\"3\" height=\"17\" fill=\"#F1D863\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">2.2 k\u03a9</text></svg>",
       "properties": [
         {
           "name": "value",
@@ -1345,15 +1345,15 @@
       "tags": [
         "resistor",
         "preset",
-        "2.2kω"
+        "2.2k\u03c9"
       ]
     },
     {
       "id": "resistor-4k7",
       "tagName": "wokwi-resistor",
-      "name": "Resistor 4.7 kΩ",
+      "name": "Resistor 4.7 k\u03a9",
       "category": "passive",
-      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"22\" width=\"36\" height=\"17\" rx=\"3\" fill=\"#d5b597\" stroke=\"#a37b4f\" stroke-width=\"0.6\"/>\n    <rect x=\"20\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FCF800\"/>\n    <rect x=\"26\" y=\"22\" width=\"3\" height=\"17\" fill=\"#A803D6\"/>\n    <rect x=\"32\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FB0000\"/>\n    <rect x=\"42\" y=\"22\" width=\"3\" height=\"17\" fill=\"#F1D863\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">4.7 kΩ</text></svg>",
+      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"22\" width=\"36\" height=\"17\" rx=\"3\" fill=\"#d5b597\" stroke=\"#a37b4f\" stroke-width=\"0.6\"/>\n    <rect x=\"20\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FCF800\"/>\n    <rect x=\"26\" y=\"22\" width=\"3\" height=\"17\" fill=\"#A803D6\"/>\n    <rect x=\"32\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FB0000\"/>\n    <rect x=\"42\" y=\"22\" width=\"3\" height=\"17\" fill=\"#F1D863\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">4.7 k\u03a9</text></svg>",
       "properties": [
         {
           "name": "value",
@@ -1369,15 +1369,15 @@
       "tags": [
         "resistor",
         "preset",
-        "4.7kω"
+        "4.7k\u03c9"
       ]
     },
     {
       "id": "resistor-10k",
       "tagName": "wokwi-resistor",
-      "name": "Resistor 10 kΩ",
+      "name": "Resistor 10 k\u03a9",
       "category": "passive",
-      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"22\" width=\"36\" height=\"17\" rx=\"3\" fill=\"#d5b597\" stroke=\"#a37b4f\" stroke-width=\"0.6\"/>\n    <rect x=\"20\" y=\"22\" width=\"3\" height=\"17\" fill=\"#8F4814\"/>\n    <rect x=\"26\" y=\"22\" width=\"3\" height=\"17\" fill=\"#000\"/>\n    <rect x=\"32\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FC9700\"/>\n    <rect x=\"42\" y=\"22\" width=\"3\" height=\"17\" fill=\"#F1D863\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">10 kΩ</text></svg>",
+      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"22\" width=\"36\" height=\"17\" rx=\"3\" fill=\"#d5b597\" stroke=\"#a37b4f\" stroke-width=\"0.6\"/>\n    <rect x=\"20\" y=\"22\" width=\"3\" height=\"17\" fill=\"#8F4814\"/>\n    <rect x=\"26\" y=\"22\" width=\"3\" height=\"17\" fill=\"#000\"/>\n    <rect x=\"32\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FC9700\"/>\n    <rect x=\"42\" y=\"22\" width=\"3\" height=\"17\" fill=\"#F1D863\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">10 k\u03a9</text></svg>",
       "properties": [
         {
           "name": "value",
@@ -1393,15 +1393,15 @@
       "tags": [
         "resistor",
         "preset",
-        "10kω"
+        "10k\u03c9"
       ]
     },
     {
       "id": "resistor-22k",
       "tagName": "wokwi-resistor",
-      "name": "Resistor 22 kΩ",
+      "name": "Resistor 22 k\u03a9",
       "category": "passive",
-      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"22\" width=\"36\" height=\"17\" rx=\"3\" fill=\"#d5b597\" stroke=\"#a37b4f\" stroke-width=\"0.6\"/>\n    <rect x=\"20\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FB0000\"/>\n    <rect x=\"26\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FB0000\"/>\n    <rect x=\"32\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FC9700\"/>\n    <rect x=\"42\" y=\"22\" width=\"3\" height=\"17\" fill=\"#F1D863\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">22 kΩ</text></svg>",
+      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"22\" width=\"36\" height=\"17\" rx=\"3\" fill=\"#d5b597\" stroke=\"#a37b4f\" stroke-width=\"0.6\"/>\n    <rect x=\"20\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FB0000\"/>\n    <rect x=\"26\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FB0000\"/>\n    <rect x=\"32\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FC9700\"/>\n    <rect x=\"42\" y=\"22\" width=\"3\" height=\"17\" fill=\"#F1D863\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">22 k\u03a9</text></svg>",
       "properties": [
         {
           "name": "value",
@@ -1417,15 +1417,15 @@
       "tags": [
         "resistor",
         "preset",
-        "22kω"
+        "22k\u03c9"
       ]
     },
     {
       "id": "resistor-47k",
       "tagName": "wokwi-resistor",
-      "name": "Resistor 47 kΩ",
+      "name": "Resistor 47 k\u03a9",
       "category": "passive",
-      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"22\" width=\"36\" height=\"17\" rx=\"3\" fill=\"#d5b597\" stroke=\"#a37b4f\" stroke-width=\"0.6\"/>\n    <rect x=\"20\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FCF800\"/>\n    <rect x=\"26\" y=\"22\" width=\"3\" height=\"17\" fill=\"#A803D6\"/>\n    <rect x=\"32\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FC9700\"/>\n    <rect x=\"42\" y=\"22\" width=\"3\" height=\"17\" fill=\"#F1D863\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">47 kΩ</text></svg>",
+      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"22\" width=\"36\" height=\"17\" rx=\"3\" fill=\"#d5b597\" stroke=\"#a37b4f\" stroke-width=\"0.6\"/>\n    <rect x=\"20\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FCF800\"/>\n    <rect x=\"26\" y=\"22\" width=\"3\" height=\"17\" fill=\"#A803D6\"/>\n    <rect x=\"32\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FC9700\"/>\n    <rect x=\"42\" y=\"22\" width=\"3\" height=\"17\" fill=\"#F1D863\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">47 k\u03a9</text></svg>",
       "properties": [
         {
           "name": "value",
@@ -1441,15 +1441,15 @@
       "tags": [
         "resistor",
         "preset",
-        "47kω"
+        "47k\u03c9"
       ]
     },
     {
       "id": "resistor-100k",
       "tagName": "wokwi-resistor",
-      "name": "Resistor 100 kΩ",
+      "name": "Resistor 100 k\u03a9",
       "category": "passive",
-      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"22\" width=\"36\" height=\"17\" rx=\"3\" fill=\"#d5b597\" stroke=\"#a37b4f\" stroke-width=\"0.6\"/>\n    <rect x=\"20\" y=\"22\" width=\"3\" height=\"17\" fill=\"#8F4814\"/>\n    <rect x=\"26\" y=\"22\" width=\"3\" height=\"17\" fill=\"#000\"/>\n    <rect x=\"32\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FCF800\"/>\n    <rect x=\"42\" y=\"22\" width=\"3\" height=\"17\" fill=\"#F1D863\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">100 kΩ</text></svg>",
+      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"22\" width=\"36\" height=\"17\" rx=\"3\" fill=\"#d5b597\" stroke=\"#a37b4f\" stroke-width=\"0.6\"/>\n    <rect x=\"20\" y=\"22\" width=\"3\" height=\"17\" fill=\"#8F4814\"/>\n    <rect x=\"26\" y=\"22\" width=\"3\" height=\"17\" fill=\"#000\"/>\n    <rect x=\"32\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FCF800\"/>\n    <rect x=\"42\" y=\"22\" width=\"3\" height=\"17\" fill=\"#F1D863\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">100 k\u03a9</text></svg>",
       "properties": [
         {
           "name": "value",
@@ -1465,15 +1465,15 @@
       "tags": [
         "resistor",
         "preset",
-        "100kω"
+        "100k\u03c9"
       ]
     },
     {
       "id": "resistor-1m",
       "tagName": "wokwi-resistor",
-      "name": "Resistor 1 MΩ",
+      "name": "Resistor 1 M\u03a9",
       "category": "passive",
-      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"22\" width=\"36\" height=\"17\" rx=\"3\" fill=\"#d5b597\" stroke=\"#a37b4f\" stroke-width=\"0.6\"/>\n    <rect x=\"20\" y=\"22\" width=\"3\" height=\"17\" fill=\"#8F4814\"/>\n    <rect x=\"26\" y=\"22\" width=\"3\" height=\"17\" fill=\"#000\"/>\n    <rect x=\"32\" y=\"22\" width=\"3\" height=\"17\" fill=\"#00B800\"/>\n    <rect x=\"42\" y=\"22\" width=\"3\" height=\"17\" fill=\"#F1D863\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">1 MΩ</text></svg>",
+      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"22\" width=\"36\" height=\"17\" rx=\"3\" fill=\"#d5b597\" stroke=\"#a37b4f\" stroke-width=\"0.6\"/>\n    <rect x=\"20\" y=\"22\" width=\"3\" height=\"17\" fill=\"#8F4814\"/>\n    <rect x=\"26\" y=\"22\" width=\"3\" height=\"17\" fill=\"#000\"/>\n    <rect x=\"32\" y=\"22\" width=\"3\" height=\"17\" fill=\"#00B800\"/>\n    <rect x=\"42\" y=\"22\" width=\"3\" height=\"17\" fill=\"#F1D863\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">1 M\u03a9</text></svg>",
       "properties": [
         {
           "name": "value",
@@ -1489,7 +1489,7 @@
       "tags": [
         "resistor",
         "preset",
-        "1mω"
+        "1m\u03c9"
       ]
     },
     {
@@ -1645,9 +1645,9 @@
     {
       "id": "cap-1u",
       "tagName": "wokwi-capacitor",
-      "name": "Cap. 1 µF",
+      "name": "Cap. 1 \u00b5F",
       "category": "passive",
-      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <ellipse cx=\"32\" cy=\"30\" rx=\"14\" ry=\"9\" fill=\"#165696\"/>\n    <ellipse cx=\"28\" cy=\"26\" rx=\"5\" ry=\"3\" fill=\"#3a7cc8\" opacity=\"0.5\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">1 µF</text></svg>",
+      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <ellipse cx=\"32\" cy=\"30\" rx=\"14\" ry=\"9\" fill=\"#165696\"/>\n    <ellipse cx=\"28\" cy=\"26\" rx=\"5\" ry=\"3\" fill=\"#3a7cc8\" opacity=\"0.5\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">1 \u00b5F</text></svg>",
       "properties": [
         {
           "name": "value",
@@ -1664,7 +1664,7 @@
         "capacitor",
         "ceramic",
         "preset",
-        "1µf"
+        "1\u00b5f"
       ]
     },
     {
@@ -1672,7 +1672,7 @@
       "tagName": "velxio-capacitor-electrolytic",
       "name": "Electrolytic Cap. (custom)",
       "category": "passive",
-      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"20\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"40\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"10\" width=\"36\" height=\"32\" rx=\"2\" fill=\"#1f3b6b\"/>\n    <ellipse cx=\"32\" cy=\"10\" rx=\"18\" ry=\"3\" fill=\"#2a4d8a\"/>\n    <rect x=\"38\" y=\"10\" width=\"12\" height=\"32\" rx=\"2\" fill=\"#dfe3ec\"/>\n    <text x=\"44\" y=\"22\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">−</text>\n    <text x=\"44\" y=\"34\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">−</text>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">?µF</text></svg>",
+      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"20\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"40\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"10\" width=\"36\" height=\"32\" rx=\"2\" fill=\"#1f3b6b\"/>\n    <ellipse cx=\"32\" cy=\"10\" rx=\"18\" ry=\"3\" fill=\"#2a4d8a\"/>\n    <rect x=\"38\" y=\"10\" width=\"12\" height=\"32\" rx=\"2\" fill=\"#dfe3ec\"/>\n    <text x=\"44\" y=\"22\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">\u2212</text>\n    <text x=\"44\" y=\"34\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">\u2212</text>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">?\u00b5F</text></svg>",
       "properties": [
         {
           "name": "value",
@@ -1714,9 +1714,9 @@
     {
       "id": "cap-elec-1u",
       "tagName": "velxio-capacitor-electrolytic",
-      "name": "Electrolytic 1 µF",
+      "name": "Electrolytic 1 \u00b5F",
       "category": "passive",
-      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"20\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"40\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"10\" width=\"36\" height=\"32\" rx=\"2\" fill=\"#1f3b6b\"/>\n    <ellipse cx=\"32\" cy=\"10\" rx=\"18\" ry=\"3\" fill=\"#2a4d8a\"/>\n    <rect x=\"38\" y=\"10\" width=\"12\" height=\"32\" rx=\"2\" fill=\"#dfe3ec\"/>\n    <text x=\"44\" y=\"22\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">−</text>\n    <text x=\"44\" y=\"34\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">−</text>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">1 µF</text></svg>",
+      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"20\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"40\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"10\" width=\"36\" height=\"32\" rx=\"2\" fill=\"#1f3b6b\"/>\n    <ellipse cx=\"32\" cy=\"10\" rx=\"18\" ry=\"3\" fill=\"#2a4d8a\"/>\n    <rect x=\"38\" y=\"10\" width=\"12\" height=\"32\" rx=\"2\" fill=\"#dfe3ec\"/>\n    <text x=\"44\" y=\"22\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">\u2212</text>\n    <text x=\"44\" y=\"34\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">\u2212</text>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">1 \u00b5F</text></svg>",
       "properties": [
         {
           "name": "value",
@@ -1753,15 +1753,15 @@
         "electrolytic",
         "polarized",
         "preset",
-        "1µf"
+        "1\u00b5f"
       ]
     },
     {
       "id": "cap-elec-10u",
       "tagName": "velxio-capacitor-electrolytic",
-      "name": "Electrolytic 10 µF",
+      "name": "Electrolytic 10 \u00b5F",
       "category": "passive",
-      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"20\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"40\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"10\" width=\"36\" height=\"32\" rx=\"2\" fill=\"#1f3b6b\"/>\n    <ellipse cx=\"32\" cy=\"10\" rx=\"18\" ry=\"3\" fill=\"#2a4d8a\"/>\n    <rect x=\"38\" y=\"10\" width=\"12\" height=\"32\" rx=\"2\" fill=\"#dfe3ec\"/>\n    <text x=\"44\" y=\"22\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">−</text>\n    <text x=\"44\" y=\"34\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">−</text>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">10 µF</text></svg>",
+      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"20\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"40\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"10\" width=\"36\" height=\"32\" rx=\"2\" fill=\"#1f3b6b\"/>\n    <ellipse cx=\"32\" cy=\"10\" rx=\"18\" ry=\"3\" fill=\"#2a4d8a\"/>\n    <rect x=\"38\" y=\"10\" width=\"12\" height=\"32\" rx=\"2\" fill=\"#dfe3ec\"/>\n    <text x=\"44\" y=\"22\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">\u2212</text>\n    <text x=\"44\" y=\"34\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">\u2212</text>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">10 \u00b5F</text></svg>",
       "properties": [
         {
           "name": "value",
@@ -1798,15 +1798,15 @@
         "electrolytic",
         "polarized",
         "preset",
-        "10µf"
+        "10\u00b5f"
       ]
     },
     {
       "id": "cap-elec-47u",
       "tagName": "velxio-capacitor-electrolytic",
-      "name": "Electrolytic 47 µF",
+      "name": "Electrolytic 47 \u00b5F",
       "category": "passive",
-      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"20\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"40\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"10\" width=\"36\" height=\"32\" rx=\"2\" fill=\"#1f3b6b\"/>\n    <ellipse cx=\"32\" cy=\"10\" rx=\"18\" ry=\"3\" fill=\"#2a4d8a\"/>\n    <rect x=\"38\" y=\"10\" width=\"12\" height=\"32\" rx=\"2\" fill=\"#dfe3ec\"/>\n    <text x=\"44\" y=\"22\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">−</text>\n    <text x=\"44\" y=\"34\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">−</text>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">47 µF</text></svg>",
+      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"20\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"40\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"10\" width=\"36\" height=\"32\" rx=\"2\" fill=\"#1f3b6b\"/>\n    <ellipse cx=\"32\" cy=\"10\" rx=\"18\" ry=\"3\" fill=\"#2a4d8a\"/>\n    <rect x=\"38\" y=\"10\" width=\"12\" height=\"32\" rx=\"2\" fill=\"#dfe3ec\"/>\n    <text x=\"44\" y=\"22\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">\u2212</text>\n    <text x=\"44\" y=\"34\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">\u2212</text>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">47 \u00b5F</text></svg>",
       "properties": [
         {
           "name": "value",
@@ -1843,15 +1843,15 @@
         "electrolytic",
         "polarized",
         "preset",
-        "47µf"
+        "47\u00b5f"
       ]
     },
     {
       "id": "cap-elec-100u",
       "tagName": "velxio-capacitor-electrolytic",
-      "name": "Electrolytic 100 µF",
+      "name": "Electrolytic 100 \u00b5F",
       "category": "passive",
-      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"20\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"40\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"10\" width=\"36\" height=\"32\" rx=\"2\" fill=\"#1f3b6b\"/>\n    <ellipse cx=\"32\" cy=\"10\" rx=\"18\" ry=\"3\" fill=\"#2a4d8a\"/>\n    <rect x=\"38\" y=\"10\" width=\"12\" height=\"32\" rx=\"2\" fill=\"#dfe3ec\"/>\n    <text x=\"44\" y=\"22\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">−</text>\n    <text x=\"44\" y=\"34\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">−</text>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">100 µF</text></svg>",
+      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"20\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"40\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"10\" width=\"36\" height=\"32\" rx=\"2\" fill=\"#1f3b6b\"/>\n    <ellipse cx=\"32\" cy=\"10\" rx=\"18\" ry=\"3\" fill=\"#2a4d8a\"/>\n    <rect x=\"38\" y=\"10\" width=\"12\" height=\"32\" rx=\"2\" fill=\"#dfe3ec\"/>\n    <text x=\"44\" y=\"22\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">\u2212</text>\n    <text x=\"44\" y=\"34\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">\u2212</text>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">100 \u00b5F</text></svg>",
       "properties": [
         {
           "name": "value",
@@ -1888,15 +1888,15 @@
         "electrolytic",
         "polarized",
         "preset",
-        "100µf"
+        "100\u00b5f"
       ]
     },
     {
       "id": "cap-elec-470u",
       "tagName": "velxio-capacitor-electrolytic",
-      "name": "Electrolytic 470 µF",
+      "name": "Electrolytic 470 \u00b5F",
       "category": "passive",
-      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"20\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"40\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"10\" width=\"36\" height=\"32\" rx=\"2\" fill=\"#1f3b6b\"/>\n    <ellipse cx=\"32\" cy=\"10\" rx=\"18\" ry=\"3\" fill=\"#2a4d8a\"/>\n    <rect x=\"38\" y=\"10\" width=\"12\" height=\"32\" rx=\"2\" fill=\"#dfe3ec\"/>\n    <text x=\"44\" y=\"22\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">−</text>\n    <text x=\"44\" y=\"34\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">−</text>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">470 µF</text></svg>",
+      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"20\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"40\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"10\" width=\"36\" height=\"32\" rx=\"2\" fill=\"#1f3b6b\"/>\n    <ellipse cx=\"32\" cy=\"10\" rx=\"18\" ry=\"3\" fill=\"#2a4d8a\"/>\n    <rect x=\"38\" y=\"10\" width=\"12\" height=\"32\" rx=\"2\" fill=\"#dfe3ec\"/>\n    <text x=\"44\" y=\"22\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">\u2212</text>\n    <text x=\"44\" y=\"34\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">\u2212</text>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">470 \u00b5F</text></svg>",
       "properties": [
         {
           "name": "value",
@@ -1933,15 +1933,15 @@
         "electrolytic",
         "polarized",
         "preset",
-        "470µf"
+        "470\u00b5f"
       ]
     },
     {
       "id": "cap-elec-1000u",
       "tagName": "velxio-capacitor-electrolytic",
-      "name": "Electrolytic 1000 µF",
+      "name": "Electrolytic 1000 \u00b5F",
       "category": "passive",
-      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"20\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"40\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"10\" width=\"36\" height=\"32\" rx=\"2\" fill=\"#1f3b6b\"/>\n    <ellipse cx=\"32\" cy=\"10\" rx=\"18\" ry=\"3\" fill=\"#2a4d8a\"/>\n    <rect x=\"38\" y=\"10\" width=\"12\" height=\"32\" rx=\"2\" fill=\"#dfe3ec\"/>\n    <text x=\"44\" y=\"22\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">−</text>\n    <text x=\"44\" y=\"34\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">−</text>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">1000 µF</text></svg>",
+      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"20\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"40\" y=\"40\" width=\"2.5\" height=\"9\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"10\" width=\"36\" height=\"32\" rx=\"2\" fill=\"#1f3b6b\"/>\n    <ellipse cx=\"32\" cy=\"10\" rx=\"18\" ry=\"3\" fill=\"#2a4d8a\"/>\n    <rect x=\"38\" y=\"10\" width=\"12\" height=\"32\" rx=\"2\" fill=\"#dfe3ec\"/>\n    <text x=\"44\" y=\"22\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">\u2212</text>\n    <text x=\"44\" y=\"34\" text-anchor=\"middle\" font-size=\"10\" font-weight=\"bold\" fill=\"#1f3b6b\">\u2212</text>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">1000 \u00b5F</text></svg>",
       "properties": [
         {
           "name": "value",
@@ -1978,15 +1978,15 @@
         "electrolytic",
         "polarized",
         "preset",
-        "1000µf"
+        "1000\u00b5f"
       ]
     },
     {
       "id": "ind-100u",
       "tagName": "wokwi-inductor",
-      "name": "Inductor 100 µH",
+      "name": "Inductor 100 \u00b5H",
       "category": "passive",
-      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <path d=\"M 12 30 Q 16 18 20 30 Q 24 18 28 30 Q 32 18 36 30 Q 40 18 44 30 Q 48 18 52 30\"\n          fill=\"none\" stroke=\"#B23820\" stroke-width=\"2.5\" stroke-linecap=\"round\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">100 µH</text></svg>",
+      "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <path d=\"M 12 30 Q 16 18 20 30 Q 24 18 28 30 Q 32 18 36 30 Q 40 18 44 30 Q 48 18 52 30\"\n          fill=\"none\" stroke=\"#B23820\" stroke-width=\"2.5\" stroke-linecap=\"round\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">100 \u00b5H</text></svg>",
       "properties": [
         {
           "name": "value",
@@ -2002,7 +2002,7 @@
       "tags": [
         "inductor",
         "preset",
-        "100µh"
+        "100\u00b5h"
       ]
     },
     {
@@ -2054,10 +2054,10 @@
       ]
     },
     {
-      "$comment": "ePaper / e-Ink panels — Velxio-native components. The Web Component is `velxio-epaper`; the panel size + palette is selected via the `panelKind` property. See docs/wiki/epaper-emulation.md.",
+      "$comment": "ePaper / e-Ink panels \u2014 Velxio-native components. The Web Component is `velxio-epaper`; the panel size + palette is selected via the `panelKind` property. See docs/wiki/epaper-emulation.md.",
       "id": "epaper-1in54-bw",
       "tagName": "velxio-epaper",
-      "name": "ePaper 1.54\" (200×200, B/W)",
+      "name": "ePaper 1.54\" (200\u00d7200, B/W)",
       "category": "displays",
       "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect x=\"4\" y=\"6\" width=\"56\" height=\"48\" rx=\"3\" fill=\"#e8e2d4\" stroke=\"#b8aa90\"/><rect x=\"10\" y=\"12\" width=\"44\" height=\"36\" fill=\"#f4f1e8\" stroke=\"#a89a80\"/><text x=\"32\" y=\"34\" text-anchor=\"middle\" font-size=\"7\" fill=\"#5a5040\" font-family=\"monospace\">e-Paper</text><rect x=\"22\" y=\"54\" width=\"20\" height=\"6\" fill=\"#d49a3c\"/></svg>",
       "properties": [
@@ -2093,7 +2093,7 @@
     {
       "id": "epaper-2in13-bw",
       "tagName": "velxio-epaper",
-      "name": "ePaper 2.13\" (250×122, B/W)",
+      "name": "ePaper 2.13\" (250\u00d7122, B/W)",
       "category": "displays",
       "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect x=\"2\" y=\"18\" width=\"60\" height=\"30\" rx=\"3\" fill=\"#e8e2d4\" stroke=\"#b8aa90\"/><rect x=\"6\" y=\"22\" width=\"52\" height=\"22\" fill=\"#f4f1e8\" stroke=\"#a89a80\"/><text x=\"32\" y=\"36\" text-anchor=\"middle\" font-size=\"6\" fill=\"#5a5040\" font-family=\"monospace\">2.13\"</text><rect x=\"24\" y=\"48\" width=\"16\" height=\"5\" fill=\"#d49a3c\"/></svg>",
       "properties": [
@@ -2130,7 +2130,7 @@
     {
       "id": "epaper-2in13-bwr",
       "tagName": "velxio-epaper",
-      "name": "ePaper 2.13\" (250×122, B/W/Red)",
+      "name": "ePaper 2.13\" (250\u00d7122, B/W/Red)",
       "category": "displays",
       "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect x=\"2\" y=\"18\" width=\"60\" height=\"30\" rx=\"3\" fill=\"#e8e2d4\" stroke=\"#b8aa90\"/><rect x=\"6\" y=\"22\" width=\"52\" height=\"22\" fill=\"#f4f1e8\" stroke=\"#a89a80\"/><circle cx=\"15\" cy=\"32\" r=\"3\" fill=\"#c01818\"/><text x=\"38\" y=\"36\" text-anchor=\"middle\" font-size=\"6\" fill=\"#5a5040\" font-family=\"monospace\">B/W/R</text><rect x=\"24\" y=\"48\" width=\"16\" height=\"5\" fill=\"#d49a3c\"/></svg>",
       "properties": [
@@ -2168,7 +2168,7 @@
     {
       "id": "epaper-2in9-bw",
       "tagName": "velxio-epaper",
-      "name": "ePaper 2.9\" (296×128, B/W)",
+      "name": "ePaper 2.9\" (296\u00d7128, B/W)",
       "category": "displays",
       "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect x=\"2\" y=\"16\" width=\"60\" height=\"34\" rx=\"3\" fill=\"#e8e2d4\" stroke=\"#b8aa90\"/><rect x=\"6\" y=\"20\" width=\"52\" height=\"26\" fill=\"#f4f1e8\" stroke=\"#a89a80\"/><text x=\"32\" y=\"36\" text-anchor=\"middle\" font-size=\"6\" fill=\"#5a5040\" font-family=\"monospace\">2.9\"</text><rect x=\"24\" y=\"50\" width=\"16\" height=\"5\" fill=\"#d49a3c\"/></svg>",
       "properties": [
@@ -2204,7 +2204,7 @@
     {
       "id": "epaper-2in9-bwr",
       "tagName": "velxio-epaper",
-      "name": "ePaper 2.9\" (296×128, B/W/Red)",
+      "name": "ePaper 2.9\" (296\u00d7128, B/W/Red)",
       "category": "displays",
       "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect x=\"2\" y=\"16\" width=\"60\" height=\"34\" rx=\"3\" fill=\"#e8e2d4\" stroke=\"#b8aa90\"/><rect x=\"6\" y=\"20\" width=\"52\" height=\"26\" fill=\"#f4f1e8\" stroke=\"#a89a80\"/><circle cx=\"15\" cy=\"32\" r=\"3\" fill=\"#c01818\"/><text x=\"38\" y=\"36\" text-anchor=\"middle\" font-size=\"6\" fill=\"#5a5040\" font-family=\"monospace\">B/W/R</text><rect x=\"24\" y=\"50\" width=\"16\" height=\"5\" fill=\"#d49a3c\"/></svg>",
       "properties": [
@@ -2242,7 +2242,7 @@
     {
       "id": "epaper-4in2-bw",
       "tagName": "velxio-epaper",
-      "name": "ePaper 4.2\" (400×300, B/W)",
+      "name": "ePaper 4.2\" (400\u00d7300, B/W)",
       "category": "displays",
       "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect x=\"2\" y=\"6\" width=\"60\" height=\"50\" rx=\"3\" fill=\"#e8e2d4\" stroke=\"#b8aa90\"/><rect x=\"6\" y=\"10\" width=\"52\" height=\"38\" fill=\"#f4f1e8\" stroke=\"#a89a80\"/><text x=\"32\" y=\"32\" text-anchor=\"middle\" font-size=\"7\" fill=\"#5a5040\" font-family=\"monospace\">4.2\"</text><rect x=\"24\" y=\"56\" width=\"16\" height=\"5\" fill=\"#d49a3c\"/></svg>",
       "properties": [
@@ -2279,7 +2279,7 @@
     {
       "id": "epaper-7in5-bw",
       "tagName": "velxio-epaper",
-      "name": "ePaper 7.5\" (800×480, B/W)",
+      "name": "ePaper 7.5\" (800\u00d7480, B/W)",
       "category": "displays",
       "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect x=\"1\" y=\"4\" width=\"62\" height=\"54\" rx=\"3\" fill=\"#e8e2d4\" stroke=\"#b8aa90\"/><rect x=\"5\" y=\"8\" width=\"54\" height=\"42\" fill=\"#f4f1e8\" stroke=\"#a89a80\"/><text x=\"32\" y=\"32\" text-anchor=\"middle\" font-size=\"8\" fill=\"#5a5040\" font-family=\"monospace\">7.5\"</text><rect x=\"24\" y=\"58\" width=\"16\" height=\"5\" fill=\"#d49a3c\"/></svg>",
       "properties": [
@@ -2316,7 +2316,7 @@
     {
       "id": "epaper-5in65-7c",
       "tagName": "velxio-epaper",
-      "name": "ePaper 5.65\" (600×448, ACeP 7-colour)",
+      "name": "ePaper 5.65\" (600\u00d7448, ACeP 7-colour)",
       "category": "displays",
       "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect x=\"2\" y=\"6\" width=\"60\" height=\"50\" rx=\"3\" fill=\"#e8e2d4\" stroke=\"#b8aa90\"/><rect x=\"6\" y=\"10\" width=\"52\" height=\"38\" fill=\"#f4f1e8\" stroke=\"#a89a80\"/><circle cx=\"14\" cy=\"19\" r=\"3\" fill=\"#202020\"/><circle cx=\"22\" cy=\"19\" r=\"3\" fill=\"#c01010\"/><circle cx=\"30\" cy=\"19\" r=\"3\" fill=\"#20a040\"/><circle cx=\"38\" cy=\"19\" r=\"3\" fill=\"#3060c0\"/><circle cx=\"46\" cy=\"19\" r=\"3\" fill=\"#e0c830\"/><circle cx=\"54\" cy=\"19\" r=\"3\" fill=\"#e08020\"/><text x=\"32\" y=\"38\" text-anchor=\"middle\" font-size=\"6\" fill=\"#5a5040\" font-family=\"monospace\">ACeP 7</text><rect x=\"24\" y=\"56\" width=\"16\" height=\"5\" fill=\"#d49a3c\"/></svg>",
       "properties": [
@@ -2457,7 +2457,7 @@
       ]
     },
     {
-      "$comment": "4-pin I2C-only SSD1306 module (GND/VCC/SCL/SDA) — the cheap 0.96\" OLED most beginners have; velxio-ssd1306-i2c native element. Counterpart to the 8-pin wokwi-ssd1306. Issue #215.",
+      "$comment": "4-pin I2C-only SSD1306 module (GND/VCC/SCL/SDA) \u2014 the cheap 0.96\" OLED most beginners have; velxio-ssd1306-i2c native element. Counterpart to the 8-pin wokwi-ssd1306. Issue #215.",
       "id": "ssd1306-i2c-4pin",
       "tagName": "velxio-ssd1306-i2c-4pin",
       "name": "SSD1306 OLED (I2C, 4-pin)",
@@ -2537,7 +2537,7 @@
           "type": "number",
           "defaultValue": 25,
           "control": "number",
-          "description": "On-chip temperature sensor (°C), readable at registers 0x11/0x12"
+          "description": "On-chip temperature sensor (\u00b0C), readable at registers 0x11/0x12"
         }
       ],
       "defaultValues": {
@@ -2671,11 +2671,11 @@
   },
   "resistor": {
     "name": "Resistor (custom)",
-    "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"22\" width=\"36\" height=\"17\" rx=\"3\" fill=\"#d5b597\" stroke=\"#a37b4f\" stroke-width=\"0.6\"/>\n    <rect x=\"20\" y=\"22\" width=\"3\" height=\"17\" fill=\"#8F4814\"/>\n    <rect x=\"26\" y=\"22\" width=\"3\" height=\"17\" fill=\"#000\"/>\n    <rect x=\"32\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FB0000\"/>\n    <rect x=\"42\" y=\"22\" width=\"3\" height=\"17\" fill=\"#F1D863\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">?Ω</text></svg>"
+    "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <rect x=\"14\" y=\"22\" width=\"36\" height=\"17\" rx=\"3\" fill=\"#d5b597\" stroke=\"#a37b4f\" stroke-width=\"0.6\"/>\n    <rect x=\"20\" y=\"22\" width=\"3\" height=\"17\" fill=\"#8F4814\"/>\n    <rect x=\"26\" y=\"22\" width=\"3\" height=\"17\" fill=\"#000\"/>\n    <rect x=\"32\" y=\"22\" width=\"3\" height=\"17\" fill=\"#FB0000\"/>\n    <rect x=\"42\" y=\"22\" width=\"3\" height=\"17\" fill=\"#F1D863\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">?\u03a9</text></svg>"
   },
   "capacitor": {
     "name": "Cap. ceramic (custom)",
-    "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <ellipse cx=\"32\" cy=\"30\" rx=\"14\" ry=\"9\" fill=\"#165696\"/>\n    <ellipse cx=\"28\" cy=\"26\" rx=\"5\" ry=\"3\" fill=\"#3a7cc8\" opacity=\"0.5\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">?µF</text></svg>"
+    "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" fill=\"#1a2332\" rx=\"4\"/>\n    <rect x=\"6\" y=\"29\" width=\"52\" height=\"3\" fill=\"#aaa\"/>\n    <ellipse cx=\"32\" cy=\"30\" rx=\"14\" ry=\"9\" fill=\"#165696\"/>\n    <ellipse cx=\"28\" cy=\"26\" rx=\"5\" ry=\"3\" fill=\"#3a7cc8\" opacity=\"0.5\"/>\n    <text x=\"32\" y=\"56\" text-anchor=\"middle\" font-size=\"10\" font-family=\"sans-serif\" fill=\"#e5e7eb\" font-weight=\"bold\">?\u00b5F</text></svg>"
   },
   "inductor": {
     "name": "Inductor (custom)",
@@ -2730,5 +2730,84 @@
       "sensor"
     ],
     "thumbnail": "<svg width=\"64\" height=\"64\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"64\" height=\"64\" rx=\"4\" fill=\"#101820\"/><rect x=\"8\" y=\"12\" width=\"48\" height=\"40\" rx=\"3\" fill=\"#1c5aa8\" stroke=\"#2f7fd6\" stroke-width=\"0.8\"/><circle cx=\"21\" cy=\"26\" r=\"6\" fill=\"#0d2b52\" stroke=\"#6fa8dc\" stroke-width=\"0.8\"/><circle cx=\"21\" cy=\"26\" r=\"2.6\" fill=\"#e04b5a\"/><rect x=\"33\" y=\"20\" width=\"9\" height=\"12\" rx=\"1.5\" fill=\"#0b1c33\" stroke=\"#6fa8dc\" stroke-width=\"0.7\"/><path d=\"M11 43h7l3-7 4 13 4-9 3 3h21\" fill=\"none\" stroke=\"#ffffff\" stroke-width=\"1.6\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/><g fill=\"#d4af37\"><rect x=\"46\" y=\"14\" width=\"4\" height=\"1.8\"/><rect x=\"46\" y=\"18\" width=\"4\" height=\"1.8\"/><rect x=\"46\" y=\"22\" width=\"4\" height=\"1.8\"/></g></svg>"
+  },
+  "ir-receiver": {
+    "$comment": "IR demodulator (VS1838B / TSOP38238 class). Its pin is DAT, which is what the element declares; the part used to look for OUT/DATA, find neither, and attach nothing at all. address/command are what a CLICK on the part transmits, and what the sensor panel's sliders edit; `channel` isolates a link when a project has several (empty = hears every emitter, which is what a room does).",
+    "pinCount": 3,
+    "tags": [
+      "ir-receiver",
+      "ir receiver",
+      "ir",
+      "receiver",
+      "infrared",
+      "nec",
+      "remote",
+      "demodulator",
+      "vs1838b",
+      "tsop",
+      "38khz"
+    ],
+    "properties": {
+      "irAddress": {
+        "name": "irAddress",
+        "type": "string",
+        "defaultValue": "0x00",
+        "control": "text",
+        "description": "NEC address this receiver transmits when clicked"
+      },
+      "irCommand": {
+        "name": "irCommand",
+        "type": "string",
+        "defaultValue": "0x45",
+        "control": "text",
+        "description": "NEC command this receiver transmits when clicked"
+      },
+      "channel": {
+        "name": "channel",
+        "type": "string",
+        "defaultValue": "",
+        "control": "text",
+        "description": "Leave empty to hear every IR emitter. Set a name to hear only emitters carrying the same one."
+      }
+    },
+    "defaultValues": {
+      "irAddress": "0x00",
+      "irCommand": "0x45",
+      "channel": ""
+    }
+  },
+  "ir-remote": {
+    "$comment": "IR handset. It has no pins and connects to nothing: it transmits into simulation/ir/irAir and every listening receiver hears it, wherever either one sits on the canvas. The button's NEC command comes from the element itself (detail.irCode); only the remote's ADDRESS is a property, because that is what distinguishes two physical handsets.",
+    "tags": [
+      "ir-remote",
+      "ir remote",
+      "ir",
+      "remote",
+      "infrared",
+      "nec",
+      "remote control",
+      "handset",
+      "transmitter"
+    ],
+    "properties": {
+      "irAddress": {
+        "name": "irAddress",
+        "type": "string",
+        "defaultValue": "0x00",
+        "control": "text",
+        "description": "NEC address of this handset"
+      },
+      "channel": {
+        "name": "channel",
+        "type": "string",
+        "defaultValue": "",
+        "control": "text",
+        "description": "Leave empty to transmit into the room. Set a name to reach only receivers carrying the same one."
+      }
+    },
+    "defaultValues": {
+      "irAddress": "0x00",
+      "channel": ""
+    }
   }
 }

--- a/test/backend/unit/test_ir_worker.py
+++ b/test/backend/unit/test_ir_worker.py
@@ -1,0 +1,238 @@
+"""
+test_ir_worker.py — the IR envelope the QEMU ESP32 worker drives
+(`app.services.esp32_ir`).
+
+The guest that reads this frame is an IR library, and the two families sample
+it very differently:
+
+  * IRremote's ESP32 backend samples the pin from a 50 us timer ISR and
+    reconstructs mark and space lengths by counting samples.
+  * a pin-change-interrupt decoder never reads the pin at all and is woken by
+    the edges themselves.
+
+The first is why the frame is paced by REAL guest microseconds rather than by
+the DHT22 player's 2 us-per-read credit — at 2 us per 50 us sample a 9 ms
+header would take 225 ms of guest time and nothing would decode it. The second
+is why the worker also advances the frame from a host ticker.
+
+The decoder here is the same one the browser runs
+(`simulation/ir/necCodec.ts`), reimplemented over the levels this player
+actually put on the pad — which is the only way to test that the envelope means
+what it is supposed to mean rather than that it has the shape we wrote down.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from app.services.esp32_ir import (
+    LEAD_US,
+    STUCK_TIMEOUT_US,
+    IrReply,
+    envelope_phases,
+    nec_pulses,
+)
+from app.services.esp32_worker import LINE_SENSOR_TYPES
+
+
+class FakePad:
+    """A pad plus a clock the test advances by hand, recording every edge."""
+
+    def __init__(self) -> None:
+        self.now = 1_000_000.0          # a guest that has been up a while
+        self.level = 1                  # a demodulator idles HIGH
+        self.edges: list[tuple[float, int]] = []
+
+    def set_level(self, level: int) -> None:
+        if level != self.level:
+            self.level = level
+            self.edges.append((self.now, level))
+
+    def now_us(self) -> float:
+        return self.now
+
+    def run(self, reply: IrReply, step_us: float, limit_us: float = 500_000.0) -> int:
+        """Sample the pad every `step_us` of guest time, the way an ISR does."""
+        samples = 0
+        start = self.now
+        while not reply.done and self.now - start < limit_us:
+            self.now += step_us
+            samples += 1
+            if reply.advance():
+                break
+        return samples
+
+
+def decode_nec(edges: list[tuple[float, int]]) -> tuple[str, int, int, bool]:
+    """The NEC frame the recorded edges carry. Mirror of necCodec.ts."""
+    if len(edges) < 4:
+        return ('raw', 0, 0, False)
+    # A mark is an interval the pad spent LOW; an edge to LOW starts one.
+    pulses: list[tuple[int, float]] = []
+    for i in range(len(edges) - 1):
+        level, nxt = edges[i][1], edges[i + 1][0]
+        pulses.append((1 if level == 0 else 0, nxt - edges[i][0]))
+
+    def near(actual: float, expected: float, tol: float = 0.25) -> bool:
+        return abs(actual - expected) <= expected * tol
+
+    i = 0
+    while i < len(pulses) and pulses[i][0] == 0:
+        i += 1
+    if len(pulses) - i < 3:
+        return ('raw', 0, 0, False)
+    if not near(pulses[i][1], 9000):
+        return ('raw', 0, 0, False)
+    if not near(pulses[i + 1][1], 4500):
+        if near(pulses[i + 1][1], 2250):
+            return ('NEC-repeat', 0, 0, True)
+        return ('raw', 0, 0, False)
+    i += 2
+
+    bits: list[int] = []
+    while len(bits) < 32:
+        if i + 1 >= len(pulses):
+            return ('raw', 0, 0, False)
+        if not near(pulses[i][1], 560):
+            return ('raw', 0, 0, False)
+        space = pulses[i + 1][1]
+        if near(space, 1690):
+            bits.append(1)
+        elif near(space, 560):
+            bits.append(0)
+        else:
+            return ('raw', 0, 0, False)
+        i += 2
+
+    def byte_at(n: int) -> int:
+        v = 0
+        for b in range(8):                     # least significant bit first
+            v |= bits[n * 8 + b] << b
+        return v
+
+    addr_lo, addr_hi, cmd, cmd_inv = (byte_at(n) for n in range(4))
+    classic = ((addr_lo ^ addr_hi) & 0xFF) == 0xFF
+    address = addr_lo if classic else addr_lo | (addr_hi << 8)
+    return ('NEC', address, cmd, ((cmd ^ cmd_inv) & 0xFF) == 0xFF)
+
+
+class TestEnvelopePhases(unittest.TestCase):
+    def test_a_mark_pulls_the_output_low(self):
+        phases = envelope_phases([(1, 9000), (0, 4500)])
+        self.assertEqual(phases[0], (1, LEAD_US))   # the settling lead
+        self.assertEqual(phases[1], (0, 9000.0))    # the mark
+        self.assertEqual(phases[2], (1, 4500.0))    # the space
+
+    def test_it_ends_idle_high_even_though_nec_ends_on_a_mark(self):
+        phases = envelope_phases(nec_pulses(0x00, 0x45))
+        self.assertEqual(phases[-1][0], 1)
+
+    def test_adjacent_marks_merge_rather_than_growing_a_zero_width_edge(self):
+        phases = envelope_phases([(1, 500), (1, 500), (0, 600)])
+        self.assertEqual(phases[1], (0, 1000.0))
+
+    def test_zero_length_pulses_are_dropped(self):
+        self.assertEqual(envelope_phases([(1, 0), (0, 0)]), [])
+
+    def test_an_empty_train_is_not_a_frame(self):
+        self.assertEqual(envelope_phases([]), [])
+
+
+class TestNecPulses(unittest.TestCase):
+    def test_header_then_thirty_two_bits_then_a_stop_mark(self):
+        p = nec_pulses(0x00, 0x45)
+        self.assertEqual(len(p), 2 + 64 + 1)
+        self.assertEqual(p[0], (1, 9000.0))
+        self.assertEqual(p[1], (0, 4500.0))
+        self.assertEqual(p[-1], (1, 560.0))
+
+    def test_a_bit_is_in_the_space_least_significant_first(self):
+        p = nec_pulses(0x01, 0x00)
+        self.assertEqual(p[3][1], 1690.0)
+        self.assertEqual(p[5][1], 560.0)
+
+
+class TestIrReply(unittest.TestCase):
+    def _play(self, address: int, command: int, step_us: float):
+        pad = FakePad()
+        reply = IrReply(envelope_phases(nec_pulses(address, command)),
+                        pad.set_level, pad.now_us)
+        pad.run(reply, step_us)
+        return pad, reply
+
+    def test_a_fifty_microsecond_sampler_decodes_the_frame(self):
+        # IRremote's ESP32 backend. This is the case the DHT22 player's 2 us
+        # per-read credit would have stretched to 225 ms and destroyed.
+        pad, reply = self._play(0x04, 0x1C, 50.0)
+        self.assertTrue(reply.done)
+        self.assertEqual(decode_nec(pad.edges), ('NEC', 0x04, 0x1C, True))
+
+    def test_it_decodes_across_every_sampling_rate_a_guest_might_use(self):
+        for step_us in (1.0, 10.0, 50.0, 100.0):
+            with self.subTest(step_us=step_us):
+                pad, _ = self._play(0x00, 0x45, step_us)
+                self.assertEqual(decode_nec(pad.edges), ('NEC', 0x00, 0x45, True))
+
+    def test_the_header_lasts_nine_milliseconds_of_guest_time(self):
+        pad, _ = self._play(0x00, 0x45, 10.0)
+        header_us = pad.edges[1][0] - pad.edges[0][0]
+        self.assertAlmostEqual(header_us, 9000.0, delta=20.0)
+
+    def test_a_coarse_advance_crosses_every_boundary_it_covers(self):
+        # One advance spanning several 560 us phases must not stretch the frame
+        # by the number of phases it fell behind.
+        pad, _ = self._play(0x04, 0x1C, 300.0)
+        span = pad.edges[-1][0] - pad.edges[0][0]
+        self.assertLess(span, 75_000.0)   # a NEC frame is ~67.5 ms
+
+    def test_extended_addresses_survive_the_round_trip(self):
+        pad, _ = self._play(0x1234, 0x56, 20.0)
+        protocol, address, command, _ = decode_nec(pad.edges)
+        self.assertEqual((protocol, address, command), ('NEC', 0x1234, 0x56))
+
+    def test_the_pad_is_left_idle_high_when_the_frame_is_over(self):
+        pad, reply = self._play(0x00, 0x45, 50.0)
+        self.assertTrue(reply.done)
+        self.assertEqual(pad.level, 1)
+
+    def test_settle_gives_the_line_back_mid_frame(self):
+        pad = FakePad()
+        reply = IrReply(envelope_phases(nec_pulses(0, 0x45)), pad.set_level, pad.now_us)
+        for _ in range(5):
+            pad.now += 50.0
+            reply.advance()
+        self.assertFalse(reply.done)
+        self.assertTrue(reply.settle())
+        self.assertEqual(pad.level, 1)
+        self.assertFalse(reply.settle())    # only acts once
+
+    def test_a_frame_nobody_advances_does_not_hold_the_pad_forever(self):
+        pad = FakePad()
+        reply = IrReply(envelope_phases(nec_pulses(0, 0x45)), pad.set_level, pad.now_us)
+        reply.advance()
+        pad.now += STUCK_TIMEOUT_US + 1000
+        self.assertTrue(reply.advance())
+        self.assertEqual(pad.level, 1)
+
+    def test_a_guest_reboot_ends_the_frame_rather_than_replaying_it(self):
+        pad = FakePad()
+        reply = IrReply(envelope_phases(nec_pulses(0, 0x45)), pad.set_level, pad.now_us)
+        reply.advance()
+        pad.now = 0.0                       # esp_restart: the clock went back
+        self.assertTrue(reply.advance())
+        self.assertEqual(pad.level, 1)
+
+    def test_a_frame_needs_at_least_one_phase(self):
+        with self.assertRaises(ValueError):
+            IrReply([], lambda _: None, lambda: 0.0)
+
+
+class TestWorkerPolicy(unittest.TestCase):
+    def test_ir_counts_as_a_line_sensor_for_the_run_policy(self):
+        # It places timed edges on a pad in guest time, which is the whole of
+        # what that list means.
+        self.assertIn('ir-nec', LINE_SENSOR_TYPES)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Both IR components shipped and neither did anything, each for its own reason, and none of the three looked like a failure on the canvas.

## What was wrong

- **`ir-receiver` never attached to anything.** It asked for a pin named `OUT` or `DATA`. `wokwi-ir-receiver` calls it `DAT`, so the lookup returned null and `attachEvents` returned an empty cleanup on its second line. Wired or not, the part was inert.
- **`ir-remote` asked for a pin too.** It is a remote control: it has no pins and never had. All it did was dispatch an `ir-signal` DOM event that nothing in the codebase listened for, carrying a command from a hand-written table whose key names the element never emits — while the element was already reporting the correct NEC code in `detail.irCode`, which was ignored. The table disagreed with it on every single key.
- **The pulse train was built out of `setTimeout(next, 0.562)`.** A NEC mark is 560 us; setTimeout's floor is a millisecond and its nested clamp is four. No IR library could ever have decoded it.

Underneath all three: there was no **medium**. Every other link on the canvas is a wire, and infrared is the one link with no wire, so nothing joined an emitter to a receiver. The Grove emitter's own documentation said so outright — it modelled the emitter, not the link.

## What is new

`simulation/ir/` is the medium. One process-wide bus carrying mark/space trains in **microseconds**, with no geometry: no distance, no angle, no line of sight, no wire. Two parts at opposite corners are as connected as two parts touching, which is the point — placing a remote and a receiver is already the whole of the user's intent, and asking them to aim it would be a puzzle rather than a simulation. Microseconds rather than cycles is what lets one remote fire a receiver on an Uno and another on an ESP32 in the same run: each receiver converts to its own board's clock. An optional `channel` property isolates a pair when a project has several links; empty means the room, so the default costs nothing.

Both parts are rebuilt on it. The receiver is now a line-owning model (`simulation/line/models/ir-nec`) that puts the envelope on its pin, active low, on the guest's own cycle counter. The remote transmits into the air with the code the element reports, and a held key repeats every 108 ms the way a real one does.

`ir-tx` is the transmit half: a model that owns no pad and only listens, demodulating what a sketch bit-bangs on a pin back into marks and spaces. One rule covers both waveforms sketches produce — a HIGH interval is always carrier, a LOW one is carrier when shorter than the carrier gap and a space when longer — so nothing has to know whether it is looking at a 38 kHz carrier or a bare envelope, or at what frequency.

## Coverage

Registering the two models is all it takes: AVR, RP2040 and RP2350 host them locally, and every in-browser ESP32 engine reports `lineModelTypes()` verbatim, so `esp32js`, `esp32s3js`, `esp32c3js`, `esp32c6js` and `esp32c5js` get them with no per-engine work. `esp32p4js` declares no line support and refuses with its reason, which the circuit check shows.

The QEMU worker gets its own model (`backend/app/services/esp32_ir.py`) rather than reusing the DHT22 player, and the difference is the whole problem: that player credits at most 2 us of guest time per GPIO_IN read, because the drivers it serves busy-wait and a phase is really a number of reads. IR libraries do not busy-wait — IRremote's ESP32 backend samples from a 50 us timer ISR. Measured under that rule, a NEC frame spans **1.7 seconds** of guest time instead of 68 ms and decodes as raw. So an IR frame is paced by real guest microseconds, and it is advanced from a host ticker as well as from reads, because a decoder using a pin-change interrupt never reads the pin at all.

## Verified in the real app, not only in tests

The built page was driven in a browser. A probe sketch measured the receiver's pin with `micros()` on the emulated AVR:

```
idle level = HIGH
pulses us: 9000 4496 564 560 556 564 560
pulses us: 564 1688 560 1692 560 560 560
```

A 9000 us header mark, a 4496 us space, 560 us bit marks, 1688 us one-spaces. Then end to end:

- **Uno + IRremote**: `protocol NEC  address 0x0  command 0x30`, `command 0xA2`, and `(key held)` for the repeat frames of a held key.
- **One remote, two receivers**: one emission, two deliveries, `A: 0x38` and `B: 0x38`.
- **ESP32, in-browser engine** (`?esp32sim=js`): `protocol NEC  address 0x00  command 0x42`.

That browser run also found two real bugs in the gallery sketches, fixed in the second commit: `ENABLE_LED_FEEDBACK` makes IRremote complete frames out of nothing on this emulated Uno, and the two-receiver sketch timed its header from wherever it happened to catch it.

## Tests

49 new: the codec round trip, the medium's delivery and channel rules, both line models, the two parts end to end (a press on one reaches another part's pin and decodes back to the button pressed), and the worker's envelope under every sampling rate a guest might use. The old IR tests all passed against code that transmitted nothing decodable on a pin nobody watched, so the new ones assert the **link** instead.

No new typecheck errors (185 before, 185 after, identical set).