### PR TITLE
fix(pi): a guest bus line reaches the console as an argument, not a format string

### DIFF
--- a/frontend/src/simulation/RaspberryPi3Bridge.ts
+++ b/frontend/src/simulation/RaspberryPi3Bridge.ts
@@ -224,8 +224,10 @@ export class RaspberryPi3Bridge {
             reply = this.onBusRequest?.(rid, line) ?? null;
           } catch (e) {
             // A model that throws must not hang the guest on its timeout:
-            // answer nothing, say why here.
-            console.warn(`[${this.boardId}] bus request failed: ${line}`, e);
+            // answer nothing, say why here. The line comes from the guest,
+            // so it goes in as an argument, never as the format string, and
+            // quoted: a newline in it cannot forge a second log entry.
+            console.warn('[%s] bus request failed: %s', this.boardId, JSON.stringify(line.slice(0, 200)), e);
           }
           // A write the guest did not wait for (a display frame, a config
           // register) is applied and not answered: the backend holds no


### PR DESCRIPTION
Follow-up to #319. Closes CodeQL alerts #47 (js/tainted-format-string) and #48 (js/log-injection) at `RaspberryPi3Bridge.ts:228`.

The bus line a Linux guest sends went into `console.warn` through a template literal, so it became part of the format string. It is now a `%s` argument, JSON-quoted and capped at 200 characters: a `%` in it can no longer consume the error object, and a newline in it can no longer forge a second log entry.

One file, no behaviour change beyond the log text. `pi-bridge-shim` and `pi-bus-relay-sync` tests pass.