### PR TITLE
fix(dht22): the response gap is 20-40 us, and we took the worst end for a guest

### DIFF
--- a/frontend/src/__tests__/protocol-parts.test.ts
+++ b/frontend/src/__tests__/protocol-parts.test.ts
@@ -21,6 +21,7 @@ import type { LineHostPort } from '../simulation/line/LineHost';
 import { INITIAL_PAD, type PadEvent, type PadState } from '../simulation/line/padEvent';
 import { clearLineGaps, lineGaps } from '../simulation/line/requestLine';
 import { dispatchSensorUpdate } from '../simulation/SensorUpdateRegistry';
+import { DHT22_RESPONSE_START_US } from '../simulation/line/models/dht22';
 import {
   emitIr,
   irAirStats,
@@ -423,7 +424,8 @@ describe('dht22 — single-wire sensor (the line contract)', () => {
     );
     sim.guest(7, ['high', 'low', 'z']);
     expect(port.edges).toHaveLength(84);
-    expect(port.edges[0]).toEqual([7, false, 10_000 + 16 * 20]);
+    // 16 cycles per us at this rig's 16 MHz, times the sensor's response gap.
+    expect(port.edges[0]).toEqual([7, false, 10_000 + 16 * DHT22_RESPONSE_START_US]);
   });
 
   it('forwards slider changes to the host', () => {

--- a/frontend/src/simulation/line/__tests__/LineSensorHub.test.ts
+++ b/frontend/src/simulation/line/__tests__/LineSensorHub.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { LineSensorHub } from '../LineSensorHub';
 import type { LineHostPort } from '../LineHost';
 import { INITIAL_PAD, type PadEvent, type PadState } from '../padEvent';
+import { DHT22_RESPONSE_START_US } from '../models/dht22';
 import '../index';
 
 function makePort(hz = 16_000_000) {
@@ -37,7 +38,12 @@ function makePort(hz = 16_000_000) {
     },
     guest: (pin, drive) => {
       const prev = pads.get(pin) ?? INITIAL_PAD;
-      const next: PadState = { drive, pull: drive === 'z' ? 1 : 0, level: drive !== 'low', cycle: now };
+      const next: PadState = {
+        drive,
+        pull: drive === 'z' ? 1 : 0,
+        level: drive !== 'low',
+        cycle: now,
+      };
       pads.set(pin, next);
       listeners.get(pin)?.forEach((cb) => cb({ pin, ...next, prev }));
     },
@@ -68,7 +74,7 @@ describe('LineSensorHub', () => {
     port.advance(16 * 1100);
     port.guest(4, 'z');
     expect(port.edges).toHaveLength(84);
-    expect(port.edges[0][2]).toBe(10_000 + 16 * 1100 + 16 * 20);
+    expect(port.edges[0][2]).toBe(10_000 + 16 * 1100 + 16 * DHT22_RESPONSE_START_US);
     expect(port.releases).toHaveLength(1);
     expect(hub.timeline.busy).toBe(true);
     expect(hub.maySkip(port.now() + 100)).toBe(false); // 84 edges: self-timed

--- a/frontend/src/simulation/line/__tests__/lineModels.test.ts
+++ b/frontend/src/simulation/line/__tests__/lineModels.test.ts
@@ -12,7 +12,7 @@ import {
   type LineClock,
 } from '../lineModels';
 import { INITIAL_PAD, type PadEvent, type PadState } from '../padEvent';
-import { dht22Payload, dht22Frame } from '../models/dht22';
+import { dht22Payload, dht22Frame, DHT22_RESPONSE_START_US } from '../models/dht22';
 import { hcsr04Frame, clampDistanceCm } from '../models/hc-sr04';
 import '../index';
 
@@ -73,12 +73,12 @@ describe('dht22 model', () => {
     expect([...dht22Payload(-10.5, 33.3)]).toEqual([0x01, 0x4d, 0x80, 0x69, 0x37]);
   });
 
-  it('answers with 84 edges: 20 us in, 80/80 preamble, 40 bits of 50 + 26|70, and a release', () => {
+  it('answers with 84 edges: the response gap, 80/80 preamble, 40 bits of 50 + 26|70, and a release', () => {
     const us = clockAt(0).us;
     const f = dht22Frame(4, 1000, dht22Payload(25, 50), us);
     expect(f.edges).toHaveLength(84);
-    expect(f.edges[0]).toEqual({ level: false, atCycle: 1000 + us(20) });
-    expect(f.edges[1]).toEqual({ level: true, atCycle: 1000 + us(20) + us(80) });
+    expect(f.edges[0]).toEqual({ level: false, atCycle: 1000 + us(DHT22_RESPONSE_START_US) });
+    expect(f.edges[1]).toEqual({ level: true, atCycle: 1000 + us(DHT22_RESPONSE_START_US) + us(80) });
     expect(f.edges[2].atCycle - f.edges[1].atCycle).toBe(us(80));
     // First data bit of 0x01 is a '0': 50 us low then 26 us high.
     expect(f.edges[3].atCycle - f.edges[2].atCycle).toBe(us(50));

--- a/frontend/src/simulation/line/models/dht22.ts
+++ b/frontend/src/simulation/line/models/dht22.ts
@@ -20,6 +20,38 @@ import { assertedLow, releasedLow } from '../padEvent';
 import type { HostEdge, HostEdgeFrame } from '../LineTimeline';
 import { numberField, registerLineModel, type LineClock, type LineModel } from '../lineModels';
 
+/**
+ * How long after the master releases the line the sensor starts answering.
+ *
+ * The AM2302 datasheet gives this as 20-40 us and the model used to take the
+ * bottom of that range, which is the worst end for an EMULATED master. The
+ * driver's whole read hinges on arriving inside the 80 us response LOW, and
+ * what it spends getting there is not the wire's problem but the guest's:
+ * arduino-esp32's `pinMode` costs 6 us of guest time on a classic ESP32 and
+ * 58 us on an ESP32-P4, nearly all of it inside the peripheral manager
+ * (`perimanGetPinBus`, ~11 000 instructions a call). Adafruit's DHT.h then
+ * waits its own `pullTime` of 55 us on top before it first looks. At 20 us the
+ * P4 arrives about 10 us before the LOW ends and its first `expectPulse(LOW)`
+ * returns instantly, which puts every one of the 80 pulses that follow one
+ * phase out and ends the read in 80 timeouts and a NaN.
+ *
+ * 40 us is the other end of the same datasheet range, so this is not a widened
+ * window -- it is the same sensor, specified. It strictly helps every host: a
+ * master that arrives EARLY finds more of the LOW left than before, and one
+ * that arrives late finds some at all.
+ *
+ * Measured on the P4 with a sketch timing the pad itself: the response the
+ * guest sees goes from `low starts +5 us, lasts 67 us` to `+11 us, lasts
+ * 80 us` -- the full width the datasheet specifies, where before the guest
+ * was arriving too late to see a sixth of it. On a classic ESP32, where the
+ * read already worked, it keeps working (28.0 C / 65.0 % on the gallery
+ * example, unchanged).
+ *
+ * It does NOT make Adafruit's DHT.h read on the P4: that still returns NaN,
+ * and the reason is somewhere past the preamble, not in this constant.
+ */
+export const DHT22_RESPONSE_START_US = 40;
+
 export const DHT22_DEFAULT_TEMPERATURE_C = 25.0;
 export const DHT22_DEFAULT_HUMIDITY_PCT = 50.0;
 
@@ -36,14 +68,17 @@ export function dht22Payload(temperatureC: number, humidityPct: number): Uint8Ar
   return new Uint8Array([h_H, h_L, t_H, t_L, chk]);
 }
 
-/** The response waveform on DATA, starting ~20 us after the MCU's release. */
+/**
+ * The response waveform on DATA, starting {@link DHT22_RESPONSE_START_US} after the
+ * MCU's release.
+ */
 export function dht22Frame(
   pin: number,
   releaseCycle: number,
   payload: Uint8Array,
   us: (n: number) => number,
 ): HostEdgeFrame {
-  const RESPONSE_START = us(20);
+  const RESPONSE_START = us(DHT22_RESPONSE_START_US);
   const LOW80 = us(80);
   const HIGH80 = us(80);
   const LOW50 = us(50);


### PR DESCRIPTION
The AM2302 answers 20-40 us after the master releases the line. The model took **20**, the bottom of that range, which is the worst end for an *emulated* master: what the guest spends getting from its release to its first look is not the wire's problem but the CPU's, and in an emulator that cost is not the one the driver was written against.

## Measured

`pinMode` in arduino-esp32 costs **6 us** of guest time on a classic ESP32 and **58 us** on an ESP32-P4. Profiled against the real firmware, offline, nearly all of it is the peripheral manager:

```
5.4%   56 627  perimanGetPinBus      (~11 000 instructions per pinMode call)
1.0%   10 454  xPortEnterCriticalTimeout
0.4%    3 942  gpio_config
```

Adafruit's DHT.h then waits its own 55 us `pullTime` on top before it first reads the pin. At a 20 us gap the P4's guest arrived so late it saw only a sixth of the 80 us response LOW — a sketch timing the pad itself reported `low starts +5 us, lasts 67 us` instead of the specified 80.

At 40 us the same sketch reports `+11 us, lasts 80 us`: the full width, which is what a driver measuring pulse ratios needs.

Both numbers are in the datasheet, so this is the same sensor either way, and it strictly helps every host — a master that arrives early now finds MORE of the LOW than before, not less. Checked for regression on the classic ESP32, where the read already worked and still does (`Temp: 28.0 C   Humidity: 65.0 %` on the gallery example, unchanged).

## What this does NOT fix

Adafruit's DHT.h **still returns NaN on the P4**. The preamble is now the right width, and a hand-rolled copy of the library's own algorithm decodes the frame correctly on that board — `022600F0` with a matching checksum, 55.0 % / 24.0 C exactly as configured — so whatever the library does differently is past the preamble. Said here so the next person does not re-derive the half that is already settled.

## Tests

The three that pinned 20 us now read the exported constant, so the next change to it does not need them edited by hand. 164 passing across `simulation/line` and `protocol-parts`.