### PR TITLE
feat(search): the picker and the gallery find parts by what they do, in any spelling

### DIFF
--- a/frontend/src/__tests__/component-search.test.ts
+++ b/frontend/src/__tests__/component-search.test.ts
@@ -1,0 +1,97 @@
+/**
+ * The component picker's search over the REAL catalogue
+ * (public/components-metadata.json): what a person types must reach the
+ * part, whatever the scanned metadata happens to call it.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import metadata from '../../public/components-metadata.json';
+import registry from '../services/ComponentRegistry';
+import type { ComponentMetadata } from '../types/component-metadata';
+
+const ids = (query: string) => registry.search(query).map((c) => c.id);
+
+beforeAll(async () => {
+  // The module-level load() fetches /components-metadata.json, which has no
+  // server here; wait for it to settle, then feed the same file directly.
+  await registry.load().catch(() => undefined);
+  registry.mergeComponents((metadata as { components: ComponentMetadata[] }).components);
+});
+
+describe('ComponentRegistry.search over the real catalogue', () => {
+  it('blank query is the whole catalogue in browsing order', () => {
+    expect(registry.search('')).toEqual(registry.getAllComponents());
+    expect(registry.search('   ')).toEqual(registry.getAllComponents());
+  });
+
+  it('finds sensors by what they measure, not just their part number', () => {
+    expect(ids('temperature')).toContain('dht22');
+    expect(ids('temperature')).toContain('bmp280');
+    expect(ids('temperature')).toContain('ntc-temperature-sensor');
+    expect(ids('humidity')).toContain('dht22');
+    expect(ids('ultrasonic')[0]).toBe('hc-sr04');
+    expect(ids('distance')).toContain('hc-sr04');
+    expect(ids('motion')).toContain('pir-motion-sensor');
+    expect(ids('light')).toContain('photoresistor-sensor');
+    expect(ids('clock')).toContain('ds3231');
+    expect(ids('weight')).toContain('hx711');
+  });
+
+  it('finds displays by kind', () => {
+    expect(ids('oled')[0]).toMatch(/^ssd1306/);
+    expect(ids('screen')).toContain('ili9341');
+    expect(ids('screen')).toContain('lcd1602-i2c');
+    expect(ids('display 20x4')).toContain('lcd2004-i2c');
+    expect(ids('eink')).toContain('epaper-2in9-bw');
+  });
+
+  it('is spelled-any-way and typo tolerant', () => {
+    expect(ids('hc-sr04')[0]).toBe('hc-sr04');
+    expect(ids('hc sr04')[0]).toBe('hc-sr04');
+    expect(ids('hcsr04')[0]).toBe('hc-sr04');
+    expect(ids('ssd 1306')[0]).toMatch(/^ssd1306/);
+    expect(ids('potenciometer')[0]).toBe('potentiometer');
+    expect(ids('ultrasnic')[0]).toBe('hc-sr04');
+    expect(ids('neopixl')).toContain('neopixel');
+    expect(ids('buzer')).toContain('buzzer');
+  });
+
+  it('works in the languages the UI ships in', () => {
+    expect(ids('temperatura')).toContain('dht22');
+    expect(ids('sensor de temperatura')).toContain('dht22');
+    expect(ids('pantalla')).toContain('ssd1306');
+    expect(ids('pantalla')).toContain('lcd1602');
+    expect(ids('boton')[0]).toMatch(/^pushbutton/);
+    expect(ids('pulsador')[0]).toMatch(/^pushbutton/);
+    expect(ids('potenciometro')[0]).toBe('potentiometer');
+    expect(ids('zumbador')[0]).toBe('buzzer');
+    expect(ids('resistencia')).toContain('resistor');
+    expect(ids('ultrasonido')[0]).toBe('hc-sr04');
+    expect(ids('reloj')).toContain('ds1307');
+    expect(ids('schrittmotor')).toContain('stepper-motor');
+    expect(ids('moteur pas')).toContain('stepper-motor');
+    expect(ids('umidita')).toContain('dht22');
+    expect(ids('botao')[0]).toMatch(/^pushbutton/);
+  });
+
+  it('ranks the part that carries the name first', () => {
+    expect(ids('led')[0]).toBe('led');
+    expect(ids('servo')[0]).toBe('servo');
+    expect(ids('relay')[0]).toBe('relay');
+    expect(ids('and gate')[0]).toBe('logic-gate-and');
+    expect(ids('nand')[0]).toMatch(/nand/);
+    expect(ids('button')[0]).toBe('pushbutton');
+    expect(ids('breadboard')[0]).toBe('breadboard');
+  });
+
+  it('several words narrow the result', () => {
+    const rgb = ids('rgb led');
+    expect(rgb[0]).toBe('rgb-led');
+    expect(rgb.length).toBeLessThan(ids('led').length);
+    expect(ids('temperature i2c')).toContain('bmp280');
+    expect(ids('temperature i2c')).not.toContain('ntc-temperature-sensor');
+  });
+
+  it('finds nothing for nonsense', () => {
+    expect(ids('qzqzqzqz')).toEqual([]);
+  });
+});

--- a/frontend/src/__tests__/examples-search.test.ts
+++ b/frontend/src/__tests__/examples-search.test.ts
@@ -1,0 +1,100 @@
+/**
+ * The examples gallery search over the REAL gallery: the same matcher the
+ * component picker uses, fed with each example's title, tags, parts (and
+ * what people call those parts), board, category and description.
+ */
+import { describe, it, expect } from 'vitest';
+import { exampleProjects, type ExampleProject } from '../data/examples';
+import { parseSearchQuery, scoreSearch } from '../utils/searchMatch';
+import { exampleSearchFields } from '../utils/exampleSearch';
+
+function boardFilter(example: ExampleProject): string {
+  if (example.boardFilter) return example.boardFilter;
+  if (example.boards) return 'multi';
+  return example.boardType ?? 'arduino-uno';
+}
+
+function search(query: string): ExampleProject[] {
+  const parsed = parseSearchQuery(query);
+  if (!parsed) return [...exampleProjects];
+  return exampleProjects
+    .map((example) => ({
+      example,
+      score: scoreSearch(parsed, exampleSearchFields(example, boardFilter(example))),
+    }))
+    .filter((s) => s.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .map((s) => s.example);
+}
+
+const partsOf = (e: ExampleProject) =>
+  (e.components ?? []).map((c) => c.type.replace(/^(wokwi|velxio)-/, ''));
+const text = (e: ExampleProject) =>
+  `${e.title} ${e.description} ${(e.tags ?? []).join(' ')}`.toLowerCase();
+
+describe('examples gallery search over the real gallery', () => {
+  it('finds every example by its own exact title, first', () => {
+    // A sample across the gallery, not just the first few Arduino ones.
+    const step = Math.max(1, Math.floor(exampleProjects.length / 25));
+    for (let i = 0; i < exampleProjects.length; i += step) {
+      const example = exampleProjects[i];
+      const hits = search(example.title);
+      expect(hits.length, example.title).toBeGreaterThan(0);
+      // Duplicate titles exist across boards; the top hit must share the title.
+      expect(hits[0].title, `query: ${example.title}`).toBe(example.title);
+    }
+  });
+
+  it('reaches an example through the parts on its canvas', () => {
+    const hits = search('temperature');
+    expect(hits.length).toBeGreaterThan(0);
+    for (const e of hits) {
+      const viaParts = partsOf(e).some((p) =>
+        ['dht22', 'bmp280', 'ntc-temperature-sensor', 'ds3231', 'pro-bme280'].includes(p),
+      );
+      expect(viaParts || /temp|weather|thermo/.test(text(e)), e.title).toBe(true);
+    }
+  });
+
+  it('understands a query in the user language', () => {
+    expect(search('temperatura').length).toBeGreaterThan(0);
+    expect(search('sensor de temperatura').length).toBeGreaterThan(0);
+    expect(search('semaforo').some((e) => /traffic/i.test(e.title))).toBe(true);
+    expect(
+      search('pantalla oled').some((e) => partsOf(e).some((p) => p.startsWith('ssd1306'))),
+    ).toBe(true);
+    expect(search('boton').some((e) => partsOf(e).includes('pushbutton'))).toBe(true);
+  });
+
+  it('survives a typo and any spelling of a part number', () => {
+    const canonical = search('hc-sr04').map((e) => e.id);
+    expect(canonical.length).toBeGreaterThan(0);
+    expect(search('hc sr04').map((e) => e.id)).toEqual(canonical);
+    expect(search('hcsr04').map((e) => e.id)).toEqual(canonical);
+    const typo = search('ultrasnic');
+    expect(typo.length).toBeGreaterThan(0);
+    for (const e of typo) {
+      expect(partsOf(e).includes('hc-sr04') || /ultrason/.test(text(e)), e.title).toBe(true);
+    }
+  });
+
+  it('several words narrow, in any order', () => {
+    const a = search('esp32 oled');
+    const b = search('oled esp32');
+    // Same set either way; the order may differ because a title that starts
+    // with the phrase as typed earns a small bonus.
+    expect(a.map((e) => e.id).sort()).toEqual(b.map((e) => e.id).sort());
+    expect(a.length).toBeGreaterThan(0);
+    expect(a.length).toBeLessThan(search('oled').length);
+    for (const e of a)
+      expect(boardFilter(e).startsWith('esp32') || /esp32/.test(text(e))).toBe(true);
+  });
+
+  it('filters by board, category and difficulty words too', () => {
+    expect(
+      search('beginner').every((e) => e.difficulty === 'beginner' || /beginner/.test(text(e))),
+    ).toBe(true);
+    expect(search('principiante').length).toBeGreaterThan(0);
+    expect(search('pico').some((e) => boardFilter(e).includes('pico'))).toBe(true);
+  });
+});

--- a/frontend/src/__tests__/searchMatch.test.ts
+++ b/frontend/src/__tests__/searchMatch.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest';
+import {
+  editDistance,
+  matchesSearch,
+  normalizeSearchText,
+  parseSearchQuery,
+  prepareSearchFields,
+  rankBySearch,
+  scoreSearch,
+} from '../utils/searchMatch';
+import { expandSearchToken } from '../utils/searchSynonyms';
+
+interface Part {
+  id: string;
+  name: string;
+  tags: string;
+  keywords: string;
+  description?: string;
+}
+
+const CATALOGUE: Part[] = [
+  { id: 'led', name: 'LED', tags: 'led', keywords: 'led light diode indicator lamp' },
+  { id: 'led-ring', name: 'LED Ring', tags: 'led ring', keywords: 'neopixel ws2812 rgb' },
+  { id: 'rgb-led', name: 'RGB Led', tags: 'rgb led', keywords: 'rgb led color light' },
+  { id: 'dht22', name: 'DHT22', tags: 'dht22', keywords: 'temperature humidity sensor' },
+  {
+    id: 'hc-sr04',
+    name: 'HC-SR04',
+    tags: 'hc-sr04 hc sr04',
+    keywords: 'ultrasonic distance sensor sonar',
+  },
+  {
+    id: 'potentiometer',
+    name: 'Potentiometer',
+    tags: 'potentiometer',
+    keywords: 'pot knob dial variable resistor analog input',
+  },
+  { id: 'pushbutton', name: 'Pushbutton', tags: 'pushbutton', keywords: 'push button switch' },
+  { id: 'logic-gate-and', name: 'AND Gate', tags: 'logic gate and', keywords: 'logic gate' },
+  { id: 'logic-gate-or', name: 'OR Gate', tags: 'logic gate or', keywords: 'logic gate' },
+  {
+    id: 'pir',
+    name: 'PIR Motion Sensor',
+    tags: 'pir motion sensor',
+    keywords: 'presence movement',
+    description: 'Detects motion; often paired with an LED to show a hit.',
+  },
+];
+
+const fields = (p: Part) =>
+  prepareSearchFields([
+    { text: p.name, weight: 3 },
+    { text: p.id, weight: 2.5 },
+    { text: p.tags, weight: 2.5 },
+    { text: p.keywords, weight: 2 },
+    { text: p.description ?? '', weight: 1 },
+  ]);
+
+const ids = (query: string) => rankBySearch(CATALOGUE, query, fields).map((p) => p.id);
+
+describe('normalizeSearchText', () => {
+  it('lower-cases, strips accents and folds punctuation to single spaces', () => {
+    expect(normalizeSearchText('  Botón  Pulsador ')).toBe('boton pulsador');
+    expect(normalizeSearchText('HC-SR04')).toBe('hc sr04');
+    expect(normalizeSearchText('ePaper 1.54" (200×200, B/W)')).toBe('epaper 1 54 200 200 b w');
+    expect(normalizeSearchText('Resistor 4.7 kΩ')).toBe('resistor 4 7 kohm');
+    expect(normalizeSearchText('Cap. 1 µF')).toBe('cap 1 uf');
+  });
+});
+
+describe('editDistance', () => {
+  it('counts substitutions, insertions, deletions and adjacent swaps', () => {
+    expect(editDistance('kitten', 'kitten', 3)).toBe(0);
+    expect(editDistance('kitten', 'sitten', 3)).toBe(1);
+    expect(editDistance('arduno', 'arduino', 3)).toBe(1);
+    expect(editDistance('ardiuno', 'arduino', 3)).toBe(1);
+    expect(editDistance('kitten', 'sitting', 3)).toBe(3);
+  });
+  it('gives up early past the budget', () => {
+    expect(editDistance('abc', 'xyzxyz', 1)).toBe(2);
+    expect(editDistance('potentiometer', 'buzzer', 2)).toBe(3);
+  });
+});
+
+describe('parseSearchQuery', () => {
+  it('is null for a blank query', () => {
+    expect(parseSearchQuery('')).toBeNull();
+    expect(parseSearchQuery('   ')).toBeNull();
+  });
+  it('marks stopwords optional unless the whole query is stopwords', () => {
+    const q = parseSearchQuery('sensor de temperatura')!;
+    expect(q.tokens.map((t) => t.required)).toEqual([true, false, true]);
+    const gates = parseSearchQuery('and')!;
+    expect(gates.tokens[0].required).toBe(true);
+  });
+  it('expands a token through the synonym table, itself first', () => {
+    expect(expandSearchToken('temperatura')[0]).toBe('temperatura');
+    expect(expandSearchToken('temperatura')).toContain('temperature');
+    expect(expandSearchToken('botones')).toContain('pushbutton');
+    expect(expandSearchToken('zzz')).toEqual(['zzz']);
+  });
+});
+
+describe('rankBySearch', () => {
+  it('returns everything, in order, for a blank query', () => {
+    expect(ids('')).toEqual(CATALOGUE.map((p) => p.id));
+  });
+
+  it('returns nothing for a word that matches nowhere', () => {
+    expect(ids('zzqqxx')).toEqual([]);
+  });
+
+  it('matches partial words', () => {
+    expect(ids('temp')).toEqual(['dht22']);
+    expect(ids('ultra')).toEqual(['hc-sr04']);
+    expect(ids('poten')).toEqual(['potentiometer']);
+  });
+
+  it('matches every word independently, in any order', () => {
+    expect(ids('sensor motion')).toEqual(['pir']);
+    expect(ids('motion sensor')).toEqual(['pir']);
+    expect(ids('sensor humidity')).toEqual(['dht22']);
+  });
+
+  it('treats punctuation and spacing variants as the same query', () => {
+    const expected = ['hc-sr04'];
+    expect(ids('hc-sr04')).toEqual(expected);
+    expect(ids('hc sr04')).toEqual(expected);
+    expect(ids('hcsr04')).toEqual(expected);
+    expect(ids('HC_SR04')).toEqual(expected);
+  });
+
+  it('survives a typo', () => {
+    expect(ids('potenciometer')).toEqual(['potentiometer']);
+    expect(ids('ultrasnic')).toEqual(['hc-sr04']);
+    expect(ids('temperture')).toEqual(['dht22']);
+  });
+
+  it('does not let short tokens be fuzzy', () => {
+    // "lcd" is one edit from "led" but a 3-letter token gets no typo budget.
+    expect(ids('lcd')).toEqual([]);
+  });
+
+  it('understands other languages and aliases through synonyms', () => {
+    expect(ids('temperatura')).toEqual(['dht22']);
+    expect(ids('humedad')).toEqual(['dht22']);
+    expect(ids('boton')).toEqual(['pushbutton']);
+    expect(ids('Taster')).toEqual(['pushbutton']);
+    expect(ids('bouton')).toEqual(['pushbutton']);
+    expect(ids('pot')).toEqual(['potentiometer']);
+    expect(ids('distancia')).toEqual(['hc-sr04']);
+    expect(ids('ultraschall')).toEqual(['hc-sr04']);
+  });
+
+  it('never fails a query on a little word', () => {
+    expect(ids('sensor de temperatura')).toEqual(['dht22']);
+    expect(ids('the pushbutton')).toEqual(['pushbutton']);
+  });
+
+  it('ranks the part that IS the word above parts that mention it', () => {
+    expect(ids('led')[0]).toBe('led');
+    expect(ids('led')).toContain('pir'); // description mentions an LED, last
+    expect(ids('led').indexOf('pir')).toBe(ids('led').length - 1);
+    expect(ids('and gate')[0]).toBe('logic-gate-and');
+    expect(ids('or gate')[0]).toBe('logic-gate-or');
+  });
+
+  it('ranks a direct hit above a synonym hit', () => {
+    // "button" is literally in pushbutton's keywords and a synonym of pushbutton.
+    const parsed = parseSearchQuery('button')!;
+    const direct = scoreSearch(parsed, fields(CATALOGUE.find((p) => p.id === 'pushbutton')!));
+    expect(direct).toBeGreaterThan(0);
+    expect(scoreSearch(parsed, fields(CATALOGUE.find((p) => p.id === 'led')!))).toBe(0);
+  });
+});
+
+describe('matchesSearch', () => {
+  it('is a yes/no over a few strings', () => {
+    expect(matchesSearch('', ['ESP32 DevKit V1'])).toBe(true);
+    expect(matchesSearch('esp32', ['ESP32 DevKit V1'])).toBe(true);
+    expect(matchesSearch('esp 32', ['ESP32 DevKit V1'])).toBe(true);
+    expect(matchesSearch('devkit', ['ESP32 DevKit V1'])).toBe(true);
+    expect(matchesSearch('pico', ['ESP32 DevKit V1'])).toBe(false);
+    expect(matchesSearch('rp2040', ['Raspberry Pi Pico', 'raspberry-pi-pico', 'rp2040'])).toBe(
+      true,
+    );
+  });
+});

--- a/frontend/src/components/ComponentPickerModal.tsx
+++ b/frontend/src/components/ComponentPickerModal.tsx
@@ -33,6 +33,8 @@ interface CardHoverApi {
 import type { BoardKind } from '../types/board';
 import { BOARD_KIND_LABELS } from '../types/board';
 import { isProBoardKind } from '../lib/proBoardGate';
+import { matchesSearch } from '../utils/searchMatch';
+import { boardSearchKeywords } from '../data/componentSearchKeywords';
 import {
   getProBoard,
   listProBoards,
@@ -298,9 +300,14 @@ export const ComponentPickerModal: React.FC<ComponentPickerModalProps> = ({
     // display far more often than a bare transistor or a 74HC gate, so
     // passives / analog / logic sink to the end. Array.sort is stable —
     // the registry's own order is preserved within each category.
-    components = [...components].sort(
-      (a, b) => categoryRank(a.category) - categoryRank(b.category),
-    );
+    // While a query is typed the registry already returns best-match
+    // first; re-sorting by category would bury "LED" under every sensor
+    // whose description mentions one.
+    if (!searchQuery.trim()) {
+      components = [...components].sort(
+        (a, b) => categoryRank(a.category) - categoryRank(b.category),
+      );
+    }
 
     return components;
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -318,13 +325,12 @@ export const ComponentPickerModal: React.FC<ComponentPickerModalProps> = ({
   // (the hosted overlay merges it in) — same contract as VISIBLE_BOARD_ADS.
   const visibleComponentAds = useMemo(() => {
     if (isLoading) return [];
-    const q = searchQuery.toLowerCase();
     return ONLINE_ONLY_COMPONENT_ADS.filter(
       (ad) =>
         !registry.getById(ad.id) &&
         !isOnlineOnlyAdSuppressed(ad.id) &&
         (selectedCategory === 'all' || ad.category === selectedCategory) &&
-        (!q || ad.label.toLowerCase().includes(q)),
+        matchesSearch(searchQuery, [ad.label]),
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [registry, isLoading, searchQuery, selectedCategory, registryVersion, proBoardsVersion]);
@@ -455,27 +461,26 @@ export const ComponentPickerModal: React.FC<ComponentPickerModalProps> = ({
                   className="components-grid components-grid--inline"
                   style={{ borderBottom: '1px solid var(--wb-6)', paddingBottom: 8, marginBottom: 4 }}
                 >
-                  {allBoards.filter(
-                    (k) =>
-                      !searchQuery ||
-                      BOARD_KIND_LABELS[k].toLowerCase().includes(searchQuery.toLowerCase()),
-                  ).map((kind) => (
-                    <BoardCard
-                      key={kind}
-                      kind={kind}
-                      onSelect={() => {
-                        onSelectBoard(kind);
-                        onClose();
-                      }}
-                      hoverApi={hoverApi}
-                    />
-                  ))}
-                  {visibleBoardAds().filter(
-                    (ad) =>
-                      !searchQuery || ad.label.toLowerCase().includes(searchQuery.toLowerCase()),
-                  ).map((ad) => (
-                    <OnlineOnlyBoardCard key={ad.id} ad={ad} />
-                  ))}
+                  {allBoards
+                    .filter((k) =>
+                      matchesSearch(searchQuery, [BOARD_KIND_LABELS[k], k, boardSearchKeywords(k)]),
+                    )
+                    .map((kind) => (
+                      <BoardCard
+                        key={kind}
+                        kind={kind}
+                        onSelect={() => {
+                          onSelectBoard(kind);
+                          onClose();
+                        }}
+                        hoverApi={hoverApi}
+                      />
+                    ))}
+                  {visibleBoardAds()
+                    .filter((ad) => matchesSearch(searchQuery, [ad.label]))
+                    .map((ad) => (
+                      <OnlineOnlyBoardCard key={ad.id} ad={ad} />
+                    ))}
                 </div>
               )}
 

--- a/frontend/src/components/examples/ExamplesGallery.tsx
+++ b/frontend/src/components/examples/ExamplesGallery.tsx
@@ -14,6 +14,8 @@ import {
 } from '../../data/examples';
 import { subscribeProBoards, getProBoardsVersion } from '../../lib/proBoardRegistry';
 import { BOARD_KIND_LABELS } from '../../types/board';
+import { parseSearchQuery, scoreSearch } from '../../utils/searchMatch';
+import { exampleSearchFields } from '../../utils/exampleSearch';
 import { ExampleThumbnail } from './ExampleThumbnail';
 import './ExamplesGallery.css';
 
@@ -116,44 +118,22 @@ export const ExamplesGallery: React.FC<ExamplesGalleryProps> = ({ onLoadExample 
     });
   }, []);
 
-  // Pre-tokenise the search string once per keystroke. Each token must match
-  // somewhere in the example's haystack, so users can type "esp32 oled dht"
-  // and find every project that hits all three.
-  const searchTokens = search
-    .trim()
-    .toLowerCase()
-    .split(/\s+/)
-    .filter(Boolean);
+  // Parsed once per keystroke. Every word must land somewhere in the
+  // example (title, tags, parts, board, category, description); words can
+  // be partial ("ultra"), misspelled ("potenciometer"), in the user's own
+  // language ("temperatura") or spaced differently ("hc sr04"), and the
+  // matches come back best-first. See utils/searchMatch.
+  const searchQuery = parseSearchQuery(search);
 
-  const exampleHaystack = (example: ExampleProject): string =>
-    [
-      example.title,
-      example.description,
-      example.category,
-      example.difficulty,
-      getBoardFilter(example),
-      ...(example.tags ?? []),
-      // Defensive. `components` is required by ExampleProject, but overlay
-      // example sets are built by factories that cast their result, so the
-      // compiler is not actually guarding this. One entry that omitted it took
-      // the entire gallery down with a TypeError the first time anyone typed in
-      // the search box — a whole page lost to one malformed example.
-      ...(example.components ?? []).map((c) => c.type),
-    ]
-      .join(' ')
-      .toLowerCase();
-
-  const filteredExamples = exampleProjects.filter((example) => {
-    const boardMatch =
-      selectedBoard === 'all' ||
-      (selectedBoard === 'retro' ? isRetro(example) : getBoardFilter(example) === selectedBoard);
-    const catMatch = selectedCategory === 'all' || example.category === selectedCategory;
-    const diffMatch = selectedDifficulty === 'all' || example.difficulty === selectedDifficulty;
-    if (!boardMatch || !catMatch || !diffMatch) return false;
-    if (searchTokens.length === 0) return true;
-    const hay = exampleHaystack(example);
-    return searchTokens.every((tok) => hay.includes(tok));
-  })
+  const browseOrder = exampleProjects
+    .filter((example) => {
+      const boardMatch =
+        selectedBoard === 'all' ||
+        (selectedBoard === 'retro' ? isRetro(example) : getBoardFilter(example) === selectedBoard);
+      const catMatch = selectedCategory === 'all' || example.category === selectedCategory;
+      const diffMatch = selectedDifficulty === 'all' || example.difficulty === selectedDifficulty;
+      return boardMatch && catMatch && diffMatch;
+    })
     .sort((a, b) => {
       // Order by board following the boardTabs order (so Arduino Uno comes
       // first), then alphabetically by title within each board.
@@ -162,6 +142,18 @@ export const ExamplesGallery: React.FC<ExamplesGalleryProps> = ({ onLoadExample 
       if (ra !== rb) return (ra < 0 ? 999 : ra) - (rb < 0 ? 999 : rb);
       return (a.title ?? '').localeCompare(b.title ?? '');
     });
+
+  const filteredExamples = searchQuery
+    ? browseOrder
+        .map((example) => ({
+          example,
+          score: scoreSearch(searchQuery, exampleSearchFields(example, getBoardFilter(example))),
+        }))
+        .filter((s) => s.score > 0)
+        // Stable sort: equal scores keep the board/title order from above.
+        .sort((a, b) => b.score - a.score)
+        .map((s) => s.example)
+    : browseOrder;
 
   // Count per board for tab badges
   const boardCounts: Record<string, number> = {
@@ -518,11 +510,11 @@ export const ExamplesGallery: React.FC<ExamplesGalleryProps> = ({ onLoadExample 
       {filteredExamples.length === 0 && (
         <div className="examples-empty">
           <p>
-            {searchTokens.length > 0
+            {searchQuery !== null
               ? t('examples.emptyForQuery', { query: search.trim() })
               : t('examples.empty')}
           </p>
-          {(searchTokens.length > 0 ||
+          {(searchQuery !== null ||
             selectedBoard !== 'all' ||
             selectedCategory !== 'all' ||
             selectedDifficulty !== 'all') && (

--- a/frontend/src/data/componentSearchKeywords.ts
+++ b/frontend/src/data/componentSearchKeywords.ts
@@ -1,0 +1,197 @@
+/**
+ * Search-only vocabulary per component id.
+ *
+ * The scanned metadata gives most parts nothing to search by beyond their
+ * own name ("DHT22", tags ["dht22"]), so "temperature" found no sensor and
+ * "ultrasonic" found no HC-SR04. These words are what a person reaching for
+ * the part would type; they are never displayed. Overlay parts can carry the
+ * same thing in `ComponentMetadata.keywords`; entries here are merged with
+ * those at search time, so an id listed in both gets both.
+ *
+ * Keep it English: the query side translates through utils/searchSynonyms.ts
+ * ("temperatura" is searched as "temperature").
+ */
+
+const KEYWORDS: Record<string, string> = {
+  // ── Boards (also the boards row of the picker) ──────────────────────────
+  'arduino-uno': 'board microcontroller atmega328p avr uno r3',
+  'arduino-nano': 'board microcontroller atmega328p avr nano small',
+  'arduino-mega': 'board microcontroller atmega2560 avr mega 2560',
+  'esp32-devkit-v1': 'board microcontroller esp32 wifi bluetooth xtensa wroom devkit',
+  franzininho: 'board microcontroller attiny85 avr digispark',
+  'nano-rp2040-connect': 'board microcontroller arduino nano rp2040 wifi',
+
+  // ── Sensors ─────────────────────────────────────────────────────────────
+  dht22: 'temperature humidity sensor dht11 dht weather climate am2302',
+  bmp280: 'pressure temperature barometer altitude weather sensor i2c bosch',
+  'hc-sr04': 'ultrasonic distance sensor sonar ranging proximity obstacle echo trigger',
+  'pir-motion-sensor': 'pir motion sensor presence movement infrared hc-sr501',
+  'ntc-temperature-sensor': 'thermistor temperature sensor ntc analog',
+  'photoresistor-sensor': 'ldr light sensor photoresistor brightness darkness analog',
+  photodiode: 'light sensor photodiode optical analog',
+  mpu6050: 'accelerometer gyroscope imu motion tilt orientation 6 axis i2c gy-521',
+  'gps-neo6m': 'gps location position satellite nmea serial uart',
+  'heart-beat-sensor': 'heart rate pulse sensor bpm ppg ky-039',
+  'gas-sensor': 'gas sensor smoke air quality mq2 mq135 mq-2 analog',
+  'flame-sensor': 'flame fire sensor infrared detector',
+  'tilt-switch': 'tilt switch ball sensor orientation shake',
+  'big-sound-sensor': 'sound sensor microphone mic audio noise clap',
+  'small-sound-sensor': 'sound sensor microphone mic audio noise clap',
+  hx711: 'load cell weight scale amplifier adc strain gauge',
+  ds1307: 'rtc real time clock date time i2c battery backup',
+  ds3231: 'rtc real time clock date time i2c precision temperature',
+
+  // ── Displays ────────────────────────────────────────────────────────────
+  ssd1306: 'oled display screen monochrome 128x64 i2c spi',
+  'ssd1306-i2c-4pin': 'oled display screen monochrome 128x64 i2c 4 pin',
+  lcd1602: 'lcd display screen character text 16x2 hd44780 liquidcrystal parallel',
+  'lcd1602-i2c': 'lcd display screen character text 16x2 hd44780 liquidcrystal i2c',
+  lcd2004: 'lcd display screen character text 20x4 hd44780 liquidcrystal parallel',
+  'lcd2004-i2c': 'lcd display screen character text 20x4 hd44780 liquidcrystal i2c',
+  ili9341: 'tft lcd display screen color spi 240x320 touch 2.8',
+  'epaper-1in54-bw': 'epaper e-ink eink display screen',
+  'epaper-2in13-bw': 'epaper e-ink eink display screen',
+  'epaper-2in13-bwr': 'epaper e-ink eink display screen red',
+  'epaper-2in9-bw': 'epaper e-ink eink display screen',
+  'epaper-2in9-bwr': 'epaper e-ink eink display screen red',
+  'epaper-4in2-bw': 'epaper e-ink eink display screen',
+  'epaper-5in65-7c': 'epaper e-ink eink display screen color',
+  'epaper-7in5-bw': 'epaper e-ink eink display screen',
+  '7segment': 'seven segment display digit number counter',
+  'led-bar-graph': 'led bar graph level meter vu indicator',
+  'neopixel-matrix': 'neopixel matrix ws2812 rgb led addressable pixels 8x8',
+  'led-ring': 'led ring neopixel ws2812 rgb addressable circle',
+
+  // ── Input ───────────────────────────────────────────────────────────────
+  pushbutton: 'push button switch tactile momentary input',
+  'pushbutton-6mm': 'push button switch tactile momentary small input',
+  'slide-switch': 'slide switch toggle spdt on off',
+  'dip-switch-8': 'dip switch toggle settings 8 way',
+  potentiometer: 'potentiometer pot knob dial variable resistor analog input trimmer volume',
+  'slide-potentiometer': 'slider fader potentiometer analog input linear',
+  'ky-040': 'rotary encoder knob dial input quadrature',
+  'membrane-keypad': 'keypad keyboard matrix buttons 4x4 numeric',
+  'analog-joystick': 'joystick gamepad thumbstick xy input analog',
+  'rotary-dialer': 'rotary dial phone telephone pulse retro',
+  'ir-receiver': 'infrared receiver remote control ir nec',
+  'ir-remote': 'infrared remote control handset ir nec',
+
+  // ── Output ──────────────────────────────────────────────────────────────
+  led: 'led light diode indicator lamp',
+  'rgb-led': 'rgb led color light multicolor',
+  neopixel: 'neopixel ws2812 rgb led addressable strip pixel',
+  buzzer: 'buzzer speaker piezo sound beep tone audio alarm music',
+
+  // ── Motors and drivers ──────────────────────────────────────────────────
+  servo: 'servo motor sg90 pwm angle position',
+  'stepper-motor': 'stepper motor 28byj-48 nema steps',
+  'biaxial-stepper': 'stepper motor bipolar biaxial',
+  a4988: 'stepper motor driver step dir microstepping',
+  'motor-driver-l293d': 'motor driver h-bridge dc motor l293d dual',
+  relay: 'relay switch coil mains load spdt',
+  'ks2e-m-dc5': 'relay dpdt coil switch',
+
+  // ── Storage and connectivity ────────────────────────────────────────────
+  'microsd-card': 'sd card microsd storage memory spi files',
+
+  // ── Passive ─────────────────────────────────────────────────────────────
+  breadboard: 'breadboard protoboard prototype',
+  'breadboard-mini': 'breadboard protoboard prototype small',
+  junction: 'junction wire node net',
+  resistor: 'resistor ohm custom value',
+  capacitor: 'capacitor ceramic custom value',
+  'capacitor-electrolytic': 'capacitor electrolytic polarized custom value',
+  inductor: 'inductor coil custom value',
+
+  // ── Analog ──────────────────────────────────────────────────────────────
+  diode: 'diode rectifier',
+  'diode-1n4007': 'rectifier diode power mains',
+  'diode-1n4148': 'signal diode switching fast',
+  'zener-1n4733': 'zener diode voltage reference regulator',
+  'diode-1n5817': 'schottky diode low drop',
+  'diode-1n5819': 'schottky diode low drop',
+  'bjt-2n2222': 'transistor bjt npn switch amplifier',
+  'bjt-2n3055': 'transistor bjt npn power switch amplifier',
+  'bjt-2n3906': 'transistor bjt pnp switch amplifier',
+  'bjt-bc547': 'transistor bjt npn switch amplifier',
+  'bjt-bc557': 'transistor bjt pnp switch amplifier',
+  'mosfet-2n7000': 'transistor mosfet fet n channel switch',
+  'mosfet-irf540': 'transistor mosfet fet n channel power switch',
+  'mosfet-irf9540': 'transistor mosfet fet p channel switch',
+  'mosfet-fqp27p06': 'transistor mosfet fet p channel switch',
+  'opto-4n25': 'optocoupler optoisolator isolation',
+  'opto-pc817': 'optocoupler optoisolator isolation',
+  'reg-7805': 'voltage regulator linear power supply 5v',
+  'reg-7812': 'voltage regulator linear power supply 12v',
+  'reg-7905': 'voltage regulator linear power supply negative 5v',
+  'reg-lm317': 'voltage regulator linear adjustable power supply',
+  'battery-9v': 'battery power source 9v',
+  'battery-aa': 'battery power source aa cell 1.5v',
+  'battery-coin-cell': 'battery power source coin cell cr2032 3v',
+  'opamp-ideal': 'op amp operational amplifier ideal',
+  'opamp-lm324': 'op amp operational amplifier quad',
+  'opamp-lm358': 'op amp operational amplifier dual',
+  'opamp-lm741': 'op amp operational amplifier',
+  'opamp-tl072': 'op amp operational amplifier jfet audio',
+  'power-supply': 'power supply psu bench voltage source dc',
+  'signal-generator': 'signal function generator waveform sine square oscillator source',
+
+  // ── Logic ───────────────────────────────────────────────────────────────
+  'ic-74hc00': 'logic ic chip nand gate 7400',
+  'ic-74hc02': 'logic ic chip nor gate 7402',
+  'ic-74hc04': 'logic ic chip not inverter 7404',
+  'ic-74hc08': 'logic ic chip and gate 7408',
+  'ic-74hc14': 'logic ic chip schmitt inverter 7414',
+  'ic-74hc32': 'logic ic chip or gate 7432',
+  'ic-74hc86': 'logic ic chip xor gate 7486',
+  'flip-flop-d': 'flip flop latch register memory',
+  'flip-flop-jk': 'flip flop latch memory',
+  'flip-flop-t': 'flip flop toggle latch memory',
+};
+
+/** Keys use the registry's bare id ("led"), not the element tag ("wokwi-led"). */
+export function componentSearchKeywords(id: string): string {
+  const bare = id.replace(/^(wokwi|velxio)-/, '');
+  return KEYWORDS[bare] ?? '';
+}
+
+/**
+ * Board kinds in the picker's boards row are not registry entries; they get
+ * a line each here so "rp2040", "riscv" or "wifi" reach the right card.
+ */
+const BOARD_KEYWORDS: Record<string, string> = {
+  'arduino-uno': 'arduino avr atmega328p uno',
+  'arduino-nano': 'arduino avr atmega328p nano',
+  'arduino-mega': 'arduino avr atmega2560 mega',
+  'raspberry-pi-pico': 'raspberry pi pico rp2040 micropython arm cortex m0',
+  'pi-pico-w': 'raspberry pi pico w rp2040 wifi wireless micropython',
+  'raspberry-pi-zero': 'raspberry pi zero linux python',
+  'raspberry-pi-1': 'raspberry pi 1 linux python',
+  'raspberry-pi-2': 'raspberry pi 2 linux python',
+  'raspberry-pi-3': 'raspberry pi 3 linux python wifi',
+  'raspberry-pi-4': 'raspberry pi 4 linux python wifi',
+  'raspberry-pi-5': 'raspberry pi 5 linux python wifi',
+  esp32: 'esp32 espressif wifi bluetooth xtensa wroom devkit',
+  'esp32-devkit-c-v4': 'esp32 espressif wifi bluetooth xtensa wroom devkit',
+  'esp32-cam': 'esp32 espressif camera wifi ov2640',
+  'wemos-lolin32-lite': 'esp32 espressif wifi bluetooth wemos lolin',
+  'esp32-s3': 'esp32 s3 espressif wifi bluetooth xtensa usb',
+  'xiao-esp32-s3': 'esp32 s3 seeed xiao espressif wifi bluetooth small',
+  'arduino-nano-esp32': 'arduino nano esp32 s3 espressif wifi bluetooth',
+  'esp32-c3': 'esp32 c3 espressif wifi bluetooth riscv risc-v',
+  'xiao-esp32-c3': 'esp32 c3 seeed xiao espressif wifi bluetooth riscv small',
+  'aitewinrobot-esp32c3-supermini': 'esp32 c3 supermini espressif wifi bluetooth riscv small',
+  'stm32-bluepill': 'stm32 arm cortex m3 f103 blue pill stmicro',
+  'stm32-blackpill': 'stm32 arm cortex m4 f401 f411 black pill stmicro',
+  'stm32-bluepill-f103cb': 'stm32 arm cortex m3 f103 blue pill stmicro',
+  'stm32-blackpill-f401': 'stm32 arm cortex m4 f401 black pill stmicro',
+  'stm32-f4-discovery': 'stm32 arm cortex m4 f407 discovery stmicro',
+  'stm32-olimex-h405': 'stm32 arm cortex m4 f405 olimex stmicro',
+  'stm32-netduino-plus2': 'stm32 arm cortex m4 netduino stmicro',
+  'stm32-netduino2': 'stm32 arm cortex m4 netduino stmicro',
+  attiny85: 'attiny avr tiny digispark small',
+};
+
+export function boardSearchKeywords(kind: string): string {
+  return BOARD_KEYWORDS[kind] ?? '';
+}

--- a/frontend/src/services/ComponentRegistry.ts
+++ b/frontend/src/services/ComponentRegistry.ts
@@ -5,6 +5,8 @@
  * Loads from components-metadata.json generated at build time.
  */
 
+import { prepareSearchFields, rankBySearch, type PreparedSearchFields } from '../utils/searchMatch';
+import { componentSearchKeywords } from '../data/componentSearchKeywords';
 import type {
   ComponentMetadata,
   ComponentCategory,
@@ -334,22 +336,41 @@ export class ComponentRegistry {
   }
 
   /**
-   * Search components by query (name, description, tags)
+   * Search components by query, best match first.
+   *
+   * Every word of the query must land somewhere in the part's name, id,
+   * tags, search keywords, category or description; words can be partial
+   * ("temp"), misspelled ("potenciometer"), in another language
+   * ("temperatura") or spaced differently ("hc sr04"). See utils/searchMatch.
+   * A blank query returns the catalogue in browsing order.
    */
   search(query: string): ComponentMetadata[] {
-    if (!query.trim()) {
-      return this.getAllComponents();
-    }
+    return rankBySearch(this.allComponents, query, (c) => this.searchFieldsOf(c));
+  }
 
-    const lowerQuery = query.toLowerCase();
-    return this.allComponents.filter((component) => {
-      return (
-        component.name.toLowerCase().includes(lowerQuery) ||
-        component.id.toLowerCase().includes(lowerQuery) ||
-        component.description?.toLowerCase().includes(lowerQuery) ||
-        component.tags.some((tag) => tag.toLowerCase().includes(lowerQuery))
-      );
-    });
+  /** Normalised once per metadata object; mergeComponents() replaces the
+   *  objects it touches, so a stale entry can never be served. */
+  private _searchFields = new WeakMap<ComponentMetadata, PreparedSearchFields>();
+
+  private searchFieldsOf(component: ComponentMetadata): PreparedSearchFields {
+    const hit = this._searchFields.get(component);
+    if (hit) return hit;
+    const prepared = prepareSearchFields([
+      { text: component.name, weight: 3 },
+      { text: component.id, weight: 2.5 },
+      { text: component.tags.join(' '), weight: 2.5 },
+      {
+        text: [componentSearchKeywords(component.id), ...(component.keywords ?? [])].join(' '),
+        weight: 2,
+      },
+      {
+        text: `${component.category} ${ComponentRegistry.getCategoryDisplayName(component.category)}`,
+        weight: 1,
+      },
+      { text: component.description ?? '', weight: 1 },
+    ]);
+    this._searchFields.set(component, prepared);
+    return prepared;
   }
 
   /**

--- a/frontend/src/types/component-metadata.ts
+++ b/frontend/src/types/component-metadata.ts
@@ -42,6 +42,10 @@ export interface ComponentMetadata {
   defaultValues: Record<string, any>;
   pinCount: number;
   tags: string[]; // For search functionality
+  // Search-only words never shown in the UI ("temperature humidity" on a
+  // DHT22). The OSS catalogue keeps its list in data/componentSearchKeywords.ts;
+  // overlay parts can ship theirs here. Merged with tags at search time.
+  keywords?: string[];
   // Optional flag set by private overlays (e.g. velxio.dev) to mark a
   // component as gated behind a paid subscription. The OSS image never
   // sets this — self-hosters have everything unlocked. The picker can

--- a/frontend/src/utils/exampleSearch.ts
+++ b/frontend/src/utils/exampleSearch.ts
@@ -1,0 +1,39 @@
+/**
+ * What the examples gallery search matches against, normalised once per
+ * example: the gallery filters on every keystroke and there are several
+ * hundred entries. Keyed by the example object, so an overlay registering
+ * late examples (new objects) can never be served a stale entry.
+ */
+
+import type { ExampleProject } from '../data/examples';
+import { componentSearchKeywords } from '../data/componentSearchKeywords';
+import { prepareSearchFields, type PreparedSearchFields } from './searchMatch';
+
+const cache = new WeakMap<ExampleProject, PreparedSearchFields>();
+
+export function exampleSearchFields(
+  example: ExampleProject,
+  boardFilter: string,
+): PreparedSearchFields {
+  const hit = cache.get(example);
+  if (hit) return hit;
+  // Defensive on `components`: it is required by ExampleProject, but overlay
+  // example sets are built by factories that cast their result, so the
+  // compiler is not actually guarding this. One entry that omitted it took
+  // the entire gallery down with a TypeError the first time anyone typed in
+  // the search box — a whole page lost to one malformed example.
+  const partTypes = (example.components ?? []).map((c) => c.type);
+  const prepared = prepareSearchFields([
+    { text: example.title, weight: 3 },
+    { text: (example.tags ?? []).join(' '), weight: 2 },
+    // The parts on the canvas, plus what people call them: an example with
+    // a DHT22 is found by "temperature" even if its title never says so.
+    { text: partTypes.join(' '), weight: 2 },
+    { text: partTypes.map(componentSearchKeywords).join(' '), weight: 1.5 },
+    { text: `${boardFilter} ${example.boardType ?? ''}`, weight: 1.5 },
+    { text: `${example.category} ${example.difficulty}`, weight: 1 },
+    { text: example.description, weight: 1 },
+  ]);
+  cache.set(example, prepared);
+  return prepared;
+}

--- a/frontend/src/utils/searchMatch.ts
+++ b/frontend/src/utils/searchMatch.ts
@@ -1,0 +1,281 @@
+/**
+ * Search matching shared by the component picker, the examples gallery and
+ * any other "type to filter a list" surface.
+ *
+ * What a query has to survive here:
+ *   - partial words: "temp" finds "temperature", "ultra" finds "ultrasonic";
+ *   - several words in any order, each matched independently ("esp32 oled");
+ *   - punctuation and spacing differences: "hc-sr04", "hc sr04" and "hcsr04"
+ *     are the same query, and "ssd 1306" finds the SSD1306;
+ *   - accents: "botón" and "boton" are the same word;
+ *   - typos: "potenciometer", "ultrasnic", "arduno" still land on the part;
+ *   - another language or an alias: "temperatura", "pantalla", "btn" go
+ *     through the synonym table in ./searchSynonyms.ts;
+ *   - little words ("sensor de temperatura", "led and button") never make a
+ *     query fail: a stopword only adds score, it is not required to match.
+ *
+ * And the result is RANKED, so a whole-word hit on the name outranks a
+ * substring buried in a description, which outranks a typo-tolerant hit.
+ *
+ * The plain `includes()` this replaces failed every one of those: it needed
+ * the literal query text inside one field, in the right order, spelled
+ * exactly, in English.
+ */
+
+import { STOPWORDS, expandSearchToken } from './searchSynonyms';
+
+// ── Normalisation ─────────────────────────────────────────────────────────
+
+const COMBINING_MARKS = /[̀-ͯ]/g;
+
+/**
+ * Lower-case, strip accents, fold the few symbols that appear in part names
+ * (µ, Ω) to letters, and turn every other non-alphanumeric run into a single
+ * space. Applied identically to the query and to the haystack, so any
+ * spelling of "HC-SR04" meets any other.
+ */
+export function normalizeSearchText(text: string): string {
+  return text
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(COMBINING_MARKS, '')
+    .replace(/µ/g, 'u')
+    .replace(/[ωΩ]/g, 'ohm')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+// ── Edit distance ─────────────────────────────────────────────────────────
+
+/**
+ * Optimal-string-alignment distance (Levenshtein + adjacent transposition),
+ * with an early exit once every cell of a row exceeds `max`. Returns
+ * `max + 1` for "too far", so callers compare with `<= max`.
+ */
+export function editDistance(a: string, b: string, max: number): number {
+  if (a === b) return 0;
+  const la = a.length;
+  const lb = b.length;
+  if (Math.abs(la - lb) > max) return max + 1;
+  if (la === 0) return lb;
+  if (lb === 0) return la;
+
+  let prev2: number[] = [];
+  let prev: number[] = new Array<number>(lb + 1);
+  for (let j = 0; j <= lb; j++) prev[j] = j;
+
+  for (let i = 1; i <= la; i++) {
+    const cur: number[] = new Array<number>(lb + 1);
+    cur[0] = i;
+    let rowMin = cur[0];
+    const ca = a.charCodeAt(i - 1);
+    for (let j = 1; j <= lb; j++) {
+      const cb = b.charCodeAt(j - 1);
+      const cost = ca === cb ? 0 : 1;
+      let v = Math.min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + cost);
+      if (i > 1 && j > 1 && ca === b.charCodeAt(j - 2) && a.charCodeAt(i - 2) === cb) {
+        v = Math.min(v, prev2[j - 2] + 1);
+      }
+      cur[j] = v;
+      if (v < rowMin) rowMin = v;
+    }
+    if (rowMin > max) return max + 1;
+    prev2 = prev;
+    prev = cur;
+  }
+  return prev[lb] > max ? max + 1 : prev[lb];
+}
+
+// ── Fields ────────────────────────────────────────────────────────────────
+
+export interface SearchField {
+  /** Raw text; normalised once by prepareSearchFields(). */
+  text: string;
+  /** Relative importance. Name-like fields around 3, tags 2, descriptions 1. */
+  weight?: number;
+}
+
+interface PreparedField {
+  text: string;
+  compact: string;
+  words: string[];
+  weight: number;
+}
+
+export interface PreparedSearchFields {
+  fields: PreparedField[];
+  /** The first field, used for whole-phrase bonuses ("exactly this name"). */
+  primary: PreparedField | null;
+}
+
+/**
+ * Normalise a set of fields once. Callers that filter on every keystroke
+ * should cache the result per item (a WeakMap keyed by the item works).
+ */
+export function prepareSearchFields(fields: SearchField[]): PreparedSearchFields {
+  const prepared: PreparedField[] = [];
+  for (const f of fields) {
+    if (!f.text) continue;
+    const text = normalizeSearchText(f.text);
+    if (!text) continue;
+    prepared.push({
+      text,
+      compact: text.replace(/ /g, ''),
+      words: text.split(' '),
+      weight: f.weight ?? 1,
+    });
+  }
+  return { fields: prepared, primary: prepared[0] ?? null };
+}
+
+// ── Query ─────────────────────────────────────────────────────────────────
+
+interface QueryToken {
+  /** The token as typed (normalised) plus its synonyms, best-first. */
+  forms: string[];
+  /** Stopwords only add score; every other token must match somewhere. */
+  required: boolean;
+}
+
+export interface ParsedSearchQuery {
+  tokens: QueryToken[];
+  /** Whole normalised query, for phrase bonuses on the primary field. */
+  phrase: string;
+  /** No token is a stopword? Then a phrase bonus makes sense. */
+  hasRequired: boolean;
+}
+
+/** Null when the query is blank, so callers can short-circuit to "all". */
+export function parseSearchQuery(query: string): ParsedSearchQuery | null {
+  const phrase = normalizeSearchText(query);
+  if (!phrase) return null;
+  const words = phrase.split(' ');
+  const tokens: QueryToken[] = words.map((w) => ({
+    forms: expandSearchToken(w),
+    required: !STOPWORDS.has(w),
+  }));
+  const hasRequired = tokens.some((t) => t.required);
+  // A query made only of stopwords ("and", "or", "not") is a real query for
+  // the logic gates of that name: nothing to relax, every token counts.
+  if (!hasRequired) for (const t of tokens) t.required = true;
+  return { tokens, phrase, hasRequired: true };
+}
+
+// ── Scoring ───────────────────────────────────────────────────────────────
+
+const LEVEL_EXACT_WORD = 1.0;
+const LEVEL_WORD_PREFIX = 0.8;
+const LEVEL_SUBSTRING = 0.6;
+const LEVEL_FUZZY = 0.4;
+const LEVEL_FUZZY_PREFIX = 0.3;
+/** A hit reached through a synonym is worth a little less than a direct one. */
+const SYNONYM_PENALTY = 0.9;
+
+/** How many typos a token may carry, by its length. Short tokens: none. */
+function typoBudget(token: string): number {
+  if (token.length >= 8) return 2;
+  if (token.length >= 5) return 1;
+  return 0;
+}
+
+function matchTokenForm(form: string, field: PreparedField): number {
+  const { words } = field;
+  for (const w of words) if (w === form) return LEVEL_EXACT_WORD;
+  for (const w of words) if (w.startsWith(form)) return LEVEL_WORD_PREFIX;
+  if (field.text.includes(form) || field.compact.includes(form)) return LEVEL_SUBSTRING;
+
+  const budget = typoBudget(form);
+  if (budget === 0) return 0;
+  let best = 0;
+  for (const w of words) {
+    if (w.length < 4) continue;
+    const d = editDistance(form, w, budget);
+    if (d <= budget) {
+      const level = LEVEL_FUZZY - (d - 1) * 0.1;
+      if (level > best) best = level;
+    }
+  }
+  if (best > 0) return best;
+  // A typo inside the first letters of a longer word ("potenc" vs
+  // "potentiometer" typed as "potenz"): compare against the word's prefix.
+  for (const w of words) {
+    if (w.length <= form.length) continue;
+    const d = editDistance(form, w.slice(0, form.length), budget);
+    if (d <= budget) return LEVEL_FUZZY_PREFIX;
+  }
+  return 0;
+}
+
+function scoreToken(token: QueryToken, prepared: PreparedSearchFields): number {
+  let best = 0;
+  token.forms.forEach((form, i) => {
+    const penalty = i === 0 ? 1 : SYNONYM_PENALTY;
+    for (const field of prepared.fields) {
+      const level = matchTokenForm(form, field);
+      if (level === 0) continue;
+      const s = level * penalty * field.weight;
+      if (s > best) best = s;
+    }
+  });
+  return best;
+}
+
+/**
+ * Score an item against a parsed query. 0 means "does not match": some
+ * required token found nothing in any field. Higher is a better match.
+ */
+export function scoreSearch(query: ParsedSearchQuery, prepared: PreparedSearchFields): number {
+  let total = 0;
+  for (const token of query.tokens) {
+    const s = scoreToken(token, prepared);
+    if (s === 0 && token.required) return 0;
+    total += s;
+  }
+  if (total === 0) return 0;
+
+  // Phrase bonuses on the primary (name) field: "led" should list the part
+  // called LED before the 40 parts that merely mention one.
+  const primary = prepared.primary;
+  if (primary) {
+    const phrase = query.phrase;
+    if (primary.text === phrase || primary.compact === phrase.replace(/ /g, '')) {
+      total += 3 * primary.weight;
+    } else if (primary.text.startsWith(phrase)) {
+      total += 2 * primary.weight;
+    } else if (primary.text.includes(phrase)) {
+      total += 1 * primary.weight;
+    }
+    // Shorter names are the more specific hit for the same score ("LED"
+    // over "LED Ring" over "Led Bar Graph").
+    total += 1 / (1 + primary.words.length);
+  }
+  return total;
+}
+
+/**
+ * Filter + rank `items` by `query`. Blank query returns `items` untouched.
+ * Ties keep the input order (Array.sort is stable), so callers can pass a
+ * list already sorted by their own browsing order.
+ */
+export function rankBySearch<T>(
+  items: readonly T[],
+  query: string,
+  prepare: (item: T) => PreparedSearchFields,
+): T[] {
+  const parsed = parseSearchQuery(query);
+  if (!parsed) return [...items];
+  const scored: { item: T; score: number }[] = [];
+  for (const item of items) {
+    const score = scoreSearch(parsed, prepare(item));
+    if (score > 0) scored.push({ item, score });
+  }
+  scored.sort((a, b) => b.score - a.score);
+  return scored.map((s) => s.item);
+}
+
+/** Yes/no for tiny lists (a boards row, a handful of ads). */
+export function matchesSearch(query: string, texts: readonly string[]): boolean {
+  const parsed = parseSearchQuery(query);
+  if (!parsed) return true;
+  return scoreSearch(parsed, prepareSearchFields(texts.map((text) => ({ text })))) > 0;
+}

--- a/frontend/src/utils/searchSynonyms.ts
+++ b/frontend/src/utils/searchSynonyms.ts
@@ -1,0 +1,722 @@
+/**
+ * Vocabulary for searchMatch.ts: stopwords and a synonym table.
+ *
+ * Part names, tags and example titles are English, but the UI ships in nine
+ * languages and people type in their own: "temperatura", "pantalla",
+ * "bouton", "Taster". Each concept below lists the English words the
+ * catalogue actually uses (`en`) and the words people type for it in any
+ * language, abbreviations included ("btn", "pot", "mic"). A synonym hit
+ * scores slightly below a direct hit, so a part whose name really is the
+ * typed word still comes first.
+ *
+ * Words are matched after normalizeSearchText(): lower-case, no accents.
+ * Keep them single words; the query is split before lookup, so a phrase like
+ * "paso a paso" is three lookups and "paso" alone reaches "stepper". A word
+ * may appear under several concepts; the lookups merge.
+ *
+ * Latin-script locales only (es, pt-br, fr, de, it). The CJK and Cyrillic
+ * locales search part numbers, which read the same in every language.
+ */
+
+/**
+ * Words that are never required to match: "sensor DE temperatura" must not
+ * fail on "de". They still add score when they do match, so the AND gate is
+ * findable as "and gate" ("gate" is required, "and" is a bonus) and a query
+ * made only of stopwords ("and", "or") is searched as typed.
+ */
+export const STOPWORDS: ReadonlySet<string> = new Set([
+  // en
+  'a',
+  'an',
+  'the',
+  'and',
+  'or',
+  'of',
+  'for',
+  'with',
+  'to',
+  'in',
+  'on',
+  'at',
+  'by',
+  'my',
+  // es
+  'de',
+  'del',
+  'la',
+  'el',
+  'los',
+  'las',
+  'un',
+  'una',
+  'unos',
+  'unas',
+  'y',
+  'o',
+  'en',
+  'con',
+  'para',
+  'por',
+  'al',
+  'mi',
+  // pt
+  'da',
+  'do',
+  'das',
+  'dos',
+  'um',
+  'uma',
+  'e',
+  'com',
+  'no',
+  'na',
+  'nos',
+  'nas',
+  'ao',
+  // fr
+  'le',
+  'les',
+  'des',
+  'du',
+  'et',
+  'une',
+  'pour',
+  'avec',
+  'au',
+  'aux',
+  'sur',
+  // de
+  'der',
+  'die',
+  'das',
+  'und',
+  'mit',
+  'fur',
+  'ein',
+  'eine',
+  'einen',
+  'einem',
+  'zum',
+  'zur',
+  'im',
+  // it
+  'il',
+  'lo',
+  'gli',
+  'di',
+  'per',
+  'della',
+  'dello',
+  'delle',
+  'degli',
+  'dei',
+  'nel',
+  'nella',
+]);
+
+interface Concept {
+  /** What the catalogue calls it (single words or short phrases). */
+  en: string[];
+  /** What people type for it, in any supported language. */
+  words: string[];
+}
+
+const CONCEPTS: Concept[] = [
+  // ── Physical quantities ─────────────────────────────────────────────────
+  {
+    en: ['temperature'],
+    words: [
+      'temp',
+      'thermo',
+      'thermometer',
+      'temperatura',
+      'termometro',
+      'thermometre',
+      'temperatur',
+      'termometer',
+    ],
+  },
+  {
+    en: ['humidity'],
+    words: [
+      'humid',
+      'moisture',
+      'humedad',
+      'umidade',
+      'humidite',
+      'feuchtigkeit',
+      'luftfeuchtigkeit',
+      'umidita',
+    ],
+  },
+  {
+    en: ['pressure'],
+    words: [
+      'barometer',
+      'altitude',
+      'presion',
+      'barometro',
+      'pressao',
+      'pression',
+      'druck',
+      'luftdruck',
+      'pressione',
+    ],
+  },
+  {
+    en: ['weather', 'temperature', 'humidity', 'pressure'],
+    words: ['clima', 'meteorologica', 'meteo', 'wetter', 'wetterstation', 'tempo'],
+  },
+  {
+    en: ['light'],
+    words: ['lux', 'brightness', 'luz', 'luces', 'lumiere', 'licht', 'luce', 'luci'],
+  },
+  {
+    en: ['light', 'night'],
+    words: ['dark', 'darkness', 'noche', 'oscuridad', 'noite', 'escuro', 'nuit', 'nacht', 'notte'],
+  },
+  {
+    en: ['distance', 'ultrasonic'],
+    words: ['range', 'proximity', 'distancia', 'distancia', 'abstand', 'entfernung', 'distanza'],
+  },
+  {
+    en: ['ultrasonic'],
+    words: [
+      'ultrasound',
+      'sonar',
+      'ultrasonido',
+      'ultrasonidos',
+      'ultrasonico',
+      'ultrassonico',
+      'ultrassom',
+      'ultrason',
+      'ultrasons',
+      'ultraschall',
+      'ultrasuoni',
+      'ultrasuono',
+    ],
+  },
+  {
+    en: ['sound'],
+    words: ['audio', 'noise', 'sonido', 'sonidos', 'som', 'son', 'ton', 'klang', 'suono'],
+  },
+  {
+    en: ['microphone', 'sound'],
+    words: ['mic', 'microfono', 'microfone', 'mikrofon'],
+  },
+  {
+    en: ['motion', 'pir'],
+    words: [
+      'presence',
+      'movement',
+      'movimiento',
+      'presencia',
+      'movimento',
+      'presenca',
+      'mouvement',
+      'bewegung',
+      'bewegungsmelder',
+      'presenza',
+    ],
+  },
+  {
+    en: ['weight', 'load cell', 'scale'],
+    words: [
+      'peso',
+      'bascula',
+      'balanza',
+      'balanca',
+      'poids',
+      'balance',
+      'gewicht',
+      'waage',
+      'bilancia',
+    ],
+  },
+  {
+    en: ['color', 'rgb'],
+    words: [
+      'colour',
+      'colores',
+      'cor',
+      'cores',
+      'couleur',
+      'couleurs',
+      'farbe',
+      'farben',
+      'colore',
+      'colori',
+    ],
+  },
+  {
+    en: ['gas', 'smoke'],
+    words: ['co2', 'humo', 'fumaca', 'fumee', 'rauch', 'fumo'],
+  },
+  {
+    en: ['flame', 'fire'],
+    words: ['llama', 'fuego', 'chama', 'fogo', 'flamme', 'feuer', 'fiamma', 'fuoco'],
+  },
+  {
+    en: ['infrared', 'ir'],
+    words: [
+      'infrarrojo',
+      'infrarrojos',
+      'infravermelho',
+      'infrarouge',
+      'infrarot',
+      'infrarosso',
+      'infrarossi',
+    ],
+  },
+  {
+    en: ['heart', 'pulse'],
+    words: [
+      'heartbeat',
+      'bpm',
+      'corazon',
+      'pulso',
+      'latido',
+      'coracao',
+      'batimento',
+      'coeur',
+      'pouls',
+      'herz',
+      'puls',
+      'cuore',
+      'battito',
+    ],
+  },
+  {
+    en: ['accelerometer', 'gyroscope'],
+    words: [
+      'imu',
+      'accel',
+      'gyro',
+      'acelerometro',
+      'giroscopio',
+      'accelerometre',
+      'beschleunigung',
+      'beschleunigungssensor',
+      'gyroskop',
+      'accelerometro',
+    ],
+  },
+  { en: ['tilt'], words: ['vibration', 'inclinacion', 'neigung', 'inclinazione'] },
+  {
+    en: ['water', 'level', 'soil', 'plant'],
+    words: [
+      'agua',
+      'suelo',
+      'tierra',
+      'planta',
+      'plantas',
+      'nivel',
+      'solo',
+      'eau',
+      'sol',
+      'plante',
+      'niveau',
+      'wasser',
+      'boden',
+      'pflanze',
+      'pegel',
+      'acqua',
+      'terreno',
+      'pianta',
+      'livello',
+    ],
+  },
+
+  // ── Parts ───────────────────────────────────────────────────────────────
+  { en: ['sensor'], words: ['sensores', 'capteur', 'capteurs', 'sensoren', 'sensore', 'sensori'] },
+  {
+    en: ['display', 'screen'],
+    words: [
+      'monitor',
+      'pantalla',
+      'pantallas',
+      'tela',
+      'telas',
+      'ecran',
+      'ecrans',
+      'afficheur',
+      'affichage',
+      'bildschirm',
+      'anzeige',
+      'anzeigen',
+      'schermo',
+      'schermi',
+    ],
+  },
+  { en: ['oled', 'ssd1306'], words: ['pantallita'] },
+  { en: ['tft', 'ili9341', 'display'], words: ['tft'] },
+  { en: ['lcd', 'display'], words: ['lcd'] },
+  { en: ['epaper', 'e ink'], words: ['eink', 'epaper', 'papel', 'tinta'] },
+  {
+    en: ['7segment', 'seven segment', 'display'],
+    words: [
+      'segment',
+      'seven',
+      'digit',
+      'segmentos',
+      'segmento',
+      'siebensegment',
+      'ziffer',
+      'cifra',
+    ],
+  },
+  {
+    en: ['button', 'pushbutton'],
+    words: [
+      'btn',
+      'buttons',
+      'boton',
+      'botones',
+      'pulsador',
+      'pulsadores',
+      'botao',
+      'botoes',
+      'bouton',
+      'boutons',
+      'poussoir',
+      'taste',
+      'taster',
+      'knopf',
+      'pulsante',
+      'pulsanti',
+      'bottone',
+    ],
+  },
+  {
+    en: ['switch'],
+    words: ['interruptor', 'interruptores', 'chave', 'interrupteur', 'schalter', 'interruttore'],
+  },
+  {
+    en: ['potentiometer'],
+    words: [
+      'pot',
+      'potenciometro',
+      'potenciometros',
+      'potentiometre',
+      'poti',
+      'drehregler',
+      'potenziometro',
+    ],
+  },
+  { en: ['potentiometer', 'encoder'], words: ['knob', 'dial', 'perilla', 'manopola'] },
+  { en: ['encoder', 'rotary'], words: ['codificador', 'codeur', 'drehgeber'] },
+  {
+    en: ['led', 'light'],
+    words: ['lamp', 'bulb', 'lampara', 'bombilla', 'lampada', 'lampe', 'ampoule', 'gluhbirne'],
+  },
+  {
+    en: ['photoresistor', 'light'],
+    words: ['ldr', 'photocell', 'fotoresistencia', 'fotoresistor'],
+  },
+  {
+    en: ['buzzer', 'speaker'],
+    words: [
+      'piezo',
+      'beeper',
+      'altavoz',
+      'zumbador',
+      'bocina',
+      'parlante',
+      'altoparlante',
+      'campainha',
+      'buzina',
+      'hautparleur',
+      'lautsprecher',
+      'summer',
+      'piepser',
+      'cicalino',
+    ],
+  },
+  {
+    en: ['resistor'],
+    words: [
+      'res',
+      'resistencia',
+      'resistencias',
+      'resistores',
+      'resistance',
+      'resistances',
+      'widerstand',
+      'widerstande',
+      'resistenza',
+      'resistenze',
+    ],
+  },
+  {
+    en: ['capacitor'],
+    words: [
+      'cap',
+      'condensador',
+      'condensadores',
+      'capacitores',
+      'condensateur',
+      'condensateurs',
+      'kondensator',
+      'kondensatoren',
+      'condensatore',
+      'condensatori',
+    ],
+  },
+  {
+    en: ['inductor', 'coil'],
+    words: ['bobina', 'indutor', 'inductance', 'bobine', 'spule', 'induttore'],
+  },
+  { en: ['diode'], words: ['diodo', 'diodos', 'diodi'] },
+  { en: ['transistor', 'bjt', 'mosfet'], words: ['fet', 'transistores', 'transistori'] },
+  {
+    en: ['op amp', 'amplifier'],
+    words: ['opamp', 'amp', 'amplificador', 'amplificateur', 'verstarker', 'amplificatore'],
+  },
+  {
+    en: ['voltage regulator', 'regulator'],
+    words: ['regulador', 'regulateur', 'regler', 'regolatore'],
+  },
+  {
+    en: ['battery'],
+    words: [
+      'batt',
+      'bateria',
+      'baterias',
+      'pila',
+      'pilas',
+      'pilha',
+      'pilhas',
+      'batterie',
+      'batteries',
+      'batterien',
+      'batteria',
+    ],
+  },
+  {
+    en: ['power supply', 'power', 'source'],
+    words: [
+      'psu',
+      'fuente',
+      'alimentacion',
+      'fonte',
+      'alimentation',
+      'netzteil',
+      'stromversorgung',
+      'alimentatore',
+    ],
+  },
+  {
+    en: ['motor'],
+    words: ['motores', 'moteur', 'moteurs', 'motore', 'motori'],
+  },
+  {
+    en: ['stepper', 'motor'],
+    words: ['paso', 'pasos', 'passo', 'pas', 'schrittmotor', 'schritt', 'passopasso'],
+  },
+  { en: ['servo'], words: ['servomotor', 'sg90'] },
+  { en: ['h bridge', 'motor driver', 'driver'], words: ['hbridge', 'puente', 'ponte', 'brucke'] },
+  { en: ['relay'], words: ['rele', 'reles', 'relevador', 'relais', 'rele'] },
+  {
+    en: ['keypad', 'keyboard'],
+    words: ['keys', 'pad', 'teclado', 'teclas', 'clavier', 'tastatur', 'tastiera'],
+  },
+  { en: ['joystick'], words: ['gamepad', 'thumbstick', 'palanca', 'manette'] },
+  {
+    en: ['remote', 'ir remote', 'infrared'],
+    words: ['mando', 'telecommande', 'fernbedienung', 'telecomando'],
+  },
+  {
+    en: ['rtc', 'clock', 'time'],
+    words: [
+      'date',
+      'reloj',
+      'hora',
+      'relogio',
+      'horloge',
+      'heure',
+      'uhr',
+      'zeit',
+      'orologio',
+      'ora',
+    ],
+  },
+  {
+    en: ['microsd', 'sd card', 'storage', 'memory'],
+    words: [
+      'sd',
+      'sdcard',
+      'memoria',
+      'almacenamiento',
+      'cartao',
+      'memoire',
+      'speicher',
+      'speicherkarte',
+      'tarjeta',
+    ],
+  },
+  {
+    en: ['neopixel', 'led'],
+    words: ['neopixels', 'ws2812', 'ws2812b', 'addressable', 'strip', 'tira'],
+  },
+  {
+    en: ['wire'],
+    words: [
+      'cable',
+      'cables',
+      'jumper',
+      'fio',
+      'fios',
+      'fil',
+      'fils',
+      'kabel',
+      'draht',
+      'filo',
+      'fili',
+      'cavo',
+    ],
+  },
+  {
+    en: ['board', 'microcontroller'],
+    words: [
+      'pcb',
+      'mcu',
+      'micro',
+      'placa',
+      'placas',
+      'carte',
+      'cartes',
+      'platine',
+      'scheda',
+      'schede',
+    ],
+  },
+  { en: ['ic', 'chip'], words: ['chip', 'integrado', 'circuito integrado'] },
+  {
+    en: ['gps', 'position'],
+    words: ['location', 'satellite', 'ubicacion', 'posicion', 'satelite'],
+  },
+  {
+    en: ['wifi', 'wireless', 'esp32'],
+    words: ['inalambrico', 'sansfil', 'drahtlos', 'senzafili', 'wireless'],
+  },
+  { en: ['ble', 'bluetooth', 'esp32'], words: ['bluetooth'] },
+  { en: ['camera', 'cam'], words: ['camara', 'camera', 'kamera', 'telecamera', 'fotocamera'] },
+  {
+    en: ['gate', 'logic'],
+    words: [
+      'gates',
+      'compuerta',
+      'compuertas',
+      'puerta',
+      'puertas',
+      'porta',
+      'portas',
+      'porte',
+      'portes',
+      'gatter',
+    ],
+  },
+  { en: ['flip flop'], words: ['flipflop', 'latch', 'ff', 'biestable'] },
+  { en: ['counter'], words: ['contador', 'compteur', 'zahler', 'contatore'] },
+  { en: ['timer'], words: ['temporizador', 'minuteur', 'timer'] },
+  { en: ['serial', 'uart'], words: ['serie', 'seriell', 'seriale'] },
+  { en: ['analog'], words: ['adc', 'analogico', 'analogica', 'analogique', 'analogico'] },
+  { en: ['pwm', 'analog'], words: ['pwm'] },
+
+  // ── Gallery categories, difficulties, themes ────────────────────────────
+  {
+    en: ['games', 'game'],
+    words: [
+      'juego',
+      'juegos',
+      'jogo',
+      'jogos',
+      'jeu',
+      'jeux',
+      'spiel',
+      'spiele',
+      'gioco',
+      'giochi',
+    ],
+  },
+  { en: ['robotics', 'robot'], words: ['robotica', 'robo', 'robotique', 'roboter'] },
+  {
+    en: ['basics', 'beginner'],
+    words: ['basic', 'basico', 'basicos', 'easy', 'simple', 'starter', 'grundlagen', 'base'],
+  },
+  { en: ['beginner'], words: ['principiante', 'iniciante', 'debutant', 'anfanger', 'einsteiger'] },
+  { en: ['intermediate'], words: ['intermedio', 'intermediario', 'intermediaire', 'intermedio'] },
+  { en: ['advanced'], words: ['avanzado', 'avancado', 'avance', 'fortgeschritten', 'avanzato'] },
+  {
+    en: ['communication'],
+    words: ['comms', 'comunicacion', 'comunicacao', 'kommunikation', 'comunicazione'],
+  },
+  { en: ['circuits', 'circuit'], words: ['circuito', 'circuitos', 'schaltung', 'circuito'] },
+  {
+    en: ['blink'],
+    words: [
+      'hello',
+      'parpadeo',
+      'parpadear',
+      'piscar',
+      'pisca',
+      'clignoter',
+      'clignotant',
+      'blinken',
+      'lampeggio',
+      'lampeggiare',
+    ],
+  },
+  { en: ['traffic light'], words: ['semaforo', 'ampel', 'feu'] },
+  { en: ['alarm'], words: ['alarma', 'alarme', 'allarme'] },
+  { en: ['fan'], words: ['ventilador', 'ventilateur', 'lufter', 'ventola'] },
+  {
+    en: ['door', 'lock'],
+    words: ['cerradura', 'fechadura', 'serrure', 'schloss', 'tur', 'serratura'],
+  },
+  { en: ['matrix'], words: ['matriz', 'matrice'] },
+  { en: ['dice'], words: ['dado', 'dados', 'wurfel'] },
+  {
+    en: ['music', 'melody', 'buzzer'],
+    words: ['musica', 'melodia', 'musique', 'melodie', 'musik'],
+  },
+  { en: ['car', 'robot'], words: ['coche', 'carro', 'vehiculo', 'voiture', 'auto', 'macchina'] },
+  { en: ['arm', 'servo'], words: ['brazo', 'bras', 'braccio'] },
+  { en: ['example'], words: ['ejemplo', 'ejemplos', 'exemple', 'beispiel', 'esempio', 'esempi'] },
+];
+
+const LOOKUP: Map<string, string[]> = (() => {
+  const m = new Map<string, string[]>();
+  for (const { en, words } of CONCEPTS) {
+    for (const w of words) {
+      const list = m.get(w) ?? [];
+      for (const e of en) if (e !== w && !list.includes(e)) list.push(e);
+      m.set(w, list);
+    }
+  }
+  return m;
+})();
+
+/** Plural forms people type ("botones", "sensores", "resistors"). */
+function stemVariants(token: string): string[] {
+  const out: string[] = [];
+  if (token.length > 4 && token.endsWith('es')) out.push(token.slice(0, -2));
+  if (token.length > 3 && token.endsWith('s')) out.push(token.slice(0, -1));
+  return out;
+}
+
+/**
+ * The forms a query token is searched under: the token itself first, then
+ * every synonym of it and of its singular. Synonyms of several words ("op
+ * amp") are kept as phrases: they match as substrings of the field text.
+ */
+export function expandSearchToken(token: string): string[] {
+  const forms: string[] = [token];
+  const push = (w: string) => {
+    if (!forms.includes(w)) forms.push(w);
+  };
+  for (const key of [token, ...stemVariants(token)]) {
+    for (const s of LOOKUP.get(key) ?? []) push(s);
+  }
+  return forms;
+}


### PR DESCRIPTION
## Why

The search box in the component picker matched the literal query inside one field, and the examples gallery matched each word as a plain substring. Neither tolerated a typo, an accent, a different spacing of a part number, or a word in the user's own language, and neither ranked results. On top of that, 90 of the 157 scanned parts have no description and no tag beyond their own id, so `temperature` found no sensor and `ultrasonic` found no HC-SR04.

## What

One matcher for both surfaces, `frontend/src/utils/searchMatch.ts`:

- every query word must land somewhere, in any order: whole word, word prefix, substring, or within an edit distance that grows with the word length (`potenciometer`, `ultrasnic`, `arduno`);
- query and haystack are normalised the same way: `hc-sr04`, `hc sr04` and `hcsr04` are one query, `botón` is `boton`;
- little words never fail a query (`sensor de temperatura`);
- results are ranked: exact name, then prefix, substring, typo; a synonym hit scores a little under a direct one, and the part that IS the word beats parts that merely mention it.

Two vocabularies feed it:

- `utils/searchSynonyms.ts`: what people type in es, pt-br, fr, de, it (plus aliases like `btn`, `pot`, `mic`) mapped to the English words the catalogue uses;
- `data/componentSearchKeywords.ts`: the words a person reaching for each OSS part would type (`temperature humidity` on the DHT22), plus a line per board kind for the picker's boards row. Overlay parts can ship theirs in the new optional `ComponentMetadata.keywords`.

Wired into `ComponentRegistry.search()` (now ranked), the picker (keeps relevance order while a query is typed; boards row and online-only ads go through the same matcher) and `ExamplesGallery` (also searches the parts on each example's canvas through those keywords, so an example with a DHT22 is found by `temperatura` even if its title never says so).

## Verification

- 32 new tests in `frontend/src/__tests__/{searchMatch,component-search,examples-search}.test.ts`, the last two over the REAL catalogue and gallery (`temperature` reaches dht22/bmp280/ntc, `pantalla` reaches ssd1306 + lcd1602, `and gate` ranks the AND gate first, every sampled example is found first by its own title, and so on).
- Existing tests touching the registry and metadata still pass (115 tests).
- `tsc` reports no error in the touched files (the other 400+ errors are pre-existing; `build:docker` skips tsc). ESLint clean on the touched files.
- Cost per keystroke, whole OSS gallery: under 20 ms in Node, with the per-item field preparation cached in a WeakMap.
