### PR TITLE
feat(pi): catalog parts attach to a Raspberry Pi, in both engines

### DIFF
--- a/backend/app/api/routes/simulation.py
+++ b/backend/app/api/routes/simulation.py
@@ -86,6 +86,7 @@ async def simulation_websocket(websocket: WebSocket, client_id: str):
             if msg_type in (
                 'start_pi', 'stop_pi', 'serial_input', 'gpio_in', 'pin_change',
                 'pi_sensor_state', 'pi_uart_rx', 'pi_attach_slave', 'pi_detach_slave',
+                'pi_bus_reply',
                 'start_stm32', 'stop_stm32', 'stm32_load_firmware', 'stm32_gpio_in',
                 'stm32_serial_input', 'stm32_sensor_attach', 'stm32_sensor_update',
                 'stm32_sensor_detach',

--- a/backend/app/api/routes/simulation.py
+++ b/backend/app/api/routes/simulation.py
@@ -86,7 +86,7 @@ async def simulation_websocket(websocket: WebSocket, client_id: str):
             if msg_type in (
                 'start_pi', 'stop_pi', 'serial_input', 'gpio_in', 'pin_change',
                 'pi_sensor_state', 'pi_uart_rx', 'pi_attach_slave', 'pi_detach_slave',
-                'pi_bus_reply',
+                'pi_bus_reply', 'pi_bus_topology', 'pi_bus_regs',
                 'start_stm32', 'stop_stm32', 'stm32_load_firmware', 'stm32_gpio_in',
                 'stm32_serial_input', 'stm32_sensor_attach', 'stm32_sensor_update',
                 'stm32_sensor_detach',

--- a/frontend/public/components-metadata.json
+++ b/frontend/public/components-metadata.json
@@ -1450,7 +1450,7 @@
       "defaultValues": {
         "i2cAddress": "0x3c"
       },
-      "pinCount": 0,
+      "pinCount": 8,
       "tags": [
         "ssd1306",
         "oled",

--- a/frontend/src/__tests__/esp32-proxy-resync-hash.test.ts
+++ b/frontend/src/__tests__/esp32-proxy-resync-hash.test.ts
@@ -1,0 +1,34 @@
+/**
+ * esp32-proxy-resync-hash.test.ts — the ESP32 proxy resync sees every byte.
+ *
+ * A peer board's I2C device is mirrored into the ESP32 QEMU worker as a
+ * 256-register snapshot and refreshed every 250 ms, but only when its hash
+ * changes. The hash used to sample one byte in sixteen plus the first eight,
+ * so a change at 0xF7 (a BMP280 measurement) or 0x3D (an MPU-6050 axis) left
+ * it equal and the ESP32 read the first value for the whole run.
+ */
+import { describe, it, expect } from 'vitest';
+import { Esp32BridgeShim } from '../store/useSimulatorStore';
+
+const hash = (regs: Uint8Array) =>
+  (Esp32BridgeShim as unknown as { _hashRegs(r: Uint8Array): number })._hashRegs(regs);
+
+describe('Esp32BridgeShim._hashRegs', () => {
+  it('changes when any single byte changes', () => {
+    const base = new Uint8Array(256);
+    const h0 = hash(base);
+    for (const i of [0x00, 0x07, 0x3d, 0xd0, 0xf7, 0xfc, 0xff]) {
+      const r = base.slice();
+      r[i] = 0x5a;
+      expect(hash(r), `byte 0x${i.toString(16)}`).not.toBe(h0);
+    }
+  });
+
+  it('is stable for equal contents and an unsigned 32-bit number', () => {
+    const a = new Uint8Array(256).map((_, i) => i);
+    const b = a.slice();
+    expect(hash(a)).toBe(hash(b));
+    expect(hash(a)).toBeGreaterThanOrEqual(0);
+    expect(hash(a)).toBeLessThan(2 ** 32);
+  });
+});

--- a/frontend/src/__tests__/multi-board-integration.test.ts
+++ b/frontend/src/__tests__/multi-board-integration.test.ts
@@ -355,14 +355,18 @@ describe('useSimulatorStore — multi-board', () => {
     expect(board?.serialMonitorOpen).toBe(true);
   });
 
-  it('addBoard for raspberry-pi-3 creates a bridge (not a simulator)', () => {
+  it('addBoard for raspberry-pi-3 creates a bridge and the bridge shim (no MCU emulator)', () => {
     const { addBoard } = useSimulatorStore.getState();
     const id = addBoard('raspberry-pi-3', 500, 50);
     const { boards } = useSimulatorStore.getState();
     const piBoard = boards.find((b) => b.id === id);
     expect(piBoard?.boardKind).toBe('raspberry-pi-3');
-    // No AVRSimulator for Pi — verify via module-level helpers
-    expect(getBoardSimulator(id)).toBeUndefined();
+    // The Pi has no MCU emulator in the browser (the guest is the CPU), but
+    // it DOES get a simulator-shaped entry: the PiBridgeShim the parts attach
+    // their I2C / SPI device models to. Until 2026-09 this slot was empty and
+    // no catalog sensor could be wired to a Pi.
+    const sim = getBoardSimulator(id) as { simulatorKind?: string } | undefined;
+    expect(sim?.simulatorKind).toBe('pi');
     expect(getBoardBridge(id)).toBeDefined();
   });
 

--- a/frontend/src/__tests__/pi-bridge-shim.test.ts
+++ b/frontend/src/__tests__/pi-bridge-shim.test.ts
@@ -1,0 +1,164 @@
+/**
+ * pi-bridge-shim.test.ts — a Raspberry Pi board gets a simulator-shaped
+ * object the catalog parts can attach to (simulation/PiBridgeShim.ts).
+ *
+ * Until 2026-09 a Pi had no entry in simulatorMap: addBoard built a bridge
+ * and a PinManager and stopped there, and DynamicComponent handed parts a
+ * hand-rolled stub with setPinState and little else. Every I2C part in the
+ * catalog attaches through addI2CDevice / getI2CBus, so on a Pi they had
+ * nowhere to go: an MPU6050 wired to SDA/SCL was drawn and never answered,
+ * and the guest's smbus2 read got the "no slave" stub. This file pins the
+ * contract the parts rely on, and the bus grammar both engines route
+ * through the shim.
+ */
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../simulation/RaspberryPi3Bridge', () => ({
+  RaspberryPi3Bridge: class {
+    boardId: string;
+    boardKind: string;
+    connected = false;
+    onSerialData: unknown = null;
+    onPinChange: unknown = null;
+    onPinPull: unknown = null;
+    onBusRequest: unknown = null;
+    onGpioPwm: unknown = null;
+    onBooted: unknown = null;
+    onDisconnected: unknown = null;
+    onError: unknown = null;
+    quietBootDefault = false;
+    quietBootLabel = '';
+    sent: unknown[] = [];
+    constructor(id: string, kind: string) {
+      this.boardId = id;
+      this.boardKind = kind;
+    }
+    connect() {}
+    disconnect() {}
+    sendPinEvent(pin: number, state: boolean) {
+      this.sent.push({ pin, state });
+    }
+    // No setSensorState / attachSlave / sendUartBytes on purpose: the 17
+    // suites that mock this bridge give it about this much, and the shim
+    // must not throw at them.
+  },
+}));
+
+import {
+  useSimulatorStore,
+  getBoardSimulator,
+  getBoardBridge,
+  getBoardPinManager,
+  piMainScript,
+} from '../store/useSimulatorStore';
+import { PiBridgeShim } from '../simulation/PiBridgeShim';
+import { VirtualBMP280, VirtualDS3231, VirtualPCF8574 } from '../simulation/I2CBusManager';
+import { PartSimulationRegistry } from '../simulation/parts';
+import { lineGaps, clearLineGaps } from '../simulation/line/requestLine';
+
+function addPi(kind = 'raspberry-pi-4') {
+  const id = useSimulatorStore.getState().addBoard(kind as never, 100, 100);
+  const shim = getBoardSimulator(id) as PiBridgeShim;
+  return { id, shim };
+}
+
+beforeEach(() => {
+  clearLineGaps();
+});
+
+describe('a Pi board has a simulator entry', () => {
+  it('addBoard installs a PiBridgeShim next to the bridge and the PinManager', () => {
+    const { id, shim } = addPi();
+    expect(shim).toBeInstanceOf(PiBridgeShim);
+    expect(shim.simulatorKind).toBe('pi');
+    expect(getBoardBridge(id)).toBeDefined();
+    expect(shim.pinManager).toBe(getBoardPinManager(id));
+  });
+
+  it('a mocked bridge without setSensorState does not make setPinState throw', () => {
+    const { id, shim } = addPi();
+    expect(() => shim.setPinState(17, true)).not.toThrow();
+    expect(getBoardPinManager(id)?.getPinState(17)).toBe(true);
+  });
+});
+
+describe('I2C parts attach to it', () => {
+  it('BMP280, DS3231 and a PCF8574 backpack land on the header bus', () => {
+    const { shim } = addPi();
+    shim.addI2CDevice(new VirtualBMP280(0x76));
+    shim.addI2CDevice(new VirtualDS3231());
+    shim.addI2CDevice(new VirtualPCF8574(0x27));
+    const addrs = shim
+      .getI2CBus()
+      .listDevices()
+      .map((d) => d.address)
+      .sort((a, b) => a - b);
+    expect(addrs).toEqual([0x27, 0x68, 0x76]);
+  });
+
+  it('the mpu6050 part attaches through the registry the way it does on an ESP32', () => {
+    const { shim } = addPi();
+    const logic = PartSimulationRegistry.get('mpu6050');
+    expect(logic?.attachEvents).toBeTypeOf('function');
+    const element = document.createElement('div');
+    const cleanup = logic!.attachEvents!(element, shim as never, () => null, 'mpu-1');
+    expect(shim.getI2CBus().listDevices().map((d) => d.address)).toContain(0x68);
+    cleanup();
+  });
+});
+
+describe('one I2C transaction', () => {
+  it('WHO_AM_I on the MPU6050 model answers 0x68; an empty address is a NAK', () => {
+    const { shim } = addPi();
+    const logic = PartSimulationRegistry.get('mpu6050');
+    const cleanup = logic!.attachEvents!(document.createElement('div'), shim as never, () => null, 'mpu-1');
+    expect(shim.i2cTransfer(0x68, [0x75], 1)).toEqual([0x68]);
+    expect(shim.i2cTransfer(0x69, [0x75], 1)).toBeNull();
+    cleanup();
+  });
+
+  it('the bus grammar: RR reads a register, T is a repeated-start read, a NAK is I2C_ERR', () => {
+    const { shim } = addPi();
+    shim.addI2CDevice(new VirtualBMP280(0x76));
+    // 0x58 is the BMP280's chip id (0x60 would be a BME280).
+    expect(shim.answerBusLine('I2C 1 76 T d0 1')).toBe('I2C_DATA 1 76 58');
+    expect(shim.answerBusLine('I2C 1 76 RR d0 1')).toBe('I2C_DATA 1 76 58');
+    expect(shim.answerBusLine('I2C 1 77 RR d0 1')).toBe('I2C_ERR 1 77 nack');
+    // Only the header bus carries devices.
+    expect(shim.answerBusLine('I2C 0 76 RR d0 1')).toBe('I2C_ERR 0 76 nack');
+  });
+});
+
+describe('what the guest tells the canvas', () => {
+  it('PWM_START reaches the PinManager as a 0-1 duty', () => {
+    const { id, shim } = addPi();
+    expect(shim.answerBusLine('PWM_START 18 50 7.5')).toBeNull();
+    expect(getBoardPinManager(id)?.getPwmValue(18)).toBeCloseTo(0.075, 5);
+    shim.answerBusLine('PWM_STOP 18');
+    expect(getBoardPinManager(id)?.getPwmValue(18)).toBe(0);
+  });
+
+  it('a pull-up input rests HIGH', () => {
+    const { id, shim } = addPi();
+    shim.answerBusLine('GPIO_SETUP 2 in pud_up');
+    expect(getBoardPinManager(id)?.getPinPull(2)).toBe(1);
+    expect(getBoardPinManager(id)?.getPinState(2)).toBe(true);
+  });
+
+  it('an analog part is refused with a no-adc gap, never silently accepted', () => {
+    const { shim } = addPi();
+    expect(shim.setAdcVoltage(26, 1.65)).toBe(false);
+    const gap = lineGaps().find((g) => g.code === 'no-adc');
+    expect(gap?.pin).toBe(26);
+    expect(gap?.why).toMatch(/MCP3008/);
+  });
+});
+
+describe('the guest runs the file the project has', () => {
+  it('script.py when present, else the first .py', () => {
+    expect(piMainScript([{ name: 'main.py' }, { name: 'script.py' }])).toBe('script.py');
+    expect(piMainScript([{ name: 'README.md' }, { name: 'main.py' }])).toBe('main.py');
+    expect(piMainScript([])).toBe('script.py');
+  });
+});

--- a/frontend/src/__tests__/pi-bus-relay-sync.test.ts
+++ b/frontend/src/__tests__/pi-bus-relay-sync.test.ts
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+/**
+ * pi-bus-relay-sync.test.ts — the board side of the backend bus relay.
+ *
+ * A Linux guest reads its I2C / SPI parts through the backend, which answers
+ * what it can without asking the tab (an absent address, a register-file
+ * device it holds a copy of) and relays the rest. For that the backend needs
+ * the bus map and fresh registers, and only a backend that relays should get
+ * them. Pinned here:
+ *
+ *  - nothing is published until the backend announces `bus_relay`; then the
+ *    map goes out once, a register-file device WITH its 256 registers and a
+ *    device that must be asked WITHOUT, and the board is marked busRelay;
+ *  - afterwards only changes travel: a device whose registers changed pushes
+ *    its registers, a device added or removed republishes the map, an
+ *    unchanged bus sends nothing (compared byte for byte: the ESP32 proxy's
+ *    sampled hash would miss a measurement register);
+ *  - a disconnect stops the sync;
+ *  - the real bridge answers a relayed read and stays silent on a `noreply`
+ *    write, which the backend holds no request open for.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const sent = {
+  topology: [] as unknown[],
+  regs: [] as Array<[number, number, string]>,
+};
+
+vi.mock('../simulation/RaspberryPi3Bridge', () => ({
+  RaspberryPi3Bridge: class {
+    boardId: string;
+    boardKind: string;
+    connected = false;
+    onSerialData: unknown = null;
+    onPinChange: unknown = null;
+    onPinPull: unknown = null;
+    onBusRequest: unknown = null;
+    onBusRelay: ((v: number) => void) | null = null;
+    onGpioPwm: unknown = null;
+    onBooted: unknown = null;
+    onDisconnected: (() => void) | null = null;
+    onError: unknown = null;
+    quietBootDefault = false;
+    quietBootLabel = '';
+    constructor(id: string, kind: string) {
+      this.boardId = id;
+      this.boardKind = kind;
+    }
+    connect() {}
+    disconnect() {}
+    sendPinEvent() {}
+    sendBusTopology(t: unknown) {
+      sent.topology.push(t);
+    }
+    sendBusRegs(bus: number, addr: number, regs: string) {
+      sent.regs.push([bus, addr, regs]);
+    }
+  },
+}));
+
+import { useSimulatorStore, getBoardSimulator, getBoardBridge } from '../store/useSimulatorStore';
+import type { PiBridgeShim } from '../simulation/PiBridgeShim';
+import { VirtualBMP280, VirtualDS3231 } from '../simulation/I2CBusManager';
+import { PartSimulationRegistry } from '../simulation/parts';
+
+type MockBridge = { onBusRelay: ((v: number) => void) | null; onDisconnected: (() => void) | null };
+
+function addPi() {
+  const id = useSimulatorStore.getState().addBoard('raspberry-pi-4' as never, 100, 100);
+  return {
+    id,
+    shim: getBoardSimulator(id) as PiBridgeShim,
+    bridge: getBoardBridge(id) as unknown as MockBridge,
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  sent.topology.length = 0;
+  sent.regs.length = 0;
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('the bus map goes to a relaying backend, and only then', () => {
+  it('nothing is published before bus_relay; once announced, the map and the busRelay flag', () => {
+    const { id, shim, bridge } = addPi();
+    shim.addI2CDevice(new VirtualBMP280(0x76));
+    const cleanup = PartSimulationRegistry.get('mpu6050')!.attachEvents!(
+      document.createElement('div'),
+      shim as never,
+      () => null,
+      'mpu-1',
+    );
+    vi.advanceTimersByTime(1000);
+    expect(sent.topology).toEqual([]);
+
+    bridge.onBusRelay!(1);
+    expect(sent.topology).toHaveLength(1);
+    const topo = sent.topology[0] as { i2c: Array<{ bus: number; addr: number; regs: string | null }>; spi: { attached: boolean } };
+    const byAddr = new Map(topo.i2c.map((d) => [d.addr, d]));
+    expect(byAddr.get(0x76)?.bus).toBe(1);
+    expect(byAddr.get(0x76)?.regs).toMatch(/^[0-9a-f]{512}$/);
+    // 0xD0 is the BMP280 chip id register: its copy must say 0x58.
+    expect(byAddr.get(0x76)?.regs?.slice(0xd0 * 2, 0xd0 * 2 + 2)).toBe('58');
+    expect(byAddr.get(0x68)?.regs).toBeNull(); // the MPU6050 is asked, not copied
+    expect(topo.spi.attached).toBe(false);
+    expect(useSimulatorStore.getState().boards.find((b) => b.id === id)?.busRelay).toBe(true);
+    cleanup();
+  });
+});
+
+describe('afterwards only changes travel', () => {
+  it('a register write pushes that device once; an idle bus sends nothing', () => {
+    const { shim, bridge } = addPi();
+    shim.addI2CDevice(new VirtualBMP280(0x76));
+    bridge.onBusRelay!(1);
+    vi.advanceTimersByTime(1000);
+    expect(sent.regs).toEqual([]);
+
+    // ctrl_meas (0xF4) is a plain read/write register on the model.
+    expect(shim.i2cTransfer(0x76, [0xf4, 0x27], 0)).toEqual([]);
+    vi.advanceTimersByTime(260);
+    expect(sent.regs).toHaveLength(1);
+    expect(sent.regs[0][0]).toBe(1);
+    expect(sent.regs[0][1]).toBe(0x76);
+    expect(sent.regs[0][2].slice(0xf4 * 2, 0xf4 * 2 + 2)).toBe('27');
+
+    vi.advanceTimersByTime(1000);
+    expect(sent.regs).toHaveLength(1);
+  });
+
+  it('a device added after the announcement republishes the map', () => {
+    const { shim, bridge } = addPi();
+    shim.addI2CDevice(new VirtualBMP280(0x76));
+    bridge.onBusRelay!(1);
+    expect(sent.topology).toHaveLength(1);
+    shim.addI2CDevice(new VirtualDS3231());
+    vi.advanceTimersByTime(260);
+    expect(sent.topology).toHaveLength(2);
+    const addrs = (sent.topology[1] as { i2c: Array<{ addr: number }> }).i2c.map((d) => d.addr).sort();
+    expect(addrs).toEqual([0x68, 0x76]);
+  });
+
+  it('an SPI listener flips spi.attached in the next map', () => {
+    const { shim, bridge } = addPi();
+    bridge.onBusRelay!(1);
+    shim.spi.onByte = () => {};
+    vi.advanceTimersByTime(260);
+    expect((sent.topology.at(-1) as { spi: { attached: boolean } }).spi.attached).toBe(true);
+  });
+
+  it('a disconnect stops the sync', () => {
+    const { shim, bridge } = addPi();
+    shim.addI2CDevice(new VirtualBMP280(0x76));
+    bridge.onBusRelay!(1);
+    bridge.onDisconnected!();
+    shim.i2cTransfer(0x76, [0xf4, 0x55], 0);
+    shim.addI2CDevice(new VirtualDS3231());
+    vi.advanceTimersByTime(2000);
+    expect(sent.regs).toEqual([]);
+    expect(sent.topology).toHaveLength(1);
+  });
+});
+
+describe('the real bridge and a noreply write', () => {
+  it('answers a relayed read, stays silent on a noreply write, announces bus_relay', async () => {
+    const { RaspberryPi3Bridge } = await vi.importActual<typeof import('../simulation/RaspberryPi3Bridge')>(
+      '../simulation/RaspberryPi3Bridge',
+    );
+    const frames: unknown[] = [];
+    class FakeWS {
+      static OPEN = 1;
+      readyState = 1;
+      onopen: (() => void) | null = null;
+      onmessage: ((e: { data: string }) => void) | null = null;
+      onclose: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      constructor(_url: string) {
+        sockets.push(this);
+      }
+      send(s: string) {
+        frames.push(JSON.parse(s));
+      }
+      close() {}
+    }
+    const sockets: FakeWS[] = [];
+    const realWS = globalThis.WebSocket;
+    (globalThis as { WebSocket: unknown }).WebSocket = FakeWS;
+    try {
+      const bridge = new RaspberryPi3Bridge('raspberry-pi-4', 'raspberry-pi-4');
+      const relayed: number[] = [];
+      bridge.onBusRequest = (_rid, line) => (line.includes(' RR ') ? 'I2C_DATA 1 68 68' : null);
+      bridge.onBusRelay = (v) => relayed.push(v);
+      bridge.connect();
+      const ws = sockets[0];
+      ws.onopen?.();
+      frames.length = 0;
+      const deliver = (type: string, data: unknown) => ws.onmessage?.({ data: JSON.stringify({ type, data }) });
+      deliver('pi_bus_request', { rid: 7, line: 'I2C 1 68 RR 75 1' });
+      deliver('pi_bus_request', { rid: 8, line: 'I2C 1 68 WR 6b 00', noreply: true });
+      deliver('system', { event: 'bus_relay', version: 1 });
+      expect(frames).toEqual([{ type: 'pi_bus_reply', data: { rid: 7, line: 'I2C_DATA 1 68 68' } }]);
+      expect(relayed).toEqual([1]);
+    } finally {
+      (globalThis as { WebSocket: unknown }).WebSocket = realWS;
+    }
+  });
+});

--- a/frontend/src/__tests__/pi-bus-relay-sync.test.ts
+++ b/frontend/src/__tests__/pi-bus-relay-sync.test.ts
@@ -87,6 +87,9 @@ describe('the bus map goes to a relaying backend, and only then', () => {
   it('nothing is published before bus_relay; once announced, the map and the busRelay flag', () => {
     const { id, shim, bridge } = addPi();
     shim.addI2CDevice(new VirtualBMP280(0x76));
+    // A device that cannot export its registers (a command-driven sensor):
+    // the backend has to ask the tab for it every time.
+    shim.addI2CDevice({ address: 0x44, writeByte: () => true, readByte: () => 0 });
     const cleanup = PartSimulationRegistry.get('mpu6050')!.attachEvents!(
       document.createElement('div'),
       shim as never,
@@ -104,7 +107,10 @@ describe('the bus map goes to a relaying backend, and only then', () => {
     expect(byAddr.get(0x76)?.regs).toMatch(/^[0-9a-f]{512}$/);
     // 0xD0 is the BMP280 chip id register: its copy must say 0x58.
     expect(byAddr.get(0x76)?.regs?.slice(0xd0 * 2, 0xd0 * 2 + 2)).toBe('58');
-    expect(byAddr.get(0x68)?.regs).toBeNull(); // the MPU6050 is asked, not copied
+    // The MPU6050 is a register file too, so it travels with its registers
+    // (WHO_AM_I at 0x75 is its own address).
+    expect(byAddr.get(0x68)?.regs?.slice(0x75 * 2, 0x75 * 2 + 2)).toBe('68');
+    expect(byAddr.get(0x44)?.regs).toBeNull(); // no dumpRegisters: asked, not copied
     expect(topo.spi.attached).toBe(false);
     expect(useSimulatorStore.getState().boards.find((b) => b.id === id)?.busRelay).toBe(true);
     cleanup();

--- a/frontend/src/components/DynamicComponent.tsx
+++ b/frontend/src/components/DynamicComponent.tsx
@@ -13,19 +13,13 @@
 
 import React, { useRef, useEffect, useCallback, useReducer } from 'react';
 import type { ComponentMetadata } from '../types/component-metadata';
-import {
-  useSimulatorStore,
-  getBoardBridge,
-  getBoardPinManager,
-  getBoardSimulator,
-} from '../store/useSimulatorStore';
+import { useSimulatorStore, getBoardSimulator } from '../store/useSimulatorStore';
 import { useElectricalStore } from '../store/useElectricalStore';
 import { useEditorStore } from '../store/useEditorStore';
 import { buildProjectSdImage, decodeSdFiles } from '../utils/sdCardFiles';
 import { PartSimulationRegistry } from '../simulation/parts';
 import { dispatchSensorUpdate } from '../simulation/SensorUpdateRegistry';
 import { isPiBoardKind } from '../types/board';
-import { getBoardLineSupport } from '../lib/proBoardRegistry';
 import { isKeyBindable, formatKeyLabel } from '../utils/keyButtonBindings';
 import {
   createDefaultPinResolver,
@@ -504,15 +498,16 @@ export const DynamicComponent: React.FC<DynamicComponentProps> = ({
       // null pin lookup (`getArduinoPin` returns null when there's no board),
       // so the stub below is enough — it satisfies the type signature without
       // doing anything when called.
-      // A QEMU-Linux board (Raspberry Pi family, UNIHIKER) has no MCU
-      // simulator: the guest IS the CPU. An input part still calls
-      // `simulator.setPinState(pin, level)` to report a button press or a
-      // PIR trip, and that call used to land on the legacy AVR instance and
-      // vanish — clicking the sensor did nothing at all. Route it to the
-      // bridge of the board this component is actually wired to: `gpio_in`
-      // for the guest, the canvas-fed `pin<N>` value the browser engine's
-      // shims read, and the PinManager so wires and SPICE see the edge.
-      const { piBoardId, piBoardKind, wiredBoardId } = (() => {
+      // A Linux-guest board (Raspberry Pi family, UNIHIKER) has no MCU
+      // emulator in the browser: the guest IS the CPU. Its simulatorMap entry
+      // is the PiBridgeShim the store installs at addBoard — the object that
+      // routes `setPinState` to the guest (`gpio_in`, the canvas-fed `pin<N>`
+      // value) and to the PinManager, hosts the I2C / SPI device models the
+      // guest's bus requests are answered against, and refuses an analog
+      // input with a reason. A hand-rolled stub used to stand here instead
+      // and, taking precedence over `getBoardSimulator`, kept every I2C part
+      // off the board's bus.
+      const { piBoardId, wiredBoardId } = (() => {
         const st = useSimulatorStore.getState();
         const ownPins = new Set<string>();
         for (const w of st.wires) {
@@ -525,50 +520,11 @@ export const DynamicComponent: React.FC<DynamicComponentProps> = ({
           const board = boardId ? st.boards.find((b) => b.id === boardId) : undefined;
           if (!board) continue;
           if (anyBoardId === null) anyBoardId = board.id;
-          if (isPiBoardKind(board.boardKind))
-            return { piBoardId: board.id, piBoardKind: board.boardKind, wiredBoardId: board.id };
+          if (isPiBoardKind(board.boardKind)) return { piBoardId: board.id, wiredBoardId: board.id };
         }
-        return { piBoardId: null, piBoardKind: null, wiredBoardId: anyBoardId };
+        return { piBoardId: null, wiredBoardId: anyBoardId };
       })();
-      const piSimulator = piBoardId
-        ? ({
-            setPinState: (pin: number, state: boolean) => {
-              getBoardBridge(piBoardId)?.sendPinEvent(pin, state);
-              getBoardBridge(piBoardId)?.setSensorState({ [`pin${pin}`]: state ? 1 : 0 });
-              getBoardPinManager(piBoardId)?.triggerPinChange(pin, state, 'external');
-            },
-            isRunning: () =>
-              !!useSimulatorStore.getState().boards.find((b) => b.id === piBoardId)?.running,
-            pinManager: getBoardPinManager(piBoardId),
-            // The line contract's declaration for this Pi-family board. Most
-            // QEMU-Linux boards read their pins over a serial link to the
-            // backend (measured ~120 reads/s) and carry levels, not timed
-            // edges, so a single-wire sensor's reply has nowhere to land in
-            // guest time: they DEFAULT to a refusal, said here so the part
-            // hears it and the circuit check shows it, instead of waiting on a
-            // silent pad. A board that DOES serve those sensors another way
-            // overrides this through registerBoardLineSupport (the UNIHIKER
-            // delivers DHT22 / HC-SR04 as named slider values, so the overlay
-            // declares it `hosted`).
-            lineSupport: () =>
-              (piBoardKind && getBoardLineSupport(piBoardKind)) ?? {
-                mode: 'none' as const,
-                why: 'this board runs a Linux guest that reads its pins over a serial link; timed single-wire sensors are not modelled here',
-              },
-            // Addressable pixels are the same story one step further out. A
-            // WS2812 bit cell is 1.25 us; this transport carries levels with
-            // no timestamps at roughly the rate a Python statement runs, so
-            // there is no waveform to decode and there cannot be one. Said out
-            // loud for the same reason as lineSupport: the part otherwise
-            // attaches, decodes nothing, feeds nothing and reports nothing,
-            // which is indistinguishable from a wiring mistake.
-            pixelSupport: () => ({
-              mode: 'none' as const,
-              why: 'this board drives its pins over a level protocol with no bit timing, so a WS2812 data stream cannot be produced or decoded here',
-            }),
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          } as any)
-        : null;
+      const piSimulator = piBoardId ? (getBoardSimulator(piBoardId) ?? null) : null;
 
       // Route the part to the simulator of the board it is actually WIRED
       // to. The legacy store `simulator` is the shared AVR instance: handing

--- a/frontend/src/components/simulator/SimulatorCanvas.tsx
+++ b/frontend/src/components/simulator/SimulatorCanvas.tsx
@@ -7,7 +7,7 @@ import {
 import { getBoardBuiltins, getProBoard } from '../../lib/proBoardRegistry';
 import { useElectricalStore } from '../../store/useElectricalStore';
 import { openDeviceGateway } from '../../lib/openDeviceGateway';
-import React, { useEffect, useState, useRef, useCallback } from 'react';
+import React, { useEffect, useState, useRef, useCallback, useSyncExternalStore } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { adcPinMapFor } from '../velxio-components/Esp32Element';
@@ -296,6 +296,13 @@ export const SimulatorCanvas = ({ headerSlot }: SimulatorCanvasProps = {}) => {
   const [showComponentPicker, setShowComponentPicker] = useState(false);
   const [registry] = useState(() => ComponentRegistry.getInstance());
   const [registryLoaded, setRegistryLoaded] = useState(registry.isLoaded);
+  // Metadata can arrive AFTER the first render: the overlay merges its own
+  // parts once its dynamic import lands, and renderComponent below resolves
+  // `registry.getById` at render time. Without this subscription a saved
+  // project whose parts came from that late merge opened with them invisible
+  // ("Metadata not found") until something else forced a render — a click on
+  // the canvas, Run. Same subscription the picker uses.
+  useSyncExternalStore(registry.subscribe, registry.getVersion, registry.getVersion);
 
   // Wait for registry to finish loading before rendering components
   useEffect(() => {

--- a/frontend/src/data/examples.ts
+++ b/frontend/src/data/examples.ts
@@ -11126,11 +11126,13 @@ void loop() {
   },
 
   // ── Raspberry Pi 3 / 4 / 5 — single-board GPIO examples ──────────────────
-  // These run a Python (gpiozero) script on the QEMU Linux board. gpiozero is
-  // board-agnostic (works on Pi 3/4/5). Only DIGITAL GPIO is wired — output
-  // (LEDs, RGB) and input (button, PIR) — since the Pi has no ADC and PWM is
-  // not simulated. To run: Start the Pi, click Upload in the File System
-  // panel, then `python3 /home/pi/script.py`.
+  // These run a Python (gpiozero) script on the Pi board. gpiozero is
+  // board-agnostic (works on Pi 3/4/5). Only DIGITAL GPIO is wired here —
+  // output (LEDs, RGB) and input (button, PIR): the Pi has no ADC (an analog
+  // part needs an MCP3008 or ADS1115). PWM reaches the canvas (servo, dimmed
+  // LED), and I2C parts answer through the board's PiBridgeShim. Run uploads
+  // the file group and starts `script.py` (or the first .py when there is
+  // none).
   {
     id: 'pi3-blink-led',
     title: '[Pi 3] Blink an LED',

--- a/frontend/src/i18n/locales/de/seo2.json
+++ b/frontend/src/i18n/locales/de/seo2.json
@@ -121,24 +121,24 @@
     "rpi": {
       "hero": {
         "title": "Raspberry Pi 3 Simulator",
-        "accent": "Volles Linux · Python · GPIO – In Ihrem Browser",
-        "subtitle": "Führen Sie einen vollständigen Raspberry Pi 3B mit Raspberry Pi OS direkt in Ihrem Browser aus – ARM Cortex-A53 Quad-Core-Emulation über QEMU. Schreiben Sie Python, steuern Sie GPIO, installieren Sie Pakete. Keine Hardware erforderlich.",
+        "accent": "Python · GPIO · I2C — In Your Browser",
+        "subtitle": "Run Raspberry Pi projects in your browser: write Python against the circuit on the canvas with RPi.GPIO, gpiozero and smbus2, the libraries real Pi projects use. Scripts start in seconds on the in-browser engine; a Linux guest on our servers is one click away when a script needs a shell.",
         "ctaPrimary": "Pi 3 Simulator öffnen",
         "ctaSecondary": "Dokumentation lesen",
-        "trust": "QEMU ARM64 · Vollständiges Raspberry Pi OS · Kostenloser Test, dann Maker- und Pro-Pläne",
+        "trust": "In-browser Python · QEMU Linux guest · Three free trial sessions, then Maker and Pro plans",
         "imageAlt": "Raspberry Pi 3 Board Illustration"
       },
       "what": {
         "heading": "Was können Sie mit dem Pi 3 Simulator tun?",
-        "lead": "Velxio emuliert einen vollständigen Raspberry Pi 3B – nicht nur GPIO-Pins, sondern das gesamte Linux-Betriebssystem. Es ist ein vollständiger Computer in Ihrem Browser.",
+        "lead": "Velxio runs your Raspberry Pi scripts against the sensors, displays and actuators you wire on the canvas — the same component models an Arduino or ESP32 talks to. Two engines: Python in the browser by default, and a QEMU Linux guest when you want a terminal.",
         "pythonTitle": "Python-Skripte ausführen",
-        "pythonBody": "Python 3 vorinstalliert auf Raspberry Pi OS. Führen Sie Skripte aus, verwenden Sie pip, importieren Sie Bibliotheken – vollständige Python-Umgebung.",
+        "pythonBody": "Python 3 with RPi.GPIO, gpiozero, smbus2 and pyserial. GPIO in and out, PWM, UART and I2C sensors on the header bus; third-party packages through a requirements.txt.",
         "gpioTitle": "GPIO-Steuerung",
         "gpioBody": "Verwenden Sie RPi.GPIO oder gpiozero, um LEDs zu steuern, Tasten zu lesen, Motoren anzutreiben – echte GPIO-Emulation in QEMU.",
         "linuxTitle": "Linux-Terminal",
-        "linuxBody": "Volles Bash-Terminal mit apt, nano, git und allen Standard-Linux-Tools. Installieren Sie Pakete, bearbeiten Sie Dateien, führen Sie Dienste aus.",
+        "linuxBody": "Optional Linux mode boots an Alpine guest in QEMU with a real shell and python3. It is not Raspberry Pi OS: no apt, no desktop, no network from inside the guest.",
         "armTitle": "ARM Cortex-A53",
-        "armBody": "Quad-Core 64-Bit ARM CPU bei 1,2 GHz über QEMU raspi3b Maschine. Führt das offizielle Raspberry Pi OS Image aus.",
+        "armBody": "The Linux guest runs a 64-bit ARM kernel under QEMU (32-bit for the Zero, 1 and 2) with the CPU profile of the board you picked.",
         "sdTitle": "Keine SD-Karte erforderlich",
         "sdBody": "Das OS-Image ist vorinstalliert. Kein Flashen, keine SD-Karte, kein Netzteil – einfach den Browser öffnen und mit dem Programmieren beginnen.",
         "multiTitle": "Multi-Board-Leinwand",
@@ -150,20 +150,20 @@
         "picoBodyPrefix": "Mikrocontroller. ARM Cortex-M0+ bei 133 MHz. Führt Arduino C++ Code aus. Kein OS, Bare-Metal. Am besten für Embedded, IoT, Sensoren. ",
         "picoLink": "Pico Simulator ausprobieren",
         "pi3Title": "Raspberry Pi 3 (ARM Cortex-A53)",
-        "pi3Body": "Vollständiger Linux-Computer. Quad-Core bei 1,2 GHz. Führt Python, Node.js, bash aus. Am besten für Automatisierung, Server, GPIO-Scripting, Bildung."
+        "pi3Body": "A Linux single-board computer. Runs Python scripts against the canvas, in the browser or in a QEMU guest with a shell. Best for GPIO scripting, sensors over I2C, automation and education."
       },
       "faq": {
         "heading": "Häufig gestellte Fragen",
         "q1": "Kann ich einen Raspberry Pi 3 in meinem Browser simulieren?",
-        "a1": "Ja. Velxio emuliert einen vollständigen Raspberry Pi 3B mit QEMU raspi3b – ARM Cortex-A53 Quad-Core bei 1,2 GHz mit Raspberry Pi OS (Linux). Sie erhalten ein echtes Terminal, um Python, bash und Systembefehle auszuführen.",
+        "a1": "Yes. Velxio runs Raspberry Pi projects (Zero through Pi 5) in your browser: Python scripts execute against the circuit on the canvas, and a Linux guest under QEMU gives you a terminal when a script needs one. The guest is Alpine Linux, not Raspberry Pi OS.",
         "q2": "Ist der Raspberry-Pi-Simulator im kostenlosen Tarif enthalten?",
         "a2": "Teilweise. Eine Raspberry-Pi-Schaltung kann mit jedem Konto gebaut und gespeichert werden, und ein kostenloses Konto erhält drei 15-minütige Testsitzungen, um sie auszuführen (jeder Lauf innerhalb einer Sitzung ist kostenlos). Unbegrenzte Raspberry-Pi-Linux-Emulation betreibt einen vollständigen ARM-Gast auf unseren Servern und gehört daher zu den Plänen Maker und Pro oder zu Velxio Desktop mit Bezahllizenz. Der Editor und die Simulatoren für Arduino, ESP32 und Raspberry Pi Pico sind kostenlos und benötigen kein Konto. Velxio selbst bleibt Open Source (GNU AGPLv3).",
         "q3": "Kann ich Python-Skripte auf dem Raspberry Pi Simulator ausführen?",
-        "a3": "Ja. Der emulierte Raspberry Pi 3 führt volles Raspberry Pi OS mit vorinstalliertem Python 3 aus. Sie können Python-Skripte ausführen, RPi.GPIO für GPIO-Steuerung verwenden, pip-Pakete installieren und mehr.",
+        "a3": "Yes. Python 3 runs in the browser with RPi.GPIO, gpiozero and smbus2, or in the Linux guest. Third-party packages are installed from a requirements.txt in your project; pip cannot reach the internet from inside the guest.",
         "q4": "Was ist der Unterschied zwischen Pi Pico und Pi 3 Simulation?",
-        "a4": "Raspberry Pi Pico (RP2040) ist ein Mikrocontroller – führt Arduino C++ Code aus, kein OS. Raspberry Pi 3 ist ein vollständiger Linux-Computer – führt Python, bash und Systemdienste aus. Velxio unterstützt beide.",
+        "a4": "Raspberry Pi Pico (RP2040) is a microcontroller — it runs Arduino C++ or MicroPython, no OS. Raspberry Pi Zero through 5 are Linux computers — they run Python scripts, and in Linux mode a shell. Velxio supports both.",
         "q5": "Unterstützt es GPIO auf dem Raspberry Pi 3?",
-        "a5": "Ja. Der QEMU-emulierte Raspberry Pi 3 unterstützt GPIO über die Python-Bibliotheken RPi.GPIO und gpiozero. Steuern Sie LEDs, lesen Sie Tasten und kommunizieren Sie mit Sensoren über Python."
+        "a5": "Yes. RPi.GPIO and gpiozero drive LEDs, read buttons and PIR sensors, and PWM reaches servos and dimmed LEDs. I2C sensors on the header bus (SDA on GPIO2, SCL on GPIO3) answer through smbus2. A Pi has no analog input: a potentiometer needs an MCP3008 or ADS1115 between it and the Pi."
       },
       "bottom": {
         "title": "Bereit, Raspberry Pi 3 zu simulieren?",

--- a/frontend/src/i18n/locales/en/seo2.json
+++ b/frontend/src/i18n/locales/en/seo2.json
@@ -121,24 +121,24 @@
     "rpi": {
       "hero": {
         "title": "Raspberry Pi 3 Simulator",
-        "accent": "Full Linux · Python · GPIO — In Your Browser",
-        "subtitle": "Run a full Raspberry Pi 3B with Raspberry Pi OS directly in your browser — ARM Cortex-A53 quad-core emulation via QEMU. Write Python, control GPIO, install packages. No hardware needed.",
+        "accent": "Python · GPIO · I2C — In Your Browser",
+        "subtitle": "Run Raspberry Pi projects in your browser: write Python against the circuit on the canvas with RPi.GPIO, gpiozero and smbus2, the libraries real Pi projects use. Scripts start in seconds on the in-browser engine; a Linux guest on our servers is one click away when a script needs a shell.",
         "ctaPrimary": "Open Pi 3 Simulator",
         "ctaSecondary": "Read the Docs",
-        "trust": "QEMU ARM64 · Full Raspberry Pi OS · Free trial, then Maker and Pro plans",
+        "trust": "In-browser Python · QEMU Linux guest · Three free trial sessions, then Maker and Pro plans",
         "imageAlt": "Raspberry Pi 3 board illustration"
       },
       "what": {
         "heading": "What can you do with the Pi 3 simulator?",
-        "lead": "Velxio emulates a complete Raspberry Pi 3B — not just GPIO pins, but the entire Linux operating system. It's a full computer in your browser.",
+        "lead": "Velxio runs your Raspberry Pi scripts against the sensors, displays and actuators you wire on the canvas — the same component models an Arduino or ESP32 talks to. Two engines: Python in the browser by default, and a QEMU Linux guest when you want a terminal.",
         "pythonTitle": "Run Python Scripts",
-        "pythonBody": "Python 3 pre-installed on Raspberry Pi OS. Run scripts, use pip, import libraries — full Python environment.",
+        "pythonBody": "Python 3 with RPi.GPIO, gpiozero, smbus2 and pyserial. GPIO in and out, PWM, UART and I2C sensors on the header bus; third-party packages through a requirements.txt.",
         "gpioTitle": "GPIO Control",
         "gpioBody": "Use RPi.GPIO or gpiozero to control LEDs, read buttons, drive motors — real GPIO emulation in QEMU.",
         "linuxTitle": "Linux Terminal",
-        "linuxBody": "Full bash terminal with apt, nano, git, and all standard Linux tools. Install packages, edit files, run services.",
+        "linuxBody": "Optional Linux mode boots an Alpine guest in QEMU with a real shell and python3. It is not Raspberry Pi OS: no apt, no desktop, no network from inside the guest.",
         "armTitle": "ARM Cortex-A53",
-        "armBody": "Quad-core 64-bit ARM CPU at 1.2 GHz via QEMU raspi3b machine. Runs the official Raspberry Pi OS image.",
+        "armBody": "The Linux guest runs a 64-bit ARM kernel under QEMU (32-bit for the Zero, 1 and 2) with the CPU profile of the board you picked.",
         "sdTitle": "No SD Card Needed",
         "sdBody": "The OS image is pre-loaded. No flashing, no SD card, no power supply — just open the browser and start coding.",
         "multiTitle": "Multi-Board Canvas",
@@ -150,20 +150,20 @@
         "picoBodyPrefix": "Microcontroller. ARM Cortex-M0+ at 133 MHz. Runs Arduino C++ code. No OS, bare-metal. Best for embedded, IoT, sensors. ",
         "picoLink": "Try Pico Simulator",
         "pi3Title": "Raspberry Pi 3 (ARM Cortex-A53)",
-        "pi3Body": "Full Linux computer. Quad-core at 1.2 GHz. Runs Python, Node.js, bash. Best for automation, servers, GPIO scripting, education."
+        "pi3Body": "A Linux single-board computer. Runs Python scripts against the canvas, in the browser or in a QEMU guest with a shell. Best for GPIO scripting, sensors over I2C, automation and education."
       },
       "faq": {
         "heading": "Frequently Asked Questions",
         "q1": "Can I simulate a Raspberry Pi 3 in my browser?",
-        "a1": "Yes. Velxio emulates a full Raspberry Pi 3B using QEMU raspi3b — ARM Cortex-A53 quad-core at 1.2 GHz running Raspberry Pi OS (Linux). You get a real terminal to run Python, bash, and system commands.",
+        "a1": "Yes. Velxio runs Raspberry Pi projects (Zero through Pi 5) in your browser: Python scripts execute against the circuit on the canvas, and a Linux guest under QEMU gives you a terminal when a script needs one. The guest is Alpine Linux, not Raspberry Pi OS.",
         "q2": "Is the Raspberry Pi simulator included in the free plan?",
         "a2": "Partly. You can build and save a Raspberry Pi circuit with any account, and a free account gets three 15-minute trial sessions to run it (every run inside a session is free). Unlimited Raspberry Pi Linux emulation runs a full ARM guest on our servers, so it is part of the Maker and Pro plans, or of Velxio Desktop with a paid licence. The editor and the Arduino, ESP32 and Raspberry Pi Pico simulators are free and need no account. Velxio itself stays open-source (GNU AGPLv3).",
         "q3": "Can I run Python scripts on the Raspberry Pi simulator?",
-        "a3": "Yes. The emulated Raspberry Pi 3 runs full Raspberry Pi OS with Python 3 pre-installed. You can run Python scripts, use RPi.GPIO for GPIO control, install pip packages, and more.",
+        "a3": "Yes. Python 3 runs in the browser with RPi.GPIO, gpiozero and smbus2, or in the Linux guest. Third-party packages are installed from a requirements.txt in your project; pip cannot reach the internet from inside the guest.",
         "q4": "What is the difference between Pi Pico and Pi 3 simulation?",
-        "a4": "Raspberry Pi Pico (RP2040) is a microcontroller — runs Arduino C++ code, no OS. Raspberry Pi 3 is a full Linux computer — runs Python, bash, and system services. Velxio supports both.",
+        "a4": "Raspberry Pi Pico (RP2040) is a microcontroller — it runs Arduino C++ or MicroPython, no OS. Raspberry Pi Zero through 5 are Linux computers — they run Python scripts, and in Linux mode a shell. Velxio supports both.",
         "q5": "Does it support GPIO on Raspberry Pi 3?",
-        "a5": "Yes. The QEMU-emulated Raspberry Pi 3 supports GPIO via RPi.GPIO and gpiozero Python libraries. Control LEDs, read buttons, and interface with sensors from Python."
+        "a5": "Yes. RPi.GPIO and gpiozero drive LEDs, read buttons and PIR sensors, and PWM reaches servos and dimmed LEDs. I2C sensors on the header bus (SDA on GPIO2, SCL on GPIO3) answer through smbus2. A Pi has no analog input: a potentiometer needs an MCP3008 or ADS1115 between it and the Pi."
       },
       "bottom": {
         "title": "Ready to simulate Raspberry Pi 3?",

--- a/frontend/src/i18n/locales/es/seo2.json
+++ b/frontend/src/i18n/locales/es/seo2.json
@@ -121,24 +121,24 @@
     "rpi": {
       "hero": {
         "title": "Simulador de Raspberry Pi 3",
-        "accent": "Linux completo · Python · GPIO — En tu navegador",
-        "subtitle": "Ejecuta una Raspberry Pi 3B completa con Raspberry Pi OS directamente en tu navegador — emulación ARM Cortex-A53 de cuatro núcleos mediante QEMU. Escribe Python, controla GPIO, instala paquetes. Sin necesidad de hardware.",
+        "accent": "Python · GPIO · I2C — In Your Browser",
+        "subtitle": "Run Raspberry Pi projects in your browser: write Python against the circuit on the canvas with RPi.GPIO, gpiozero and smbus2, the libraries real Pi projects use. Scripts start in seconds on the in-browser engine; a Linux guest on our servers is one click away when a script needs a shell.",
         "ctaPrimary": "Abrir Simulador Pi 3",
         "ctaSecondary": "Leer la Documentación",
-        "trust": "QEMU ARM64 · Raspberry Pi OS completo · Prueba gratis, luego planes Maker y Pro",
+        "trust": "In-browser Python · QEMU Linux guest · Three free trial sessions, then Maker and Pro plans",
         "imageAlt": "Ilustración de placa Raspberry Pi 3"
       },
       "what": {
         "heading": "¿Qué puedes hacer con el simulador de Pi 3?",
-        "lead": "Velxio emula una Raspberry Pi 3B completa — no solo pines GPIO, sino todo el sistema operativo Linux. Es un ordenador completo en tu navegador.",
+        "lead": "Velxio runs your Raspberry Pi scripts against the sensors, displays and actuators you wire on the canvas — the same component models an Arduino or ESP32 talks to. Two engines: Python in the browser by default, and a QEMU Linux guest when you want a terminal.",
         "pythonTitle": "Ejecutar Scripts Python",
-        "pythonBody": "Python 3 preinstalado en Raspberry Pi OS. Ejecuta scripts, usa pip, importa librerías — entorno Python completo.",
+        "pythonBody": "Python 3 with RPi.GPIO, gpiozero, smbus2 and pyserial. GPIO in and out, PWM, UART and I2C sensors on the header bus; third-party packages through a requirements.txt.",
         "gpioTitle": "Control GPIO",
         "gpioBody": "Usa RPi.GPIO o gpiozero para controlar LEDs, leer botones, accionar motores — emulación GPIO real en QEMU.",
         "linuxTitle": "Terminal Linux",
-        "linuxBody": "Terminal bash completa con apt, nano, git y todas las herramientas Linux estándar. Instala paquetes, edita archivos, ejecuta servicios.",
+        "linuxBody": "Optional Linux mode boots an Alpine guest in QEMU with a real shell and python3. It is not Raspberry Pi OS: no apt, no desktop, no network from inside the guest.",
         "armTitle": "ARM Cortex-A53",
-        "armBody": "CPU ARM de 64 bits de cuatro núcleos a 1.2 GHz mediante la máquina raspi3b de QEMU. Ejecuta la imagen oficial de Raspberry Pi OS.",
+        "armBody": "The Linux guest runs a 64-bit ARM kernel under QEMU (32-bit for the Zero, 1 and 2) with the CPU profile of the board you picked.",
         "sdTitle": "Sin necesidad de tarjeta SD",
         "sdBody": "La imagen del SO está precargada. Sin flasheo, sin tarjeta SD, sin fuente de alimentación — solo abre el navegador y empieza a programar.",
         "multiTitle": "Lienzo Multiplaca",
@@ -150,20 +150,20 @@
         "picoBodyPrefix": "Microcontrolador. ARM Cortex-M0+ a 133 MHz. Ejecuta código Arduino C++. Sin SO, a nivel de metal. Ideal para embebido, IoT, sensores. ",
         "picoLink": "Probar Simulador Pico",
         "pi3Title": "Raspberry Pi 3 (ARM Cortex-A53)",
-        "pi3Body": "Ordenador Linux completo. Cuatro núcleos a 1.2 GHz. Ejecuta Python, Node.js, bash. Ideal para automatización, servidores, scripting GPIO, educación."
+        "pi3Body": "A Linux single-board computer. Runs Python scripts against the canvas, in the browser or in a QEMU guest with a shell. Best for GPIO scripting, sensors over I2C, automation and education."
       },
       "faq": {
         "heading": "Preguntas Frecuentes",
         "q1": "¿Puedo simular una Raspberry Pi 3 en mi navegador?",
-        "a1": "Sí. Velxio emula una Raspberry Pi 3B completa usando QEMU raspi3b — ARM Cortex-A53 de cuatro núcleos a 1.2 GHz ejecutando Raspberry Pi OS (Linux). Obtienes un terminal real para ejecutar Python, bash y comandos del sistema.",
+        "a1": "Yes. Velxio runs Raspberry Pi projects (Zero through Pi 5) in your browser: Python scripts execute against the circuit on the canvas, and a Linux guest under QEMU gives you a terminal when a script needs one. The guest is Alpine Linux, not Raspberry Pi OS.",
         "q2": "¿El simulador de Raspberry Pi entra en el plan gratuito?",
         "a2": "En parte. Puedes montar y guardar un circuito con Raspberry Pi con cualquier cuenta, y una cuenta gratuita tiene tres sesiones de prueba de 15 minutos para ejecutarlo (cada ejecucion dentro de una sesion es gratis). La emulacion ilimitada de Linux en Raspberry Pi ejecuta un invitado ARM completo en nuestros servidores, asi que forma parte de los planes Maker y Pro, o de Velxio Desktop con licencia de pago. El editor y los simuladores de Arduino, ESP32 y Raspberry Pi Pico son gratuitos y no piden cuenta. Velxio sigue siendo de codigo abierto (GNU AGPLv3).",
         "q3": "¿Puedo ejecutar scripts Python en el simulador de Raspberry Pi?",
-        "a3": "Sí. La Raspberry Pi 3 emulada ejecuta Raspberry Pi OS completo con Python 3 preinstalado. Puedes ejecutar scripts Python, usar RPi.GPIO para control GPIO, instalar paquetes pip y más.",
+        "a3": "Yes. Python 3 runs in the browser with RPi.GPIO, gpiozero and smbus2, or in the Linux guest. Third-party packages are installed from a requirements.txt in your project; pip cannot reach the internet from inside the guest.",
         "q4": "¿Cuál es la diferencia entre la simulación de Pi Pico y Pi 3?",
-        "a4": "Raspberry Pi Pico (RP2040) es un microcontrolador — ejecuta código Arduino C++, sin SO. Raspberry Pi 3 es un ordenador Linux completo — ejecuta Python, bash y servicios del sistema. Velxio soporta ambos.",
+        "a4": "Raspberry Pi Pico (RP2040) is a microcontroller — it runs Arduino C++ or MicroPython, no OS. Raspberry Pi Zero through 5 are Linux computers — they run Python scripts, and in Linux mode a shell. Velxio supports both.",
         "q5": "¿Soporta GPIO en Raspberry Pi 3?",
-        "a5": "Sí. La Raspberry Pi 3 emulada por QEMU soporta GPIO mediante las librerías Python RPi.GPIO y gpiozero. Controla LEDs, lee botones e interactúa con sensores desde Python."
+        "a5": "Yes. RPi.GPIO and gpiozero drive LEDs, read buttons and PIR sensors, and PWM reaches servos and dimmed LEDs. I2C sensors on the header bus (SDA on GPIO2, SCL on GPIO3) answer through smbus2. A Pi has no analog input: a potentiometer needs an MCP3008 or ADS1115 between it and the Pi."
       },
       "bottom": {
         "title": "¿Listo para simular Raspberry Pi 3?",

--- a/frontend/src/i18n/locales/fr/seo2.json
+++ b/frontend/src/i18n/locales/fr/seo2.json
@@ -121,24 +121,24 @@
     "rpi": {
       "hero": {
         "title": "Simulateur Raspberry Pi 3",
-        "accent": "Linux complet · Python · GPIO — Dans votre navigateur",
-        "subtitle": "Exécutez un Raspberry Pi 3B complet avec Raspberry Pi OS directement dans votre navigateur — émulation ARM Cortex-A53 quad-core via QEMU. Écrivez du Python, contrôlez les GPIO, installez des paquets. Aucun matériel nécessaire.",
+        "accent": "Python · GPIO · I2C — In Your Browser",
+        "subtitle": "Run Raspberry Pi projects in your browser: write Python against the circuit on the canvas with RPi.GPIO, gpiozero and smbus2, the libraries real Pi projects use. Scripts start in seconds on the in-browser engine; a Linux guest on our servers is one click away when a script needs a shell.",
         "ctaPrimary": "Ouvrir le simulateur Pi 3",
         "ctaSecondary": "Lire la documentation",
-        "trust": "QEMU ARM64 · Raspberry Pi OS complet · Essai gratuit, puis formules Maker et Pro",
+        "trust": "In-browser Python · QEMU Linux guest · Three free trial sessions, then Maker and Pro plans",
         "imageAlt": "Illustration de la carte Raspberry Pi 3"
       },
       "what": {
         "heading": "Que pouvez-vous faire avec le simulateur Pi 3 ?",
-        "lead": "Velxio émule un Raspberry Pi 3B complet — pas seulement les broches GPIO, mais tout le système d'exploitation Linux. C'est un ordinateur complet dans votre navigateur.",
+        "lead": "Velxio runs your Raspberry Pi scripts against the sensors, displays and actuators you wire on the canvas — the same component models an Arduino or ESP32 talks to. Two engines: Python in the browser by default, and a QEMU Linux guest when you want a terminal.",
         "pythonTitle": "Exécuter des scripts Python",
-        "pythonBody": "Python 3 préinstallé sur Raspberry Pi OS. Exécutez des scripts, utilisez pip, importez des bibliothèques — environnement Python complet.",
+        "pythonBody": "Python 3 with RPi.GPIO, gpiozero, smbus2 and pyserial. GPIO in and out, PWM, UART and I2C sensors on the header bus; third-party packages through a requirements.txt.",
         "gpioTitle": "Contrôle GPIO",
         "gpioBody": "Utilisez RPi.GPIO ou gpiozero pour contrôler des LED, lire des boutons, piloter des moteurs — véritable émulation GPIO dans QEMU.",
         "linuxTitle": "Terminal Linux",
-        "linuxBody": "Terminal bash complet avec apt, nano, git et tous les outils Linux standard. Installez des paquets, éditez des fichiers, exécutez des services.",
+        "linuxBody": "Optional Linux mode boots an Alpine guest in QEMU with a real shell and python3. It is not Raspberry Pi OS: no apt, no desktop, no network from inside the guest.",
         "armTitle": "ARM Cortex-A53",
-        "armBody": "CPU ARM 64 bits quad-core à 1,2 GHz via la machine QEMU raspi3b. Exécute l'image officielle de Raspberry Pi OS.",
+        "armBody": "The Linux guest runs a 64-bit ARM kernel under QEMU (32-bit for the Zero, 1 and 2) with the CPU profile of the board you picked.",
         "sdTitle": "Pas de carte SD nécessaire",
         "sdBody": "L'image du système d'exploitation est préchargée. Pas de flash, pas de carte SD, pas d'alimentation — ouvrez simplement le navigateur et commencez à coder.",
         "multiTitle": "Canevas multi-cartes",
@@ -150,20 +150,20 @@
         "picoBodyPrefix": "Microcontrôleur. ARM Cortex-M0+ à 133 MHz. Exécute du code Arduino C++. Pas d'OS, bare-metal. Idéal pour l'embarqué, l'IoT, les capteurs. ",
         "picoLink": "Essayer le simulateur Pico",
         "pi3Title": "Raspberry Pi 3 (ARM Cortex-A53)",
-        "pi3Body": "Ordinateur Linux complet. Quad-core à 1,2 GHz. Exécute Python, Node.js, bash. Idéal pour l'automatisation, les serveurs, les scripts GPIO, l'éducation."
+        "pi3Body": "A Linux single-board computer. Runs Python scripts against the canvas, in the browser or in a QEMU guest with a shell. Best for GPIO scripting, sensors over I2C, automation and education."
       },
       "faq": {
         "heading": "Questions fréquentes",
         "q1": "Puis-je simuler un Raspberry Pi 3 dans mon navigateur ?",
-        "a1": "Oui. Velxio émule un Raspberry Pi 3B complet en utilisant QEMU raspi3b — ARM Cortex-A53 quad-core à 1,2 GHz exécutant Raspberry Pi OS (Linux). Vous obtenez un vrai terminal pour exécuter Python, bash et des commandes système.",
+        "a1": "Yes. Velxio runs Raspberry Pi projects (Zero through Pi 5) in your browser: Python scripts execute against the circuit on the canvas, and a Linux guest under QEMU gives you a terminal when a script needs one. The guest is Alpine Linux, not Raspberry Pi OS.",
         "q2": "Le simulateur Raspberry Pi est-il inclus dans l'offre gratuite ?",
         "a2": "En partie. Vous pouvez construire et enregistrer un circuit Raspberry Pi avec n'importe quel compte, et un compte gratuit dispose de trois sessions d'essai de 15 minutes pour l'exécuter (chaque exécution pendant une session est gratuite). L'émulation Linux Raspberry Pi illimitée fait tourner un invité ARM complet sur nos serveurs : elle fait donc partie des formules Maker et Pro, ou de Velxio Desktop avec une licence payante. L'éditeur et les simulateurs Arduino, ESP32 et Raspberry Pi Pico sont gratuits et ne demandent pas de compte. Velxio reste open source (GNU AGPLv3).",
         "q3": "Puis-je exécuter des scripts Python sur le simulateur Raspberry Pi ?",
-        "a3": "Oui. Le Raspberry Pi 3 émulé exécute un Raspberry Pi OS complet avec Python 3 préinstallé. Vous pouvez exécuter des scripts Python, utiliser RPi.GPIO pour le contrôle GPIO, installer des paquets pip, et plus encore.",
+        "a3": "Yes. Python 3 runs in the browser with RPi.GPIO, gpiozero and smbus2, or in the Linux guest. Third-party packages are installed from a requirements.txt in your project; pip cannot reach the internet from inside the guest.",
         "q4": "Quelle est la différence entre la simulation Pi Pico et Pi 3 ?",
-        "a4": "Le Raspberry Pi Pico (RP2040) est un microcontrôleur — exécute du code Arduino C++, pas d'OS. Le Raspberry Pi 3 est un ordinateur Linux complet — exécute Python, bash et des services système. Velxio prend en charge les deux.",
+        "a4": "Raspberry Pi Pico (RP2040) is a microcontroller — it runs Arduino C++ or MicroPython, no OS. Raspberry Pi Zero through 5 are Linux computers — they run Python scripts, and in Linux mode a shell. Velxio supports both.",
         "q5": "Prend-il en charge les GPIO sur Raspberry Pi 3 ?",
-        "a5": "Oui. Le Raspberry Pi 3 émulé par QEMU prend en charge les GPIO via les bibliothèques Python RPi.GPIO et gpiozero. Contrôlez des LED, lisez des boutons et interfaccez avec des capteurs depuis Python."
+        "a5": "Yes. RPi.GPIO and gpiozero drive LEDs, read buttons and PIR sensors, and PWM reaches servos and dimmed LEDs. I2C sensors on the header bus (SDA on GPIO2, SCL on GPIO3) answer through smbus2. A Pi has no analog input: a potentiometer needs an MCP3008 or ADS1115 between it and the Pi."
       },
       "bottom": {
         "title": "Prêt à simuler Raspberry Pi 3 ?",

--- a/frontend/src/i18n/locales/it/seo2.json
+++ b/frontend/src/i18n/locales/it/seo2.json
@@ -121,24 +121,24 @@
     "rpi": {
       "hero": {
         "title": "Simulatore Raspberry Pi 3",
-        "accent": "Linux completo · Python · GPIO — Nel tuo browser",
-        "subtitle": "Esegui un Raspberry Pi 3B completo con Raspberry Pi OS direttamente nel tuo browser — emulazione ARM Cortex-A53 quad-core tramite QEMU. Scrivi Python, controlla GPIO, installa pacchetti. Nessun hardware necessario.",
+        "accent": "Python · GPIO · I2C — In Your Browser",
+        "subtitle": "Run Raspberry Pi projects in your browser: write Python against the circuit on the canvas with RPi.GPIO, gpiozero and smbus2, the libraries real Pi projects use. Scripts start in seconds on the in-browser engine; a Linux guest on our servers is one click away when a script needs a shell.",
         "ctaPrimary": "Apri il simulatore Pi 3",
         "ctaSecondary": "Leggi la documentazione",
-        "trust": "QEMU ARM64 · Raspberry Pi OS completo · Prova gratuita, poi piani Maker e Pro",
+        "trust": "In-browser Python · QEMU Linux guest · Three free trial sessions, then Maker and Pro plans",
         "imageAlt": "Illustrazione della scheda Raspberry Pi 3"
       },
       "what": {
         "heading": "Cosa puoi fare con il simulatore Pi 3?",
-        "lead": "Velxio emula un Raspberry Pi 3B completo — non solo pin GPIO, ma l'intero sistema operativo Linux. È un computer completo nel tuo browser.",
+        "lead": "Velxio runs your Raspberry Pi scripts against the sensors, displays and actuators you wire on the canvas — the same component models an Arduino or ESP32 talks to. Two engines: Python in the browser by default, and a QEMU Linux guest when you want a terminal.",
         "pythonTitle": "Esegui script Python",
-        "pythonBody": "Python 3 preinstallato su Raspberry Pi OS. Esegui script, usa pip, importa librerie — ambiente Python completo.",
+        "pythonBody": "Python 3 with RPi.GPIO, gpiozero, smbus2 and pyserial. GPIO in and out, PWM, UART and I2C sensors on the header bus; third-party packages through a requirements.txt.",
         "gpioTitle": "Controllo GPIO",
         "gpioBody": "Usa RPi.GPIO o gpiozero per controllare LED, leggere pulsanti, pilotare motori — emulazione GPIO reale in QEMU.",
         "linuxTitle": "Terminale Linux",
-        "linuxBody": "Terminale bash completo con apt, nano, git e tutti gli strumenti Linux standard. Installa pacchetti, modifica file, esegui servizi.",
+        "linuxBody": "Optional Linux mode boots an Alpine guest in QEMU with a real shell and python3. It is not Raspberry Pi OS: no apt, no desktop, no network from inside the guest.",
         "armTitle": "ARM Cortex-A53",
-        "armBody": "CPU ARM a 64 bit quad-core a 1.2 GHz tramite macchina QEMU raspi3b. Esegue l'immagine ufficiale di Raspberry Pi OS.",
+        "armBody": "The Linux guest runs a 64-bit ARM kernel under QEMU (32-bit for the Zero, 1 and 2) with the CPU profile of the board you picked.",
         "sdTitle": "Nessuna scheda SD necessaria",
         "sdBody": "L'immagine del sistema operativo è precaricata. Nessuna masterizzazione, nessuna scheda SD, nessun alimentatore — basta aprire il browser e iniziare a programmare.",
         "multiTitle": "Tela multi-scheda",
@@ -150,20 +150,20 @@
         "picoBodyPrefix": "Microcontrollore. ARM Cortex-M0+ a 133 MHz. Esegue codice C++ Arduino. Nessun sistema operativo, bare-metal. Ideale per embedded, IoT, sensori. ",
         "picoLink": "Prova il simulatore Pico",
         "pi3Title": "Raspberry Pi 3 (ARM Cortex-A53)",
-        "pi3Body": "Computer Linux completo. Quad-core a 1.2 GHz. Esegue Python, Node.js, bash. Ideale per automazione, server, scripting GPIO, educazione."
+        "pi3Body": "A Linux single-board computer. Runs Python scripts against the canvas, in the browser or in a QEMU guest with a shell. Best for GPIO scripting, sensors over I2C, automation and education."
       },
       "faq": {
         "heading": "Domande frequenti",
         "q1": "Posso simulare un Raspberry Pi 3 nel mio browser?",
-        "a1": "Sì. Velxio emula un Raspberry Pi 3B completo usando QEMU raspi3b — ARM Cortex-A53 quad-core a 1.2 GHz che esegue Raspberry Pi OS (Linux). Ottieni un terminale reale per eseguire Python, bash e comandi di sistema.",
+        "a1": "Yes. Velxio runs Raspberry Pi projects (Zero through Pi 5) in your browser: Python scripts execute against the circuit on the canvas, and a Linux guest under QEMU gives you a terminal when a script needs one. The guest is Alpine Linux, not Raspberry Pi OS.",
         "q2": "Il simulatore Raspberry Pi e incluso nel piano gratuito?",
         "a2": "In parte. Puoi costruire e salvare un circuito con Raspberry Pi con qualsiasi account, e un account gratuito ha tre sessioni di prova da 15 minuti per eseguirlo (ogni esecuzione durante una sessione è gratuita). L'emulazione Linux illimitata su Raspberry Pi esegue un guest ARM completo sui nostri server, quindi fa parte dei piani Maker e Pro, o di Velxio Desktop con licenza a pagamento. L'editor e i simulatori Arduino, ESP32 e Raspberry Pi Pico sono gratuiti e non richiedono un account. Velxio resta open source (GNU AGPLv3).",
         "q3": "Posso eseguire script Python sul simulatore Raspberry Pi?",
-        "a3": "Sì. Il Raspberry Pi 3 emulato esegue Raspberry Pi OS completo con Python 3 preinstallato. Puoi eseguire script Python, usare RPi.GPIO per il controllo GPIO, installare pacchetti pip e altro.",
+        "a3": "Yes. Python 3 runs in the browser with RPi.GPIO, gpiozero and smbus2, or in the Linux guest. Third-party packages are installed from a requirements.txt in your project; pip cannot reach the internet from inside the guest.",
         "q4": "Qual è la differenza tra la simulazione di Pi Pico e Pi 3?",
-        "a4": "Raspberry Pi Pico (RP2040) è un microcontrollore — esegue codice C++ Arduino, nessun sistema operativo. Raspberry Pi 3 è un computer Linux completo — esegue Python, bash e servizi di sistema. Velxio supporta entrambi.",
+        "a4": "Raspberry Pi Pico (RP2040) is a microcontroller — it runs Arduino C++ or MicroPython, no OS. Raspberry Pi Zero through 5 are Linux computers — they run Python scripts, and in Linux mode a shell. Velxio supports both.",
         "q5": "Supporta GPIO su Raspberry Pi 3?",
-        "a5": "Sì. Il Raspberry Pi 3 emulato da QEMU supporta GPIO tramite le librerie Python RPi.GPIO e gpiozero. Controlla LED, leggi pulsanti e interfaccia con sensori da Python."
+        "a5": "Yes. RPi.GPIO and gpiozero drive LEDs, read buttons and PIR sensors, and PWM reaches servos and dimmed LEDs. I2C sensors on the header bus (SDA on GPIO2, SCL on GPIO3) answer through smbus2. A Pi has no analog input: a potentiometer needs an MCP3008 or ADS1115 between it and the Pi."
       },
       "bottom": {
         "title": "Pronto a simulare Raspberry Pi 3?",

--- a/frontend/src/i18n/locales/ja/seo2.json
+++ b/frontend/src/i18n/locales/ja/seo2.json
@@ -121,24 +121,24 @@
     "rpi": {
       "hero": {
         "title": "Raspberry Pi 3 シミュレーター",
-        "accent": "完全なLinux · Python · GPIO — ブラウザで",
-        "subtitle": "ブラウザでRaspberry Pi 3BをRaspberry Pi OSとともに直接実行—QEMUによるARM Cortex-A53クアッドコアエミュレーション。Pythonの記述、GPIO制御、パッケージのインストール。ハードウェア不要。",
+        "accent": "Python · GPIO · I2C — In Your Browser",
+        "subtitle": "Run Raspberry Pi projects in your browser: write Python against the circuit on the canvas with RPi.GPIO, gpiozero and smbus2, the libraries real Pi projects use. Scripts start in seconds on the in-browser engine; a Linux guest on our servers is one click away when a script needs a shell.",
         "ctaPrimary": "Pi 3シミュレーターを開く",
         "ctaSecondary": "ドキュメントを読む",
-        "trust": "QEMU ARM64 · 完全なRaspberry Pi OS · 無料試用、その後MakerおよびProプラン",
+        "trust": "In-browser Python · QEMU Linux guest · Three free trial sessions, then Maker and Pro plans",
         "imageAlt": "Raspberry Pi 3ボードのイラスト"
       },
       "what": {
         "heading": "Pi 3シミュレーターでできること",
-        "lead": "Velxioは完全なRaspberry Pi 3Bをエミュレートします—GPIOピンだけでなく、Linuxオペレーティングシステム全体。ブラウザ内の完全なコンピュータです。",
+        "lead": "Velxio runs your Raspberry Pi scripts against the sensors, displays and actuators you wire on the canvas — the same component models an Arduino or ESP32 talks to. Two engines: Python in the browser by default, and a QEMU Linux guest when you want a terminal.",
         "pythonTitle": "Pythonスクリプトの実行",
-        "pythonBody": "Raspberry Pi OSにPython 3がプリインストール。スクリプトの実行、pipの使用、ライブラリのインポート—完全なPython環境。",
+        "pythonBody": "Python 3 with RPi.GPIO, gpiozero, smbus2 and pyserial. GPIO in and out, PWM, UART and I2C sensors on the header bus; third-party packages through a requirements.txt.",
         "gpioTitle": "GPIO制御",
         "gpioBody": "RPi.GPIOまたはgpiozeroを使用してLEDの制御、ボタンの読み取り、モーターの駆動—QEMUでの実際のGPIOエミュレーション。",
         "linuxTitle": "Linuxターミナル",
-        "linuxBody": "apt、nano、git、およびすべての標準Linuxツールを備えた完全なbashターミナル。パッケージのインストール、ファイルの編集、サービスの実行。",
+        "linuxBody": "Optional Linux mode boots an Alpine guest in QEMU with a real shell and python3. It is not Raspberry Pi OS: no apt, no desktop, no network from inside the guest.",
         "armTitle": "ARM Cortex-A53",
-        "armBody": "QEMU raspi3bマシンによる1.2 GHzクアッドコア64ビットARM CPU。公式のRaspberry Pi OSイメージを実行。",
+        "armBody": "The Linux guest runs a 64-bit ARM kernel under QEMU (32-bit for the Zero, 1 and 2) with the CPU profile of the board you picked.",
         "sdTitle": "SDカード不要",
         "sdBody": "OSイメージはプリロード済み。フラッシュ不要、SDカード不要、電源不要—ブラウザを開いてすぐにコーディング開始。",
         "multiTitle": "マルチボードキャンバス",
@@ -150,20 +150,20 @@
         "picoBodyPrefix": "マイクロコントローラ。133 MHzのARM Cortex-M0+。Arduino C++コードを実行。OSなし、ベアメタル。組み込み、IoT、センサーに最適。",
         "picoLink": "Picoシミュレーターを試す",
         "pi3Title": "Raspberry Pi 3 (ARM Cortex-A53)",
-        "pi3Body": "完全なLinuxコンピュータ。1.2 GHzクアッドコア。Python、Node.js、bashを実行。自動化、サーバー、GPIOスクリプティング、教育に最適。"
+        "pi3Body": "A Linux single-board computer. Runs Python scripts against the canvas, in the browser or in a QEMU guest with a shell. Best for GPIO scripting, sensors over I2C, automation and education."
       },
       "faq": {
         "heading": "よくある質問",
         "q1": "ブラウザでRaspberry Pi 3をシミュレーションできますか？",
-        "a1": "はい。VelxioはQEMU raspi3bを使用して完全なRaspberry Pi 3Bをエミュレート—1.2 GHzのARM Cortex-A53クアッドコアでRaspberry Pi OS（Linux）を実行。Python、bash、システムコマンドを実行できる実際のターミナルを提供します。",
+        "a1": "Yes. Velxio runs Raspberry Pi projects (Zero through Pi 5) in your browser: Python scripts execute against the circuit on the canvas, and a Linux guest under QEMU gives you a terminal when a script needs one. The guest is Alpine Linux, not Raspberry Pi OS.",
         "q2": "Raspberry Pi シミュレーターは無料プランに含まれますか?",
         "a2": "一部含まれます。Raspberry Piの回路はどのアカウントでも作成・保存でき、無料アカウントには実行用に15分の試用セッションが3回付きます（セッション中の実行は何度でも無料）。無制限のRaspberry Pi Linuxエミュレーションは当社サーバー上で完全なARMゲストを動かすため、MakerおよびProプラン、または有料ライセンスのVelxio Desktopに含まれます。エディタとArduino、ESP32、Raspberry Pi Picoのシミュレータは無料でアカウント不要です。Velxio自体はオープンソース（GNU AGPLv3）のままです。",
         "q3": "Raspberry PiシミュレーターでPythonスクリプトを実行できますか？",
-        "a3": "はい。エミュレートされたRaspberry Pi 3は、Python 3がプリインストールされた完全なRaspberry Pi OSを実行します。Pythonスクリプトの実行、RPi.GPIOを使用したGPIO制御、pipパッケージのインストールなどが可能です。",
+        "a3": "Yes. Python 3 runs in the browser with RPi.GPIO, gpiozero and smbus2, or in the Linux guest. Third-party packages are installed from a requirements.txt in your project; pip cannot reach the internet from inside the guest.",
         "q4": "Pi PicoとPi 3のシミュレーションの違いは何ですか？",
-        "a4": "Raspberry Pi Pico（RP2040）はマイクロコントローラ—Arduino C++コードを実行、OSなし。Raspberry Pi 3は完全なLinuxコンピュータ—Python、bash、システムサービスを実行。Velxioは両方をサポートしています。",
+        "a4": "Raspberry Pi Pico (RP2040) is a microcontroller — it runs Arduino C++ or MicroPython, no OS. Raspberry Pi Zero through 5 are Linux computers — they run Python scripts, and in Linux mode a shell. Velxio supports both.",
         "q5": "Raspberry Pi 3のGPIOはサポートされていますか？",
-        "a5": "はい。QEMUエミュレートされたRaspberry Pi 3は、RPi.GPIOおよびgpiozero Pythonライブラリを介してGPIOをサポートしています。LEDの制御、ボタンの読み取り、Pythonからのセンサーとのインターフェースが可能です。"
+        "a5": "Yes. RPi.GPIO and gpiozero drive LEDs, read buttons and PIR sensors, and PWM reaches servos and dimmed LEDs. I2C sensors on the header bus (SDA on GPIO2, SCL on GPIO3) answer through smbus2. A Pi has no analog input: a potentiometer needs an MCP3008 or ADS1115 between it and the Pi."
       },
       "bottom": {
         "title": "Raspberry Pi 3のシミュレーションを始めましょう",

--- a/frontend/src/i18n/locales/pt-br/seo2.json
+++ b/frontend/src/i18n/locales/pt-br/seo2.json
@@ -121,24 +121,24 @@
     "rpi": {
       "hero": {
         "title": "Simulador de Raspberry Pi 3",
-        "accent": "Linux Completo · Python · GPIO — No Seu Navegador",
-        "subtitle": "Execute um Raspberry Pi 3B completo com Raspberry Pi OS diretamente no seu navegador — emulação ARM Cortex-A53 quad-core via QEMU. Escreva Python, controle GPIO, instale pacotes. Sem necessidade de hardware.",
+        "accent": "Python · GPIO · I2C — In Your Browser",
+        "subtitle": "Run Raspberry Pi projects in your browser: write Python against the circuit on the canvas with RPi.GPIO, gpiozero and smbus2, the libraries real Pi projects use. Scripts start in seconds on the in-browser engine; a Linux guest on our servers is one click away when a script needs a shell.",
         "ctaPrimary": "Abrir Simulador Pi 3",
         "ctaSecondary": "Ler a Documentação",
-        "trust": "QEMU ARM64 · Raspberry Pi OS completo · Teste gratis, depois planos Maker e Pro",
+        "trust": "In-browser Python · QEMU Linux guest · Three free trial sessions, then Maker and Pro plans",
         "imageAlt": "Ilustração da placa Raspberry Pi 3"
       },
       "what": {
         "heading": "O que você pode fazer com o simulador Pi 3?",
-        "lead": "Velxio emula um Raspberry Pi 3B completo — não apenas pinos GPIO, mas todo o sistema operacional Linux. É um computador completo no seu navegador.",
+        "lead": "Velxio runs your Raspberry Pi scripts against the sensors, displays and actuators you wire on the canvas — the same component models an Arduino or ESP32 talks to. Two engines: Python in the browser by default, and a QEMU Linux guest when you want a terminal.",
         "pythonTitle": "Executar Scripts Python",
-        "pythonBody": "Python 3 pré-instalado no Raspberry Pi OS. Execute scripts, use pip, importe bibliotecas — ambiente Python completo.",
+        "pythonBody": "Python 3 with RPi.GPIO, gpiozero, smbus2 and pyserial. GPIO in and out, PWM, UART and I2C sensors on the header bus; third-party packages through a requirements.txt.",
         "gpioTitle": "Controle GPIO",
         "gpioBody": "Use RPi.GPIO ou gpiozero para controlar LEDs, ler botões, acionar motores — emulação GPIO real no QEMU.",
         "linuxTitle": "Terminal Linux",
-        "linuxBody": "Terminal bash completo com apt, nano, git e todas as ferramentas Linux padrão. Instale pacotes, edite arquivos, execute serviços.",
+        "linuxBody": "Optional Linux mode boots an Alpine guest in QEMU with a real shell and python3. It is not Raspberry Pi OS: no apt, no desktop, no network from inside the guest.",
         "armTitle": "ARM Cortex-A53",
-        "armBody": "CPU ARM quad-core de 64 bits a 1,2 GHz via máquina raspi3b do QEMU. Executa a imagem oficial do Raspberry Pi OS.",
+        "armBody": "The Linux guest runs a 64-bit ARM kernel under QEMU (32-bit for the Zero, 1 and 2) with the CPU profile of the board you picked.",
         "sdTitle": "Sem Necessidade de Cartão SD",
         "sdBody": "A imagem do SO é pré-carregada. Sem flashing, sem cartão SD, sem fonte de alimentação — apenas abra o navegador e comece a programar.",
         "multiTitle": "Tela Multi-Placa",
@@ -150,20 +150,20 @@
         "picoBodyPrefix": "Microcontrolador. ARM Cortex-M0+ a 133 MHz. Executa código Arduino C++. Sem SO, bare-metal. Melhor para embarcados, IoT, sensores. ",
         "picoLink": "Experimentar Simulador Pico",
         "pi3Title": "Raspberry Pi 3 (ARM Cortex-A53)",
-        "pi3Body": "Computador Linux completo. Quad-core a 1,2 GHz. Executa Python, Node.js, bash. Melhor para automação, servidores, script GPIO, educação."
+        "pi3Body": "A Linux single-board computer. Runs Python scripts against the canvas, in the browser or in a QEMU guest with a shell. Best for GPIO scripting, sensors over I2C, automation and education."
       },
       "faq": {
         "heading": "Perguntas Frequentes",
         "q1": "Posso simular um Raspberry Pi 3 no meu navegador?",
-        "a1": "Sim. Velxio emula um Raspberry Pi 3B completo usando QEMU raspi3b — ARM Cortex-A53 quad-core a 1,2 GHz executando Raspberry Pi OS (Linux). Você obtém um terminal real para executar Python, bash e comandos do sistema.",
+        "a1": "Yes. Velxio runs Raspberry Pi projects (Zero through Pi 5) in your browser: Python scripts execute against the circuit on the canvas, and a Linux guest under QEMU gives you a terminal when a script needs one. The guest is Alpine Linux, not Raspberry Pi OS.",
         "q2": "O simulador de Raspberry Pi esta incluido no plano gratuito?",
         "a2": "Em parte. Voce pode montar e salvar um circuito com Raspberry Pi com qualquer conta, e uma conta gratuita tem tres sessoes de teste de 15 minutos para executa-lo (cada execucao dentro de uma sessao e gratis). A emulacao ilimitada de Linux na Raspberry Pi roda um convidado ARM completo em nossos servidores, por isso faz parte dos planos Maker e Pro, ou do Velxio Desktop com licenca paga. O editor e os simuladores de Arduino, ESP32 e Raspberry Pi Pico sao gratuitos e nao pedem conta. O Velxio continua sendo codigo aberto (GNU AGPLv3).",
         "q3": "Posso executar scripts Python no simulador Raspberry Pi?",
-        "a3": "Sim. O Raspberry Pi 3 emulado executa Raspberry Pi OS completo com Python 3 pré-instalado. Você pode executar scripts Python, usar RPi.GPIO para controle GPIO, instalar pacotes pip e mais.",
+        "a3": "Yes. Python 3 runs in the browser with RPi.GPIO, gpiozero and smbus2, or in the Linux guest. Third-party packages are installed from a requirements.txt in your project; pip cannot reach the internet from inside the guest.",
         "q4": "Qual é a diferença entre a simulação do Pi Pico e do Pi 3?",
-        "a4": "Raspberry Pi Pico (RP2040) é um microcontrolador — executa código Arduino C++, sem SO. Raspberry Pi 3 é um computador Linux completo — executa Python, bash e serviços do sistema. Velxio suporta ambos.",
+        "a4": "Raspberry Pi Pico (RP2040) is a microcontroller — it runs Arduino C++ or MicroPython, no OS. Raspberry Pi Zero through 5 are Linux computers — they run Python scripts, and in Linux mode a shell. Velxio supports both.",
         "q5": "Ele suporta GPIO no Raspberry Pi 3?",
-        "a5": "Sim. O Raspberry Pi 3 emulado pelo QEMU suporta GPIO via bibliotecas Python RPi.GPIO e gpiozero. Controle LEDs, leia botões e interfira com sensores a partir do Python."
+        "a5": "Yes. RPi.GPIO and gpiozero drive LEDs, read buttons and PIR sensors, and PWM reaches servos and dimmed LEDs. I2C sensors on the header bus (SDA on GPIO2, SCL on GPIO3) answer through smbus2. A Pi has no analog input: a potentiometer needs an MCP3008 or ADS1115 between it and the Pi."
       },
       "bottom": {
         "title": "Pronto para simular Raspberry Pi 3?",

--- a/frontend/src/i18n/locales/ru/seo2.json
+++ b/frontend/src/i18n/locales/ru/seo2.json
@@ -121,24 +121,24 @@
     "rpi": {
       "hero": {
         "title": "Симулятор Raspberry Pi 3",
-        "accent": "Полноценный Linux · Python · GPIO — в вашем браузере",
-        "subtitle": "Запустите полноценный Raspberry Pi 3B с Raspberry Pi OS прямо в браузере — эмуляция четырёхъядерного ARM Cortex-A53 через QEMU. Пишите на Python, управляйте GPIO, устанавливайте пакеты. Оборудование не требуется.",
+        "accent": "Python · GPIO · I2C — In Your Browser",
+        "subtitle": "Run Raspberry Pi projects in your browser: write Python against the circuit on the canvas with RPi.GPIO, gpiozero and smbus2, the libraries real Pi projects use. Scripts start in seconds on the in-browser engine; a Linux guest on our servers is one click away when a script needs a shell.",
         "ctaPrimary": "Открыть симулятор Pi 3",
         "ctaSecondary": "Читать документацию",
-        "trust": "QEMU ARM64 · Полная Raspberry Pi OS · Бесплатная проба, затем планы Maker и Pro",
+        "trust": "In-browser Python · QEMU Linux guest · Three free trial sessions, then Maker and Pro plans",
         "imageAlt": "Иллюстрация платы Raspberry Pi 3"
       },
       "what": {
         "heading": "Что можно делать с симулятором Pi 3?",
-        "lead": "Velxio эмулирует полноценный Raspberry Pi 3B — не только пины GPIO, но и всю операционную систему Linux. Это полноценный компьютер в вашем браузере.",
+        "lead": "Velxio runs your Raspberry Pi scripts against the sensors, displays and actuators you wire on the canvas — the same component models an Arduino or ESP32 talks to. Two engines: Python in the browser by default, and a QEMU Linux guest when you want a terminal.",
         "pythonTitle": "Запуск скриптов Python",
-        "pythonBody": "Python 3 предустановлен на Raspberry Pi OS. Запускайте скрипты, используйте pip, импортируйте библиотеки — полноценная среда Python.",
+        "pythonBody": "Python 3 with RPi.GPIO, gpiozero, smbus2 and pyserial. GPIO in and out, PWM, UART and I2C sensors on the header bus; third-party packages through a requirements.txt.",
         "gpioTitle": "Управление GPIO",
         "gpioBody": "Используйте RPi.GPIO или gpiozero для управления светодиодами, чтения кнопок, управления двигателями — реальная эмуляция GPIO в QEMU.",
         "linuxTitle": "Терминал Linux",
-        "linuxBody": "Полноценный bash-терминал с apt, nano, git и всеми стандартными инструментами Linux. Устанавливайте пакеты, редактируйте файлы, запускайте службы.",
+        "linuxBody": "Optional Linux mode boots an Alpine guest in QEMU with a real shell and python3. It is not Raspberry Pi OS: no apt, no desktop, no network from inside the guest.",
         "armTitle": "ARM Cortex-A53",
-        "armBody": "Четырёхъядерный 64-битный процессор ARM с частотой 1,2 ГГц через машину QEMU raspi3b. Запускает официальный образ Raspberry Pi OS.",
+        "armBody": "The Linux guest runs a 64-bit ARM kernel under QEMU (32-bit for the Zero, 1 and 2) with the CPU profile of the board you picked.",
         "sdTitle": "SD-карта не нужна",
         "sdBody": "Образ ОС предварительно загружен. Никакой прошивки, SD-карты или блока питания — просто откройте браузер и начинайте программировать.",
         "multiTitle": "Многоплатный холст",
@@ -150,20 +150,20 @@
         "picoBodyPrefix": "Микроконтроллер. ARM Cortex-M0+ на 133 МГц. Запускает код Arduino C++. Без ОС, «голое железо». Лучше всего подходит для встраиваемых систем, IoT, датчиков. ",
         "picoLink": "Попробовать симулятор Pico",
         "pi3Title": "Raspberry Pi 3 (ARM Cortex-A53)",
-        "pi3Body": "Полноценный компьютер на Linux. Четырёхъядерный процессор 1,2 ГГц. Запускает Python, Node.js, bash. Лучше всего подходит для автоматизации, серверов, скриптов GPIO, обучения."
+        "pi3Body": "A Linux single-board computer. Runs Python scripts against the canvas, in the browser or in a QEMU guest with a shell. Best for GPIO scripting, sensors over I2C, automation and education."
       },
       "faq": {
         "heading": "Часто задаваемые вопросы",
         "q1": "Могу ли я симулировать Raspberry Pi 3 в своём браузере?",
-        "a1": "Да. Velxio эмулирует полноценный Raspberry Pi 3B с помощью QEMU raspi3b — четырёхъядерный ARM Cortex-A53 на 1,2 ГГц под управлением Raspberry Pi OS (Linux). Вы получаете настоящий терминал для запуска Python, bash и системных команд.",
+        "a1": "Yes. Velxio runs Raspberry Pi projects (Zero through Pi 5) in your browser: Python scripts execute against the circuit on the canvas, and a Linux guest under QEMU gives you a terminal when a script needs one. The guest is Alpine Linux, not Raspberry Pi OS.",
         "q2": "Входит ли симулятор Raspberry Pi в бесплатный тариф?",
         "a2": "Частично. Собрать и сохранить схему с Raspberry Pi можно с любым аккаунтом, а бесплатный аккаунт получает три пробные сессии по 15 минут для её запуска (каждый запуск внутри сессии бесплатен). Неограниченная эмуляция Linux на Raspberry Pi запускает полноценный гостевой ARM на наших серверах, поэтому входит в планы Maker и Pro или в Velxio Desktop с платной лицензией. Редактор и симуляторы Arduino, ESP32 и Raspberry Pi Pico бесплатны и не требуют аккаунта. Сам Velxio остаётся открытым (GNU AGPLv3).",
         "q3": "Могу ли я запускать скрипты Python на симуляторе Raspberry Pi?",
-        "a3": "Да. Эмулируемый Raspberry Pi 3 запускает полноценную Raspberry Pi OS с предустановленным Python 3. Вы можете запускать скрипты Python, использовать RPi.GPIO для управления GPIO, устанавливать пакеты pip и многое другое.",
+        "a3": "Yes. Python 3 runs in the browser with RPi.GPIO, gpiozero and smbus2, or in the Linux guest. Third-party packages are installed from a requirements.txt in your project; pip cannot reach the internet from inside the guest.",
         "q4": "В чём разница между симуляцией Pi Pico и Pi 3?",
-        "a4": "Raspberry Pi Pico (RP2040) — это микроконтроллер: запускает код Arduino C++, без ОС. Raspberry Pi 3 — это полноценный компьютер на Linux: запускает Python, bash и системные службы. Velxio поддерживает оба.",
+        "a4": "Raspberry Pi Pico (RP2040) is a microcontroller — it runs Arduino C++ or MicroPython, no OS. Raspberry Pi Zero through 5 are Linux computers — they run Python scripts, and in Linux mode a shell. Velxio supports both.",
         "q5": "Поддерживает ли он GPIO на Raspberry Pi 3?",
-        "a5": "Да. Эмулируемый через QEMU Raspberry Pi 3 поддерживает GPIO через библиотеки Python RPi.GPIO и gpiozero. Управляйте светодиодами, читайте кнопки и взаимодействуйте с датчиками из Python."
+        "a5": "Yes. RPi.GPIO and gpiozero drive LEDs, read buttons and PIR sensors, and PWM reaches servos and dimmed LEDs. I2C sensors on the header bus (SDA on GPIO2, SCL on GPIO3) answer through smbus2. A Pi has no analog input: a potentiometer needs an MCP3008 or ADS1115 between it and the Pi."
       },
       "bottom": {
         "title": "Готовы симулировать Raspberry Pi 3?",

--- a/frontend/src/i18n/locales/zh-cn/seo2.json
+++ b/frontend/src/i18n/locales/zh-cn/seo2.json
@@ -121,24 +121,24 @@
     "rpi": {
       "hero": {
         "title": "Raspberry Pi 3 模拟器",
-        "accent": "完整的Linux · Python · GPIO —— 在你的浏览器中",
-        "subtitle": "直接在浏览器中运行完整的Raspberry Pi 3B和Raspberry Pi OS——通过QEMU进行ARM Cortex-A53四核仿真。编写Python，控制GPIO，安装软件包。无需硬件。",
+        "accent": "Python · GPIO · I2C — In Your Browser",
+        "subtitle": "Run Raspberry Pi projects in your browser: write Python against the circuit on the canvas with RPi.GPIO, gpiozero and smbus2, the libraries real Pi projects use. Scripts start in seconds on the in-browser engine; a Linux guest on our servers is one click away when a script needs a shell.",
         "ctaPrimary": "打开Pi 3仿真器",
         "ctaSecondary": "阅读文档",
-        "trust": "QEMU ARM64 · 完整 Raspberry Pi OS · 免费试用，然后 Maker 和 Pro 方案",
+        "trust": "In-browser Python · QEMU Linux guest · Three free trial sessions, then Maker and Pro plans",
         "imageAlt": "Raspberry Pi 3板示意图"
       },
       "what": {
         "heading": "你能用Pi 3仿真器做什么？",
-        "lead": "Velxio仿真完整的Raspberry Pi 3B——不仅仅是GPIO引脚，而是整个Linux操作系统。它是你浏览器中的一台完整计算机。",
+        "lead": "Velxio runs your Raspberry Pi scripts against the sensors, displays and actuators you wire on the canvas — the same component models an Arduino or ESP32 talks to. Two engines: Python in the browser by default, and a QEMU Linux guest when you want a terminal.",
         "pythonTitle": "运行Python脚本",
-        "pythonBody": "Python 3预装在Raspberry Pi OS上。运行脚本，使用pip，导入库——完整的Python环境。",
+        "pythonBody": "Python 3 with RPi.GPIO, gpiozero, smbus2 and pyserial. GPIO in and out, PWM, UART and I2C sensors on the header bus; third-party packages through a requirements.txt.",
         "gpioTitle": "GPIO控制",
         "gpioBody": "使用RPi.GPIO或gpiozero控制LED、读取按钮、驱动电机——QEMU中的真实GPIO仿真。",
         "linuxTitle": "Linux终端",
-        "linuxBody": "完整的bash终端，带有apt、nano、git和所有标准Linux工具。安装软件包，编辑文件，运行服务。",
+        "linuxBody": "Optional Linux mode boots an Alpine guest in QEMU with a real shell and python3. It is not Raspberry Pi OS: no apt, no desktop, no network from inside the guest.",
         "armTitle": "ARM Cortex-A53",
-        "armBody": "通过QEMU raspi3b机器，四核64位ARM CPU，1.2 GHz。运行官方的Raspberry Pi OS镜像。",
+        "armBody": "The Linux guest runs a 64-bit ARM kernel under QEMU (32-bit for the Zero, 1 and 2) with the CPU profile of the board you picked.",
         "sdTitle": "无需SD卡",
         "sdBody": "操作系统镜像已预加载。无需刷写，无需SD卡，无需电源——只需打开浏览器即可开始编码。",
         "multiTitle": "多板画布",
@@ -150,20 +150,20 @@
         "picoBodyPrefix": "微控制器。ARM Cortex-M0+，133 MHz。运行Arduino C++代码。无操作系统，裸机。最适合嵌入式、物联网、传感器。",
         "picoLink": "尝试Pico仿真器",
         "pi3Title": "Raspberry Pi 3 (ARM Cortex-A53)",
-        "pi3Body": "完整的Linux计算机。四核1.2 GHz。运行Python、Node.js、bash。最适合自动化、服务器、GPIO脚本、教育。"
+        "pi3Body": "A Linux single-board computer. Runs Python scripts against the canvas, in the browser or in a QEMU guest with a shell. Best for GPIO scripting, sensors over I2C, automation and education."
       },
       "faq": {
         "heading": "常见问题",
         "q1": "我可以在浏览器中模拟Raspberry Pi 3吗？",
-        "a1": "是的。Velxio使用QEMU raspi3b仿真完整的Raspberry Pi 3B——ARM Cortex-A53四核1.2 GHz，运行Raspberry Pi OS (Linux)。你得到一个真实的终端来运行Python、bash和系统命令。",
+        "a1": "Yes. Velxio runs Raspberry Pi projects (Zero through Pi 5) in your browser: Python scripts execute against the circuit on the canvas, and a Linux guest under QEMU gives you a terminal when a script needs one. The guest is Alpine Linux, not Raspberry Pi OS.",
         "q2": "Raspberry Pi 模拟器包含在免费套餐中吗？",
         "a2": "部分包含。任何账户都可以搭建并保存 Raspberry Pi 电路，免费账户还有三次 15 分钟的试用会话来运行它（会话期间的每次运行都免费）。不限次数的 Raspberry Pi Linux 模拟会在我们的服务器上运行完整的 ARM 客户机，因此属于 Maker 和 Pro 方案，或带付费许可证的 Velxio Desktop。编辑器以及 Arduino、ESP32 和 Raspberry Pi Pico 模拟器免费且无需账户。Velxio 本身仍然开源（GNU AGPLv3）。",
         "q3": "我可以在Raspberry Pi仿真器上运行Python脚本吗？",
-        "a3": "是的。仿真的Raspberry Pi 3运行完整的Raspberry Pi OS，预装Python 3。你可以运行Python脚本，使用RPi.GPIO进行GPIO控制，安装pip包等。",
+        "a3": "Yes. Python 3 runs in the browser with RPi.GPIO, gpiozero and smbus2, or in the Linux guest. Third-party packages are installed from a requirements.txt in your project; pip cannot reach the internet from inside the guest.",
         "q4": "Pi Pico和Pi 3仿真有什么区别？",
-        "a4": "Raspberry Pi Pico (RP2040) 是微控制器——运行Arduino C++代码，无操作系统。Raspberry Pi 3是完整的Linux计算机——运行Python、bash和系统服务。Velxio两者都支持。",
+        "a4": "Raspberry Pi Pico (RP2040) is a microcontroller — it runs Arduino C++ or MicroPython, no OS. Raspberry Pi Zero through 5 are Linux computers — they run Python scripts, and in Linux mode a shell. Velxio supports both.",
         "q5": "它支持Raspberry Pi 3上的GPIO吗？",
-        "a5": "是的。QEMU仿真的Raspberry Pi 3通过RPi.GPIO和gpiozero Python库支持GPIO。从Python控制LED、读取按钮并与传感器交互。"
+        "a5": "Yes. RPi.GPIO and gpiozero drive LEDs, read buttons and PIR sensors, and PWM reaches servos and dimmed LEDs. I2C sensors on the header bus (SDA on GPIO2, SCL on GPIO3) answer through smbus2. A Pi has no analog input: a potentiometer needs an MCP3008 or ADS1115 between it and the Pi."
       },
       "bottom": {
         "title": "准备好模拟Raspberry Pi 3了吗？",

--- a/frontend/src/simulation/PiBridgeShim.ts
+++ b/frontend/src/simulation/PiBridgeShim.ts
@@ -1,0 +1,567 @@
+/**
+ * PiBridgeShim — the simulator-shaped object a Linux-guest board (the
+ * Raspberry Pi family and any overlay-registered kind of the same family)
+ * hands to the parts wired to it.
+ *
+ * Why it exists: every part on the canvas attaches to
+ * `getBoardSimulator(boardId)` and asks it for a bus (`addI2CDevice`, `.spi`,
+ * `setSPIHandler`), a pin (`setPinState`, `pinManager`) or an ADC
+ * (`setAdcVoltage`). A Pi had no entry in that map: a hand-rolled stub in
+ * DynamicComponent answered `setPinState` and nothing else, so an I2C sensor
+ * wired to GPIO2/3 attached nowhere and the guest read 0x00 from an address
+ * that had a model sitting right there on the canvas. This class gives the
+ * Pi the same surface the STM32 and ESP32 shims give their boards, over the
+ * same `I2CBusManager` and `PinManager` every other board uses.
+ *
+ * Two engines run a Pi script, and both come here for their peripherals:
+ *
+ *   - the Linux guest in QEMU (via `RaspberryPi3Bridge`): the guest's shim
+ *     libraries send one request line per bus operation and the backend
+ *     relays it to the browser as `pi_bus_request {rid, line}`; the store
+ *     wires `bridge.onBusRequest` to {@link answerBusLine} and the bridge
+ *     sends the answer back as `pi_bus_reply`;
+ *   - an in-browser engine, which calls {@link answerBusLine} directly with
+ *     the same lines.
+ *
+ * One grammar, one answerer, the same device models: whatever a sensor
+ * answers in one engine it answers in the other, by construction.
+ *
+ * Request lines (one per operation; `<addr>`, `<reg>` and byte strings in hex):
+ *
+ *   I2C <bus> <addr> R  <n>              raw read of n bytes
+ *   I2C <bus> <addr> W  <hex>            raw write
+ *   I2C <bus> <addr> RR <reg> <n>        write reg, repeated start, read n
+ *   I2C <bus> <addr> WR <reg> <hex>      write reg + bytes
+ *   I2C <bus> <addr> T  <hex|-> <n>      write bytes, repeated start, read n
+ *   SPI <bus> <cs> X  <hex>              full-duplex transfer, CS released after
+ *   SPI <bus> <cs> XC <hex>              same, CS held low for the next transfer
+ *   SPI <bus> <cs> CONFIG ...            accepted, nothing to answer
+ *   W1 <pin> LIST | SP <rom> | RES <rom> <bits>
+ *   W1 <pin> RESET | RB | WB <hex> | RBLK <n> | WBLK <hex> | TRIPLET <d>
+ *   PWM <ch> <period_ns> <duty_ns> <en>  hardware PWM channel (0 = GPIO18, 1 = GPIO19)
+ *   PWM_START | PWM_CHANGE <pin> <hz> <duty_pct>, PWM_STOP <pin>
+ *   GPIO_SETUP <pin> <in|out> [<pud_up|pud_down|pud_off>]
+ *
+ * Replies:
+ *
+ *   I2C_DATA <bus> <addr> [<hex>]        ack; the bytes read, if any
+ *   I2C_ERR  <bus> <addr> nack           nobody acknowledged the address
+ *   SPI_DATA <bus> <cs> <hex>            the bytes clocked in on MISO
+ *   W1_LIST  <pin> [<rom>,...]           ROM ids on that pin
+ *   W1_SLAVE <pin> <rom> <18hex> <crc_ok>  a slave's 9-byte scratchpad
+ *   W1_DATA  <pin> <hex|0|1|ok>          the byte-level ops
+ *   W1_ERR   <pin> no-master             nothing registered on that pin
+ *   (null)                               lines that need no answer (PWM, GPIO_SETUP, CONFIG)
+ */
+
+import { I2CBusManager, nullI2CMaster, type I2CDevice } from './I2CBusManager';
+import type { PinManager } from './PinManager';
+import type { RaspberryPi3Bridge } from './RaspberryPi3Bridge';
+import type { LineSupport } from './line/LineHost';
+import { recordPartGap } from './line/requestLine';
+import { requestElectricalResolve } from './spice/electricalResolveHook';
+import { getBoardLineSupport } from '../lib/proBoardRegistry';
+import type { OneWireByteMaster } from './oneWireHost';
+
+/** What the store tells the shim about its board, read fresh on every call. */
+export interface PiShimBoardState {
+  running?: boolean;
+  engineMode?: 'instant' | 'linux';
+}
+
+/**
+ * The in-browser engine's side of the shim: set by whoever runs the script in
+ * the browser, so a part's input reaches the engine's pin table and a wired
+ * peer's UART bytes reach its serial shim. Every member optional — a board
+ * with no such engine simply has nothing here.
+ */
+export interface PiInstantAdapter {
+  onPinInput?(pin: number, state: boolean): void;
+  onUartRx?(bytes: number[]): void;
+}
+
+export interface PiBridgeShimOptions {
+  boardId: string;
+  boardKind: string;
+  bridge: RaspberryPi3Bridge;
+  pinManager: PinManager;
+  /** The board's live store record (running flag, engine mode). */
+  boardState: () => PiShimBoardState | undefined;
+}
+
+/** The SPI adapter in the AVR shape parts already hook (`spi.onByte`). */
+export interface PiSpiAdapter {
+  onByte: ((mosi: number) => void) | null;
+  completeTransfer: (miso: number) => void;
+}
+
+/** BCM pins of the chip-selects per SPI bus, indexed by the guest's `cs`. */
+const SPI_CE_PINS: Record<number, number[]> = {
+  0: [8, 7],
+  1: [18, 17, 16],
+};
+
+/** Hardware PWM channels of `pwmchip0` on the 40-pin header. */
+const PWM_CHANNEL_PINS: Record<number, number> = { 0: 18, 1: 19 };
+
+/** The header I2C bus (GPIO2 SDA / GPIO3 SCL). Bus 0 is the ID EEPROM pair. */
+const HEADER_I2C_BUS = 1;
+
+const LINE_SUPPORT_NONE_WHY =
+  'this board runs a Linux guest that reads its pins over a serial link; timed single-wire sensors are not modelled here';
+const PIXEL_SUPPORT_NONE_WHY =
+  'this board drives its pins over a level protocol with no bit timing, so a WS2812 data stream cannot be produced or decoded here';
+
+/** Hex helpers: byte strings on the wire are lowercase, two chars per byte, no separators. */
+function toHex(bytes: readonly number[]): string {
+  return bytes.map((b) => (b & 0xff).toString(16).padStart(2, '0')).join('');
+}
+function fromHex(s: string | undefined): number[] | null {
+  if (s === undefined || s === '-' || s === '') return [];
+  if (s.length % 2 !== 0 || /[^0-9a-fA-F]/.test(s)) return null;
+  const out: number[] = [];
+  for (let i = 0; i < s.length; i += 2) out.push(parseInt(s.slice(i, i + 2), 16));
+  return out;
+}
+function parseCount(s: string | undefined): number | null {
+  if (s === undefined) return null;
+  const n = Number(s);
+  return Number.isInteger(n) && n >= 0 && n <= 4096 ? n : null;
+}
+
+/** Dallas/Maxim CRC-8 (poly 0x31 reflected), as the w1 kernel driver checks it. */
+function crc8(bytes: readonly number[]): number {
+  let crc = 0;
+  for (const b of bytes) {
+    let x = (crc ^ b) & 0xff;
+    for (let i = 0; i < 8; i++) x = x & 1 ? (x >> 1) ^ 0x8c : x >> 1;
+    crc = x;
+  }
+  return crc;
+}
+
+export class PiBridgeShim {
+  readonly simulatorKind = 'pi' as const;
+  /**
+   * Inputs are NOT driven from the SPICE solve: a Pi's guest reads levels
+   * over a link and the parts seed them directly (the way the old stub did).
+   * A later phase raises this per pin once the guest's pull is known.
+   */
+  readonly spiceDrivenInputs = false;
+  readonly boardId: string;
+  readonly boardKind: string;
+  pinManager: PinManager;
+  onSerialData: ((ch: string) => void) | null = null;
+  onPinChangeWithTime: ((pin: number, state: boolean, timeMs: number) => void) | null = null;
+  /** The in-browser engine's hooks, when one is running this board. */
+  instantAdapter: PiInstantAdapter | null = null;
+
+  private readonly bridge: RaspberryPi3Bridge;
+  private readonly boardState: () => PiShimBoardState | undefined;
+  private readonly i2cBusInstance: I2CBusManager;
+  private readonly spiHandlers = new Map<number, (mosi: number) => number>();
+  private _spiAdapter: PiSpiAdapter | null = null;
+  /** `bus:cs` of a chip-select held low by an `XC` transfer, if any. */
+  private heldCs: { bus: number; cs: number } | null = null;
+  private readonly oneWireMasters = new Map<number, OneWireByteMaster>();
+  private readonly adcWarned = new Set<number>();
+
+  constructor(opts: PiBridgeShimOptions) {
+    this.boardId = opts.boardId;
+    this.boardKind = opts.boardKind;
+    this.bridge = opts.bridge;
+    this.pinManager = opts.pinManager;
+    this.boardState = opts.boardState;
+    this.i2cBusInstance = new I2CBusManager(nullI2CMaster());
+  }
+
+  // ── Lifecycle (the store drives the guest through the bridge / engine) ──
+  start(): void {}
+  /** Nothing to halt here; a chip-select held by an unfinished transfer is released. */
+  stop(): void {
+    this.releaseHeldCs();
+  }
+  reset(): void {}
+  setSpeed(_s: number): void {}
+  getSpeed(): number {
+    return 1;
+  }
+  loadHex(_hex: string): void {}
+  loadBinary(_b64: string): void {}
+  /** The board's own flag, not the socket: a mocked bridge reports connected
+   *  forever, and the in-browser engine has no socket at all. */
+  isRunning(): boolean {
+    return !!this.boardState()?.running;
+  }
+  getBridge(): RaspberryPi3Bridge {
+    return this.bridge;
+  }
+
+  // ── Pins ───────────────────────────────────────────────────────────────
+  /**
+   * A part reports the level on one of its pins (a button, a PIR trip). The
+   * PinManager sees it (wires, SPICE), the guest sees it (`gpio_in` and the
+   * named `pin<N>` value its shims poll), and the in-browser engine sees it.
+   * Bridge members are called optionally on purpose: the test suites that
+   * mock RaspberryPi3Bridge build it with a handful of methods.
+   */
+  setPinState(pin: number, state: boolean): void {
+    this.pinManager.triggerPinChange(pin, state, 'external');
+    const bridge = this.bridge as Partial<RaspberryPi3Bridge>;
+    bridge.sendPinEvent?.(pin, state);
+    bridge.setSensorState?.({ [`pin${pin}`]: state ? 1 : 0 });
+    this.instantAdapter?.onPinInput?.(pin, state);
+  }
+
+  /**
+   * The guest programmed a pull on a pin (`GPIO_SETUP ... pud_up`). Same rule
+   * as the store's pull handler for the MCU boards: record it so the netlist
+   * stamps the weak resistor, seed the input to the pull's resting level when
+   * nothing drives the pin, and ask for a re-solve.
+   */
+  setPinPull(pin: number, pull: 0 | 1 | 2): void {
+    this.pinManager.setPinPull(pin, pull);
+    if (pull !== 0 && !this.pinManager.getOutputPins().has(pin)) {
+      this.setPinState(pin, pull === 1);
+    }
+    requestElectricalResolve();
+  }
+
+  /**
+   * PWM activity from either engine. `dutyPct` is 0-100 as the guest says it;
+   * the PinManager carries 0-1 (servo, dimmed LED and buzzer listeners read
+   * that). A stop is a zero duty.
+   */
+  applyPwm(pin: number, freqHz: number, dutyPct: number): void {
+    if (freqHz > 0) this.pinManager.setPwmFreq(pin, freqHz);
+    const duty = Math.min(1, Math.max(0, dutyPct / 100));
+    this.pinManager.updatePwm(pin, Number.isFinite(duty) ? duty : 0);
+  }
+
+  /**
+   * The Pi has no ADC. Said once per pin in the console and recorded as a
+   * gap for the circuit check, instead of the silent AVR fallback a shim
+   * without this method used to get. Returns false: nothing was set.
+   */
+  setAdcVoltage(pin: number, _voltage: number): boolean {
+    const why = `${this.boardKind.startsWith('raspberry-pi') ? 'the Raspberry Pi' : 'this board'} has no analog input; use an MCP3008 (SPI) or an ADS1115 (I2C)`;
+    recordPartGap({ sensorType: 'analog input', pin, why, code: 'no-adc' });
+    if (!this.adcWarned.has(pin)) {
+      this.adcWarned.add(pin);
+      console.warn(`[pi] analog input on GPIO ${pin}: ${why}`);
+    }
+    return false;
+  }
+
+  // ── Line-owning sensors / addressable pixels: declared refusals ────────
+  /** The overlay may register a declaration per kind (a board that serves
+   *  DHT22 / HC-SR04 as hosted values); the default is a refusal with the
+   *  reason, so the part hears it and the circuit check shows it. */
+  lineSupport(): LineSupport {
+    return getBoardLineSupport(this.boardKind) ?? { mode: 'none', why: LINE_SUPPORT_NONE_WHY };
+  }
+  pixelSupport(): { mode: 'none'; why: string } {
+    return { mode: 'none', why: PIXEL_SUPPORT_NONE_WHY };
+  }
+
+  // ── Header UART (a wired peer board's TX) ──────────────────────────────
+  /** Raw bytes into the guest's header UART RX, by engine. */
+  sendSerialBytes(bytes: number[], _uart = 0): void {
+    if (!bytes.length) return;
+    if (this.boardState()?.engineMode === 'instant') {
+      this.instantAdapter?.onUartRx?.(bytes);
+      return;
+    }
+    (this.bridge as Partial<RaspberryPi3Bridge>).sendUartBytes?.(bytes);
+  }
+  /** Text counterpart, the uniform `sim.feedUart(uart, data)` seam. */
+  feedUart(uart: number, data: string): boolean {
+    this.sendSerialBytes(Array.from(new TextEncoder().encode(data)), uart);
+    return true;
+  }
+
+  // ── I2C: the header bus, shared by the parts and both engines ──────────
+  // No `registerSensor` and no `addI2CTransactionListener` on purpose: the
+  // parts then take their `addI2CDevice` branch (the AVR / RP2040 path), so
+  // every device lives on this one I2CBusManager and nobody feeds it twice.
+  getI2CBus(_bus: 0 | 1 = 0): I2CBusManager {
+    return this.i2cBusInstance;
+  }
+  addI2CDevice(device: I2CDevice, _bus: 0 | 1 = 0): void {
+    this.i2cBusInstance.addDevice(device);
+  }
+  removeI2CDevice(addr: number, _bus: 0 | 1 = 0): void {
+    this.i2cBusInstance.removeDevice(addr);
+  }
+
+  /**
+   * One I2C transaction as a master would run it: address for write, send
+   * `write`, and when `readLen` > 0 re-address for read WITHOUT a stop in
+   * between (a repeated start: the device keeps its register pointer), read,
+   * then stop. Null when nobody acknowledges the address (a NAK), which is
+   * what the guest turns into errno 121. Only the header bus has devices;
+   * any other bus number is empty.
+   */
+  i2cTransfer(addr: number, write: readonly number[], readLen: number, bus = HEADER_I2C_BUS): number[] | null {
+    if (bus !== HEADER_I2C_BUS) return null;
+    const i2c = this.i2cBusInstance;
+    if (write.length > 0 || readLen === 0) {
+      if (!i2c.handleExternalConnect(addr, true)) return null;
+      for (const b of write) i2c.handleExternalWrite(b);
+    }
+    const out: number[] = [];
+    if (readLen > 0) {
+      if (!i2c.handleExternalConnect(addr, false)) {
+        i2c.handleExternalStop();
+        return null;
+      }
+      for (let i = 0; i < readLen; i++) out.push(i2c.handleExternalRead() & 0xff);
+    }
+    i2c.handleExternalStop();
+    return out;
+  }
+
+  // ── SPI: the AVR adapter shape AND the RP2040 handler shape ────────────
+  // Parts hook whichever they know; a transfer feeds both and ANDs the MISO
+  // bytes (an idle line reads high, so a silent side contributes 0xff).
+  get spi(): PiSpiAdapter {
+    if (!this._spiAdapter) {
+      this._spiAdapter = { onByte: null, completeTransfer: (_miso: number) => {} };
+    }
+    return this._spiAdapter;
+  }
+  setSPIHandler(bus: 0 | 1, handler: (value: number) => number): void {
+    this.spiHandlers.set(bus, handler);
+  }
+
+  /**
+   * Clock `mosi` out on `bus` with chip-select `cs` low, return MISO.
+   * `holdCs` keeps the select asserted after the last byte (a multi-call
+   * transaction); the next transfer on another select, or without the hold,
+   * releases it.
+   */
+  spiTransfer(bus: number, cs: number, mosi: readonly number[], holdCs = false): number[] {
+    const cePin = SPI_CE_PINS[bus]?.[cs];
+    const held = this.heldCs && this.heldCs.bus === bus && this.heldCs.cs === cs;
+    if (!held) {
+      this.releaseHeldCs();
+      if (cePin !== undefined) this.pinManager.triggerPinChange(cePin, false, 'mcu');
+    }
+    const adapter = this.spi;
+    const handler = this.spiHandlers.get(bus);
+    const out: number[] = [];
+    for (const byte of mosi) {
+      let fromAdapter = 0xff;
+      adapter.completeTransfer = (miso: number) => {
+        fromAdapter = miso & 0xff;
+      };
+      adapter.onByte?.(byte & 0xff);
+      const fromHandler = handler ? handler(byte & 0xff) & 0xff : 0xff;
+      out.push(fromAdapter & fromHandler);
+    }
+    adapter.completeTransfer = (_miso: number) => {};
+    if (holdCs) {
+      this.heldCs = { bus, cs };
+    } else {
+      this.heldCs = null;
+      if (cePin !== undefined) this.pinManager.triggerPinChange(cePin, true, 'mcu');
+    }
+    return out;
+  }
+
+  private releaseHeldCs(): void {
+    if (!this.heldCs) return;
+    const cePin = SPI_CE_PINS[this.heldCs.bus]?.[this.heldCs.cs];
+    this.heldCs = null;
+    if (cePin !== undefined) this.pinManager.triggerPinChange(cePin, true, 'mcu');
+  }
+
+  // ── 1-Wire: one byte master per pin, registered by the part that models it ─
+  attachOneWireMaster(pin: number, master: OneWireByteMaster): void {
+    this.oneWireMasters.set(pin, master);
+  }
+  detachOneWireMaster(pin: number): void {
+    this.oneWireMasters.delete(pin);
+  }
+
+  /**
+   * One 1-Wire operation on `pin`; `op` is the request's tokens after the
+   * pin. The composites (LIST, SP, RES) are what a w1 kernel driver does for
+   * `w1_slave`: match the ROM, read or write the scratchpad, check the CRC.
+   * Returns the reply line, or null when the op is unknown.
+   */
+  w1Op(pin: number, op: readonly string[]): string | null {
+    const master = this.oneWireMasters.get(pin);
+    if (!master) return `W1_ERR ${pin} no-master`;
+    const [kind, a, b] = op;
+    switch (kind) {
+      case 'LIST':
+        return `W1_LIST ${pin} ${master.roms().join(',')}`;
+      case 'SP': {
+        const rom = fromHex(a);
+        if (!rom || rom.length !== 8) return null;
+        if (!master.reset()) return `W1_ERR ${pin} no-presence`;
+        master.writeByte(0x55); // MATCH ROM
+        master.writeBlock(rom);
+        master.writeByte(0xbe); // READ SCRATCHPAD
+        const sp = master.readBlock(9);
+        const ok = crc8(sp.slice(0, 8)) === (sp[8] & 0xff) ? 1 : 0;
+        return `W1_SLAVE ${pin} ${a} ${toHex(sp)} ${ok}`;
+      }
+      case 'RES': {
+        const rom = fromHex(a);
+        const bits = parseCount(b);
+        if (!rom || rom.length !== 8 || bits === null || bits < 9 || bits > 12) return null;
+        if (!master.reset()) return `W1_ERR ${pin} no-presence`;
+        master.writeByte(0x55);
+        master.writeBlock(rom);
+        master.writeByte(0xbe);
+        const sp = master.readBlock(9);
+        if (!master.reset()) return `W1_ERR ${pin} no-presence`;
+        master.writeByte(0x55);
+        master.writeBlock(rom);
+        master.writeByte(0x4e); // WRITE SCRATCHPAD: TH, TL, config
+        master.writeBlock([sp[2], sp[3], (((bits - 9) & 3) << 5) | 0x1f]);
+        return `W1_DATA ${pin} ok`;
+      }
+      case 'RESET':
+        return `W1_DATA ${pin} ${master.reset() ? 1 : 0}`;
+      case 'RB':
+        return `W1_DATA ${pin} ${toHex([master.readByte()])}`;
+      case 'WB': {
+        const bytes = fromHex(a);
+        if (!bytes || bytes.length !== 1) return null;
+        master.writeByte(bytes[0]);
+        return `W1_DATA ${pin} ok`;
+      }
+      case 'RBLK': {
+        const n = parseCount(a);
+        if (n === null) return null;
+        return `W1_DATA ${pin} ${toHex(master.readBlock(n))}`;
+      }
+      case 'WBLK': {
+        const bytes = fromHex(a);
+        if (!bytes) return null;
+        master.writeBlock(bytes);
+        return `W1_DATA ${pin} ok`;
+      }
+      case 'TRIPLET': {
+        const d = a === '1' ? 1 : a === '0' ? 0 : null;
+        if (d === null) return null;
+        const [id, cmp, dir] = master.triplet(d);
+        return `W1_DATA ${pin} ${id}${cmp}${dir}`;
+      }
+      default:
+        return null;
+    }
+  }
+
+  // ── The request grammar, answered over the objects above ───────────────
+  /**
+   * Answer one guest request line. Returns the reply line, null for lines
+   * that carry no answer (PWM, GPIO_SETUP, SPI CONFIG) and for lines the
+   * grammar does not know. The Linux relay and the in-browser engine both
+   * call this, so a sensor answers the same in either mode.
+   */
+  answerBusLine(line: string): string | null {
+    const parts = line.trim().split(/\s+/);
+    switch (parts[0]) {
+      case 'I2C':
+        return this.answerI2C(parts);
+      case 'SPI':
+        return this.answerSPI(parts);
+      case 'W1': {
+        const pin = parseCount(parts[1]);
+        if (pin === null) return null;
+        return this.w1Op(pin, parts.slice(2));
+      }
+      case 'PWM': {
+        // PWM <ch> <period_ns> <duty_ns> <en>: the sysfs pwmchip contract.
+        const ch = parseCount(parts[1]);
+        const period = Number(parts[2]);
+        const duty = Number(parts[3]);
+        const pin = ch === null ? undefined : PWM_CHANNEL_PINS[ch];
+        if (pin === undefined || !(period > 0) || !(duty >= 0)) return null;
+        const enabled = parts[4] === '1';
+        this.applyPwm(pin, 1e9 / period, enabled ? (100 * duty) / period : 0);
+        return null;
+      }
+      case 'PWM_START':
+      case 'PWM_CHANGE': {
+        const pin = parseCount(parts[1]);
+        const hz = Number(parts[2]);
+        const duty = Number(parts[3]);
+        if (pin === null || !Number.isFinite(hz) || !Number.isFinite(duty)) return null;
+        this.applyPwm(pin, hz, duty);
+        return null;
+      }
+      case 'PWM_STOP': {
+        const pin = parseCount(parts[1]);
+        if (pin !== null) this.applyPwm(pin, 0, 0);
+        return null;
+      }
+      case 'GPIO_SETUP': {
+        const pin = parseCount(parts[1]);
+        if (pin === null) return null;
+        const pull = parts[3] === 'pud_up' ? 1 : parts[3] === 'pud_down' ? 2 : 0;
+        this.setPinPull(pin, pull);
+        return null;
+      }
+      default:
+        return null;
+    }
+  }
+
+  private answerI2C(parts: string[]): string | null {
+    const bus = parseCount(parts[1]);
+    const addr = parts[2] !== undefined && /^[0-9a-fA-F]{1,2}$/.test(parts[2]) ? parseInt(parts[2], 16) : null;
+    if (bus === null || addr === null) return null;
+    const op = parts[3];
+    let write: number[] | null = [];
+    let readLen: number | null = 0;
+    switch (op) {
+      case 'R':
+        readLen = parseCount(parts[4]);
+        break;
+      case 'W':
+        write = fromHex(parts[4]);
+        break;
+      case 'RR': {
+        const reg = fromHex(parts[4]);
+        write = reg && reg.length === 1 ? reg : null;
+        readLen = parseCount(parts[5]);
+        break;
+      }
+      case 'WR': {
+        const reg = fromHex(parts[4]);
+        const data = fromHex(parts[5]);
+        write = reg && reg.length === 1 && data ? [...reg, ...data] : null;
+        break;
+      }
+      case 'T':
+        write = fromHex(parts[4]);
+        readLen = parseCount(parts[5]);
+        break;
+      default:
+        return null;
+    }
+    if (write === null || readLen === null) return null;
+    const addrHex = addr.toString(16).padStart(2, '0');
+    const data = this.i2cTransfer(addr, write, readLen, bus);
+    if (data === null) return `I2C_ERR ${bus} ${addrHex} nack`;
+    return data.length ? `I2C_DATA ${bus} ${addrHex} ${toHex(data)}` : `I2C_DATA ${bus} ${addrHex}`;
+  }
+
+  private answerSPI(parts: string[]): string | null {
+    const bus = parseCount(parts[1]);
+    const cs = parseCount(parts[2]);
+    if (bus === null || cs === null) return null;
+    const op = parts[3];
+    if (op === 'CONFIG') return null;
+    if (op !== 'X' && op !== 'XC') return null;
+    const mosi = fromHex(parts[4]);
+    if (mosi === null) return null;
+    const miso = this.spiTransfer(bus, cs, mosi, op === 'XC');
+    return `SPI_DATA ${bus} ${cs} ${toHex(miso)}`;
+  }
+}

--- a/frontend/src/simulation/PiBridgeShim.ts
+++ b/frontend/src/simulation/PiBridgeShim.ts
@@ -56,7 +56,7 @@
 
 import { I2CBusManager, nullI2CMaster, type I2CDevice } from './I2CBusManager';
 import type { PinManager } from './PinManager';
-import type { RaspberryPi3Bridge } from './RaspberryPi3Bridge';
+import type { RaspberryPi3Bridge, PiBusTopology } from './RaspberryPi3Bridge';
 import type { LineSupport } from './line/LineHost';
 import { recordPartGap } from './line/requestLine';
 import { requestElectricalResolve } from './spice/electricalResolveHook';
@@ -165,6 +165,10 @@ export class PiBridgeShim {
   private heldCs: { bus: number; cs: number } | null = null;
   private readonly oneWireMasters = new Map<number, OneWireByteMaster>();
   private readonly adcWarned = new Set<number>();
+  /** Bus-map sync with a relaying backend (see startBusSync). */
+  private busTimer: ReturnType<typeof setInterval> | null = null;
+  private busMapKey = '';
+  private readonly lastRegs = new Map<number, string>();
 
   constructor(opts: PiBridgeShimOptions) {
     this.boardId = opts.boardId;
@@ -177,9 +181,81 @@ export class PiBridgeShim {
 
   // ── Lifecycle (the store drives the guest through the bridge / engine) ──
   start(): void {}
-  /** Nothing to halt here; a chip-select held by an unfinished transfer is released. */
+  /** Nothing to halt here; a chip-select held by an unfinished transfer is
+   *  released and the bus-map sync with the backend stops. */
   stop(): void {
     this.releaseHeldCs();
+    this.stopBusSync();
+  }
+
+  // ── The bus map, for a backend that answers the guest from the canvas ──
+  /**
+   * What is on this board's buses, as the backend relay needs it: every I2C
+   * address with a device, and for each the 256 registers when the device
+   * can export them (a register file: BMP280, DS3231, ...). The backend
+   * answers an absent address with a NAK and a register-file read from its
+   * copy, both without asking this tab; only the rest travels here.
+   */
+  busTopology(): PiBusTopology {
+    const i2c = this.i2cBusInstance.listDevices().map((dev) => ({
+      bus: HEADER_I2C_BUS,
+      addr: dev.address & 0x7f,
+      regs: typeof dev.dumpRegisters === 'function' ? toHex(Array.from(dev.dumpRegisters())) : null,
+    }));
+    return { version: 1, i2c, spi: { attached: this.spiAttached() } };
+  }
+
+  /**
+   * The backend said it relays (`bus_relay`): publish the map, then keep it
+   * true. Every 250 ms (the ESP32 proxy's cadence) a changed set of devices
+   * republishes the whole map, and a register-file device whose registers
+   * changed pushes just its registers — compared byte for byte, because a
+   * sampled hash misses the measurement registers a slider moves.
+   */
+  startBusSync(): void {
+    this.stopBusSync();
+    this.publishBusTopology();
+    this.busTimer = setInterval(() => this.busTick(), 250);
+  }
+
+  stopBusSync(): void {
+    if (this.busTimer !== null) clearInterval(this.busTimer);
+    this.busTimer = null;
+    this.busMapKey = '';
+    this.lastRegs.clear();
+  }
+
+  private publishBusTopology(): void {
+    const topology = this.busTopology();
+    this.busMapKey = this.mapKeyOf(topology);
+    this.lastRegs.clear();
+    for (const dev of topology.i2c) if (dev.regs !== null) this.lastRegs.set(dev.addr, dev.regs);
+    (this.bridge as Partial<RaspberryPi3Bridge>).sendBusTopology?.(topology);
+  }
+
+  private busTick(): void {
+    const topology = this.busTopology();
+    if (this.mapKeyOf(topology) !== this.busMapKey) {
+      this.publishBusTopology();
+      return;
+    }
+    const bridge = this.bridge as Partial<RaspberryPi3Bridge>;
+    for (const dev of topology.i2c) {
+      if (dev.regs === null || this.lastRegs.get(dev.addr) === dev.regs) continue;
+      this.lastRegs.set(dev.addr, dev.regs);
+      bridge.sendBusRegs?.(dev.bus, dev.addr, dev.regs);
+    }
+  }
+
+  /** Which devices are where (not their register contents). */
+  private mapKeyOf(topology: PiBusTopology): string {
+    const i2c = topology.i2c.map((d) => `${d.bus}:${d.addr}:${d.regs === null ? 'ask' : 'regs'}`).sort();
+    return `${i2c.join(',')}|spi:${topology.spi.attached ? 1 : 0}`;
+  }
+
+  /** A part listens on the SPI bus in either shape parts use. */
+  private spiAttached(): boolean {
+    return !!this._spiAdapter?.onByte || this.spiHandlers.size > 0;
   }
   reset(): void {}
   setSpeed(_s: number): void {}

--- a/frontend/src/simulation/RaspberryPi3Bridge.ts
+++ b/frontend/src/simulation/RaspberryPi3Bridge.ts
@@ -39,6 +39,18 @@
 
 import { getTabSessionId } from './Esp32Bridge';
 
+/**
+ * What the board publishes to the backend about its bus (`pi_bus_topology`).
+ * `regs` is the device's 256 registers as hex when it can export them (the
+ * backend then answers reads from that copy with no round trip), null when
+ * the device has to be asked each time.
+ */
+export interface PiBusTopology {
+  version: 1;
+  i2c: Array<{ bus: number; addr: number; regs: string | null }>;
+  spi: { attached: boolean };
+}
+
 const API_BASE = (): string => {
   // The desktop shell injects the sidecar URL at runtime (random port) via
   // window.__VELXIO_API_BASE__; honor it first so the QEMU-board WebSocket
@@ -72,6 +84,10 @@ export class RaspberryPi3Bridge {
    * the reply line, or null when there is nothing to say; either way a
    * `pi_bus_reply` with the same `rid` goes back. */
   onBusRequest: ((rid: number, line: string) => string | null) | null = null;
+  /** The backend announced (`system` event `bus_relay`) that it answers the
+   * guest's bus from the canvas: publish the bus map now. Its own slot so it
+   * never competes with whoever owns onSystemEvent. */
+  onBusRelay: ((version: number) => void) | null = null;
   onConnected: (() => void) | null = null;
   onDisconnected: (() => void) | null = null;
   /** Backend refused or lost the session. `code` is the server's
@@ -211,10 +227,18 @@ export class RaspberryPi3Bridge {
             // answer nothing, say why here.
             console.warn(`[${this.boardId}] bus request failed: ${line}`, e);
           }
-          this._send({ type: 'pi_bus_reply', data: { rid, line: reply } });
+          // A write the guest did not wait for (a display frame, a config
+          // register) is applied and not answered: the backend holds no
+          // request open for it.
+          if (msg.data.noreply !== true) {
+            this._send({ type: 'pi_bus_reply', data: { rid, line: reply } });
+          }
           break;
         }
         case 'system':
+          if (msg.data.event === 'bus_relay') {
+            this.onBusRelay?.(Number(msg.data.version) || 1);
+          }
           this.onSystemEvent?.(msg.data.event as string, msg.data);
           break;
         case 'display':
@@ -418,6 +442,17 @@ export class RaspberryPi3Bridge {
     cs?: number;
   }): void {
     this._send({ type: 'pi_detach_slave', data: spec });
+  }
+
+  /** The I2C / SPI parts wired to this board, for the backend relay to
+   * answer the guest from (`pi_bus_topology`). */
+  sendBusTopology(topology: PiBusTopology): void {
+    this._send({ type: 'pi_bus_topology', data: topology });
+  }
+
+  /** A register-file device's registers changed (`pi_bus_regs`). */
+  sendBusRegs(bus: number, address: number, regsHex: string): void {
+    this._send({ type: 'pi_bus_regs', data: { bus, addr: address, regs: regsHex } });
   }
 
   private _send(payload: unknown): void {

--- a/frontend/src/simulation/RaspberryPi3Bridge.ts
+++ b/frontend/src/simulation/RaspberryPi3Bridge.ts
@@ -19,12 +19,22 @@
  *         config?:  Record<string, unknown>,
  *     }}
  *     { type: 'pi_detach_slave', data: { bus_kind, bus_num, address?|cs? } }
+ *     { type: 'pi_bus_reply',  data: { rid: number, line: string | null } }
  *
  *   Backend → Frontend
  *     { type: 'serial_output', data: { data: string } }
  *     { type: 'gpio_change',   data: { pin: number, state: 0 | 1 } }
+ *     { type: 'gpio_setup',    data: { pin: number, direction: 'in'|'out', pull: 'pud_up'|'pud_down'|'pud_off' } }
+ *     { type: 'pi_bus_request', data: { rid: number, line: string } }
  *     { type: 'system',        data: { event: string, ... } }
  *     { type: 'error',         data: { message: string } }
+ *
+ * `pi_bus_request` / `pi_bus_reply` carry one bus operation each (an I2C
+ * transaction, an SPI transfer, a 1-Wire op) as a request line the guest's
+ * shim libraries wrote; the board's simulator shim answers it against the
+ * device models on the canvas (see simulation/PiBridgeShim). A request the
+ * frontend cannot answer is replied with `line: null` so the backend never
+ * waits on it.
  */
 
 import { getTabSessionId } from './Esp32Bridge';
@@ -54,6 +64,14 @@ export class RaspberryPi3Bridge {
   // Callbacks wired up by useSimulatorStore
   onSerialData: ((char: string) => void) | null = null;
   onPinChange: ((gpioPin: number, state: boolean) => void) | null = null;
+  /** The guest programmed a pin's internal pull (from its GPIO_SETUP):
+   * 0 = none, 1 = pull-up, 2 = pull-down. Wired to the store's pull handler
+   * so the netlist stamps the resistor and the pin rests at its level. */
+  onPinPull: ((gpioPin: number, pull: 0 | 1 | 2) => void) | null = null;
+  /** One bus operation the guest is waiting on (`pi_bus_request`). Return
+   * the reply line, or null when there is nothing to say; either way a
+   * `pi_bus_reply` with the same `rid` goes back. */
+  onBusRequest: ((rid: number, line: string) => string | null) | null = null;
   onConnected: (() => void) | null = null;
   onDisconnected: (() => void) | null = null;
   /** Backend refused or lost the session. `code` is the server's
@@ -173,6 +191,27 @@ export class RaspberryPi3Bridge {
           const pin = msg.data.pin as number;
           const state = (msg.data.state as number) === 1;
           this.onPinChange?.(pin, state);
+          break;
+        }
+        case 'gpio_setup': {
+          const pin = msg.data.pin as number;
+          const pull = msg.data.pull === 'pud_up' ? 1 : msg.data.pull === 'pud_down' ? 2 : 0;
+          if (typeof pin === 'number') this.onPinPull?.(pin, pull);
+          break;
+        }
+        case 'pi_bus_request': {
+          const rid = msg.data.rid as number;
+          const line = msg.data.line;
+          if (typeof rid !== 'number' || typeof line !== 'string') break;
+          let reply: string | null = null;
+          try {
+            reply = this.onBusRequest?.(rid, line) ?? null;
+          } catch (e) {
+            // A model that throws must not hang the guest on its timeout:
+            // answer nothing, say why here.
+            console.warn(`[${this.boardId}] bus request failed: ${line}`, e);
+          }
+          this._send({ type: 'pi_bus_reply', data: { rid, line: reply } });
           break;
         }
         case 'system':

--- a/frontend/src/simulation/line/requestLine.ts
+++ b/frontend/src/simulation/line/requestLine.ts
@@ -52,6 +52,13 @@ export interface LineGap {
   why: string;
   /** The canvas component that asked, when it said so — for the circuit check to point at it. */
   componentId?: string;
+  /**
+   * What kind of refusal this is, for the circuit check's wording. Absent for
+   * a line-owning sensor the board cannot host; `no-adc` for an analog part
+   * on a board with no analog input, where "will not answer" is the wrong
+   * sentence — the fix is a converter chip, not a different board.
+   */
+  code?: string;
 }
 
 export interface LineRequestOptions {

--- a/frontend/src/simulation/oneWireHost.ts
+++ b/frontend/src/simulation/oneWireHost.ts
@@ -1,0 +1,35 @@
+/**
+ * oneWireHost — the byte-level 1-Wire master a board simulator lets a part
+ * register on one of its pins.
+ *
+ * Why a type of its own: a Linux guest reads its 1-Wire sensors through the
+ * kernel's w1 bus (`/sys/bus/w1/devices/28-<id>/w1_slave`), and an in-browser
+ * Python engine reads them through the same file names. Neither side can
+ * bit-bang the line in real time, so the board answers *bus operations*
+ * (reset, a byte, a block, a search triplet) rather than edges, and whoever
+ * models the sensor implements this interface over its own state. The board
+ * shim owns the pin -> master table and the request grammar
+ * (`W1 <pin> RESET | RB | WB <hex> | RBLK <n> | WBLK <hex> | TRIPLET <d>`);
+ * the part owns the protocol. A DS18B20 model is one implementation; nothing
+ * here knows its name.
+ */
+
+export interface OneWireByteMaster {
+  /** Reset pulse. True when at least one slave answered with presence. */
+  reset(): boolean;
+  /** One bit slot: write `bit` (1 = release), return what the line read. */
+  touchBit(bit: 0 | 1): 0 | 1;
+  readBit(): 0 | 1;
+  writeBit(bit: 0 | 1): void;
+  readByte(): number;
+  writeByte(value: number): void;
+  readBlock(length: number): number[];
+  writeBlock(bytes: number[]): void;
+  /**
+   * One ROM-search step: read the id bit and its complement, then write the
+   * direction taken. Returns [idBit, cmpBit, directionWritten].
+   */
+  triplet(direction: 0 | 1): [0 | 1, 0 | 1, 0 | 1];
+  /** ROM ids of every slave on the line, as 16-char lowercase hex. */
+  roms(): string[];
+}

--- a/frontend/src/simulation/parts/ProtocolParts.ts
+++ b/frontend/src/simulation/parts/ProtocolParts.ts
@@ -535,6 +535,17 @@ class VirtualMPU6050 implements I2CDevice {
   stop(): void {
     this.firstByte = true;
   }
+
+  /**
+   * The 256 registers as they stand. The MPU-6050 is a plain register file
+   * (pointer write, auto-incrementing reads, no clear-on-read), so a copy
+   * answers reads exactly like the chip: a board whose firmware runs
+   * elsewhere (the ESP32 QEMU proxy, the Raspberry Pi guest's bus relay)
+   * reads it from that copy instead of a round trip per transaction.
+   */
+  dumpRegisters(): Uint8Array {
+    return this.registers.slice();
+  }
 }
 
 PartSimulationRegistry.register('mpu6050', {

--- a/frontend/src/simulation/verify/circuitVerifier.ts
+++ b/frontend/src/simulation/verify/circuitVerifier.ts
@@ -130,7 +130,13 @@ export async function verifyCircuit(
       severity: 'warning',
       code: 'unsupported-sensor',
       componentId: gap.componentId,
-      message: `${gap.sensorType} on GPIO ${gap.pin} will not answer here: ${gap.why}`,
+      // A board with no analog input refuses a pot or a joystick the same
+      // way, but "will not answer" is the wrong sentence for it: the part is
+      // fine, the pin cannot measure. Its `why` already names the converter.
+      message:
+        gap.code === 'no-adc'
+          ? `${gap.sensorType} on GPIO ${gap.pin}: ${gap.why}`
+          : `${gap.sensorType} on GPIO ${gap.pin} will not answer here: ${gap.why}`,
     });
   }
 

--- a/frontend/src/store/useSimulatorStore.ts
+++ b/frontend/src/store/useSimulatorStore.ts
@@ -1815,6 +1815,21 @@ export const useSimulatorStore = create<SimulatorState>((set, get) => {
         bridge.onGpioPwm = (pin, frequency, dutyCycle, event) =>
           shim.applyPwm(pin, frequency, event === 'stop' ? 0 : dutyCycle);
         bridge.onBusRequest = (_rid, line) => shim.answerBusLine(line);
+        // A backend that answers the guest's bus from the canvas announces
+        // it once per guest; the shim then publishes the bus map and keeps
+        // it true, and the board says so (a part that used to be handed to
+        // the guest can stay in the tab).
+        bridge.onBusRelay = () => {
+          shim.startBusSync();
+          set((s) => ({
+            boards: s.boards.map((b) => (b.id === id ? { ...b, busRelay: true } : b)),
+          }));
+        };
+        const disconnected = bridge.onDisconnected;
+        bridge.onDisconnected = () => {
+          shim.stopBusSync();
+          disconnected?.();
+        };
         // The UART routes were built at page load, when this bridge did
         // not exist — re-attempt the TX hook now that it does, or the
         // guest's header-UART bytes never reach the canvas wire.

--- a/frontend/src/store/useSimulatorStore.ts
+++ b/frontend/src/store/useSimulatorStore.ts
@@ -750,20 +750,20 @@ export class Esp32BridgeShim {
   }
 
   /**
-   * Cheap XOR-stride hash over a 256-byte buffer.  Detects any byte
-   * difference; collisions are theoretically possible but we don't
-   * care — a missed update on a flaky hash just delays freshness by
-   * one cycle.
+   * FNV-1a over EVERY byte of a register dump. The previous hash sampled one
+   * byte in sixteen plus the first eight, so a change anywhere else — the
+   * BMP280 measurement registers at 0xF7-0xFC, an MPU-6050 axis the slider
+   * moved — left the hash equal and the proxy never refreshed: the ESP32 read
+   * a stale value for as long as the run lasted. 256 bytes every 250 ms per
+   * proxied device costs nothing.
    */
-  private static _hashRegs(regs: Uint8Array): number {
-    let h = regs.length & 0xff;
-    for (let i = 0; i < regs.length; i += 16) {
-      h = ((h << 5) - h + regs[i]) | 0;
+  static _hashRegs(regs: Uint8Array): number {
+    let h = 0x811c9dc5;
+    for (let i = 0; i < regs.length; i++) {
+      h ^= regs[i];
+      h = Math.imul(h, 0x01000193);
     }
-    for (let i = 0; i < Math.min(regs.length, 8); i++) {
-      h = ((h << 5) - h + regs[i]) | 0;
-    }
-    return h;
+    return h >>> 0;
   }
 
   private _resyncTick(): void {

--- a/frontend/src/store/useSimulatorStore.ts
+++ b/frontend/src/store/useSimulatorStore.ts
@@ -34,6 +34,7 @@ import { getSerialTxInterceptor } from '../lib/proHardwareSerial';
 import { calculatePinPosition } from '../utils/pinPositionCalculator';
 import { useOscilloscopeStore } from './useOscilloscopeStore';
 import { RaspberryPi3Bridge } from '../simulation/RaspberryPi3Bridge';
+import { PiBridgeShim } from '../simulation/PiBridgeShim';
 import { Esp32Bridge } from '../simulation/Esp32Bridge';
 import type { Ws2812Pixel } from '../simulation/Esp32Bridge';
 import { createEsp32Bridge } from '../simulation/Esp32BridgeFactory';
@@ -1025,7 +1026,13 @@ class Stm32BridgeShim {
 // ── Runtime Maps (outside Zustand — not serialisable) ─────────────────────
 const simulatorMap = new Map<
   string,
-  AVRSimulator | RP2040Simulator | RiscVSimulator | Esp32C3Simulator | Esp32BridgeShim | Stm32BridgeShim
+  | AVRSimulator
+  | RP2040Simulator
+  | RiscVSimulator
+  | Esp32C3Simulator
+  | Esp32BridgeShim
+  | Stm32BridgeShim
+  | PiBridgeShim
 >();
 const pinManagerMap = new Map<string, PinManager>();
 // Per-board ESP32 GPIO Matrix mirror.  Populated for boards whose kind
@@ -1053,10 +1060,8 @@ export async function piSyncAndRunScript(boardId: string, boardKind: string): Pr
   const home = (proDef?.guestHome ?? '/home/pi').replace(/\/+$/, '');
   const board = useSimulatorStore.getState().boards.find((b) => b.id === boardId);
   const groupId = board?.activeFileGroupId ?? `group-${boardId}`;
-  const files = useEditorStore
-    .getState()
-    .getGroupFiles(groupId)
-    .map((f) => ({ path: `${home}/${f.name}`, content: f.content }));
+  const groupFiles = useEditorStore.getState().getGroupFiles(groupId);
+  const files = groupFiles.map((f) => ({ path: `${home}/${f.name}`, content: f.content }));
   try {
     const { uploadFilesToPi } = await import('../utils/piUpload');
     await uploadFilesToPi(bridge, files);
@@ -1065,8 +1070,20 @@ export async function piSyncAndRunScript(boardId: string, boardKind: string): Pr
     // the user's first visible output is their own program.
     bridge.setQuiet(false);
   }
-  const cmd = proDef?.autoRun ?? `python3 ${home}/script.py`;
+  const cmd = proDef?.autoRun ?? `python3 ${home}/${piMainScript(groupFiles)}`;
   bridge.sendSerialText(cmd.endsWith('\n') ? cmd : cmd + '\n');
+}
+
+/** The file the guest runs: `script.py` when the group has one, else the
+ * first `.py` — the same rule the in-browser engine applies, so a project
+ * whose only script is `main.py` starts in either mode instead of the guest
+ * printing "No such file" for a name the user never typed. */
+export function piMainScript(files: readonly { name: string }[]): string {
+  return (
+    files.find((f) => f.name === 'script.py')?.name ??
+    files.find((f) => f.name.endsWith('.py'))?.name ??
+    'script.py'
+  );
 }
 
 /** Re-run on a BOOTED QEMU-Linux board without rebooting: interrupt the
@@ -1239,6 +1256,8 @@ interface SimulatorState {
     | RiscVSimulator
     | Esp32C3Simulator
     | Esp32BridgeShim
+    | Stm32BridgeShim
+    | PiBridgeShim
     | null;
   /** @deprecated use getBoardPinManager(activeBoardId) */
   pinManager: PinManager;
@@ -1778,6 +1797,24 @@ export const useSimulatorStore = create<SimulatorState>((set, get) => {
           });
         };
         bridgeMap.set(id, bridge);
+        // The simulator-shaped object the parts attach to (I2C devices, SPI
+        // panels, PWM consumers, the ADC refusal). Both engines route their
+        // bus requests through it, so a sensor answers the same in either.
+        const shim = new PiBridgeShim({
+          boardId: id,
+          boardKind,
+          bridge,
+          pinManager: pm,
+          boardState: () => get().boards.find((b) => b.id === id),
+        });
+        simulatorMap.set(id, shim);
+        // The guest's pulls reach the netlist and rest the pin, like every
+        // MCU board; its PWM reaches the servo / dimmed LED listeners; its
+        // bus operations reach the device models on the canvas.
+        bridge.onPinPull = makePinPullHandler(id);
+        bridge.onGpioPwm = (pin, frequency, dutyCycle, event) =>
+          shim.applyPwm(pin, frequency, event === 'stop' ? 0 : dutyCycle);
+        bridge.onBusRequest = (_rid, line) => shim.answerBusLine(line);
         // The UART routes were built at page load, when this bridge did
         // not exist — re-attempt the TX hook now that it does, or the
         // guest's header-UART bytes never reach the canvas wire.
@@ -2840,6 +2877,9 @@ export const useSimulatorStore = create<SimulatorState>((set, get) => {
       if (isPiBoardKind(board.boardKind)) {
         if (board.engineMode === 'instant') getInstantEngine()?.stop(boardId);
         else getBoardBridge(boardId)?.disconnect();
+        // The shim holds no process, but it may hold a chip-select from an
+        // unfinished transfer.
+        getBoardSimulator(boardId)?.stop();
       } else if (isEsp32Kind(board.boardKind)) {
         getEsp32Bridge(boardId)?.disconnect();
       } else if (isStm32BoardKind(board.boardKind)) {

--- a/frontend/src/types/board.ts
+++ b/frontend/src/types/board.ts
@@ -138,6 +138,11 @@ export interface BoardInstance {
    *  mode chip or by turning on the Linux terminal; wins over the detector
    *  so a project doesn't silently change behaviour between runs. */
   enginePinned?: 'instant' | 'linux';
+  /** QEMU-Linux boards only. The backend running this board's guest answers
+   *  the guest's I2C / SPI requests from the parts on the canvas (it said so
+   *  with a `bus_relay` system event). Until then a part that needs the
+   *  guest to reach it has to be handed to the backend some other way. */
+  busRelay?: boolean;
   compiledProgram: string | null; // hex for AVR/RP2040, null for Pi (runs Python)
   /**
    * Fingerprint of the sources (+ build options) `compiledProgram` was built

--- a/scripts/generate-component-metadata.ts
+++ b/scripts/generate-component-metadata.ts
@@ -271,6 +271,14 @@ class MetadataGenerator {
       if (Array.isArray(ov.tags)) {
         comp.tags = ov.tags;
       }
+      // The pin count is read from the element's `pinInfo` getter by a regex
+      // over its source. An element whose getter builds the array some other
+      // way scans as 0 pins, and the only fix used to be editing the generated
+      // JSON by hand — which the CI staleness check then rejects on every run
+      // (ir-receiver, 2026-09). Declare it here instead.
+      if (typeof ov.pinCount === 'number') {
+        comp.pinCount = ov.pinCount;
+      }
 
       applied++;
       console.log(`  🔧 Applied overrides for ${comp.id}`);


### PR DESCRIPTION
A Raspberry Pi board had no simulator object, so no part in the catalog could attach to it: an MPU6050, DS3231, SHT31 or SSD1306 wired to GPIO2/3 was drawn and never answered, in either engine. Measured on real user projects, every I2C, SPI and 1-Wire sensor on a Pi returned the script's own fallback values.

**1. `PiBridgeShim`** (`simulation/PiBridgeShim.ts`)
Gives the Pi the surface the STM32 and ESP32 shims give their boards, over the same `I2CBusManager` and `PinManager`. It answers one request grammar (I2C / SPI / W1 / PWM / GPIO_SETUP lines), so the in-browser Python engine and the Linux guest get the same answer from the same device model.
- I2C transactions are real ones: repeated start, and a NAK reported as `I2C_ERR nack`.
- PWM from the guest reaches the PinManager, so servos and dimmed LEDs react.
- Pulls programmed by the guest rest the pin.
- An analog part on a GPIO is refused with a `no-adc` gap that the circuit check prints ("use an MCP3008 or an ADS1115").
- `DynamicComponent`'s hand-rolled stub, which took precedence over the map, is gone.

**2. The bus map for a relaying backend**
When the backend announces `bus_relay`, the board publishes what is on its buses (`pi_bus_topology`):
- every I2C address, which lets the backend answer an absent address with a NAK locally;
- the 256 registers of each register-file device, which lets it answer those reads from a copy (the ESP32 ProxySlave pattern).

After that, every 250 ms, a device-set change republishes the map, and a device whose registers changed pushes only those (`pi_bus_regs`), compared byte for byte. Writes the guest does not wait for arrive as `noreply` requests. The board is marked `busRelay`.

**Also**
- The guest runs `script.py`, or else the first `.py` in the project. Before, a project whose only file was `main.py` booted a guest to print "No such file".
- `SimulatorCanvas` subscribes to the component registry, so parts whose metadata loads late are drawn without a click.
- The Pi marketing copy in 9 locales stops promising a full Raspberry Pi OS with I2C and SPI to the parts.
- The route forwards `pi_bus_reply`, `pi_bus_topology` and `pi_bus_regs`.

**Tests**
- `pi-bridge-shim.test.ts` and `pi-bus-relay-sync.test.ts` are new.
- `multi-board-integration` is updated: it asserted that a Pi has no simulator.
- tsc is clean. The full suite passes except failures that already fail on master or are environment-only (galaksija, code-formatters).

The backend relay and the guest-side shims live in the private deployment; they were verified end to end on a real QEMU guest.
