### PR TITLE
feat(verify): name the pin a Raspberry Pi's I2C or SPI part needs

### DIFF
--- a/frontend/src/__tests__/circuit-verifier-pi-bus.test.ts
+++ b/frontend/src/__tests__/circuit-verifier-pi-bus.test.ts
@@ -1,0 +1,92 @@
+/**
+ * The Raspberry Pi bus-pin check: a part on I2C or SPI wired to the wrong
+ * GPIO is named with the pin it needs, and nothing legitimate is flagged.
+ */
+import { describe, it, expect } from 'vitest';
+import { piBusPinWarnings } from '../simulation/verify/circuitVerifier';
+import type { BuildNetlistInput } from '../simulation/spice/types';
+
+function board(id: string, boardKind: string): BuildNetlistInput['boards'][number] {
+  return { id, boardKind, vcc: 3.3, pins: {}, groundPinNames: ['GND'], vccPinNames: ['3V3'] };
+}
+
+function wire(id: string, part: string, pin: string, boardId: string, boardPin: string): BuildNetlistInput['wires'][number] {
+  return { id, start: { componentId: part, pinName: pin }, end: { componentId: boardId, pinName: boardPin } };
+}
+
+function check(
+  boardKind: string,
+  parts: Array<{ id: string; metadataId: string }>,
+  wires: BuildNetlistInput['wires'],
+) {
+  return piBusPinWarnings({
+    boards: [board('pi', boardKind)],
+    components: parts.map((p) => ({ ...p, properties: {} })),
+    wires,
+  });
+}
+
+describe('piBusPinWarnings', () => {
+  it('an MPU6050 on GPIO2/GPIO3 (or header pins 3/5) is fine', () => {
+    expect(check('raspberry-pi-4', [{ id: 'mpu', metadataId: 'mpu6050' }], [
+      wire('a', 'mpu', 'SDA', 'pi', 'GPIO2'),
+      wire('b', 'mpu', 'SCL', 'pi', 'GPIO3'),
+    ])).toEqual([]);
+    expect(check('raspberry-pi-3', [{ id: 'mpu', metadataId: 'mpu6050' }], [
+      wire('a', 'mpu', 'SDA', 'pi', '3'),
+      wire('b', 'mpu', 'SCL', 'pi', '5'),
+    ])).toEqual([]);
+  });
+
+  it('SDA on GPIO17 is named, with the pin it needs', () => {
+    const w = check('raspberry-pi-4', [{ id: 'mpu', metadataId: 'mpu6050' }], [
+      wire('a', 'mpu', 'SDA', 'pi', 'GPIO17'),
+      wire('b', 'mpu', 'SCL', 'pi', 'GPIO3'),
+    ]);
+    expect(w).toHaveLength(1);
+    expect(w[0].code).toBe('bus-off-pins');
+    expect(w[0].componentId).toBe('mpu');
+    expect(w[0].message).toContain('GPIO17');
+    expect(w[0].message).toContain('GPIO2 (header pin 3)');
+  });
+
+  it('an SPI part with its clock off SCLK is named; its chip select never is', () => {
+    const w = check('raspberry-pi-5', [{ id: 'adc', metadataId: 'pro-mcp3008' }], [
+      wire('a', 'adc', 'CLK', 'pi', 'GPIO5'),
+      wire('b', 'adc', 'DOUT', 'pi', 'GPIO9'),
+      wire('c', 'adc', 'DIN', 'pi', 'GPIO10'),
+      wire('d', 'adc', 'CS', 'pi', 'GPIO22'),
+    ]);
+    expect(w.map((x) => x.message.split(' is on ')[0])).toEqual(['adc CLK']);
+    expect(w[0].message).toContain('GPIO11 (header pin 23)');
+  });
+
+  it('a clock with no SPI data pin is a bit-banged part: HX711, TM1637, encoder', () => {
+    expect(check('raspberry-pi-4', [
+      { id: 'load', metadataId: 'hx711' },
+      { id: 'disp', metadataId: 'tm1637-7segment' },
+      { id: 'enc', metadataId: 'ky-040' },
+    ], [
+      wire('a', 'load', 'SCK', 'pi', 'GPIO5'),
+      wire('b', 'load', 'DT', 'pi', 'GPIO6'),
+      wire('c', 'disp', 'CLK', 'pi', 'GPIO23'),
+      wire('d', 'disp', 'DIO', 'pi', 'GPIO24'),
+      wire('e', 'enc', 'CLK', 'pi', 'GPIO17'),
+      wire('f', 'enc', 'DT', 'pi', 'GPIO27'),
+    ])).toEqual([]);
+  });
+
+  it('never on another board family, the Pico, or a UNIHIKER', () => {
+    for (const kind of ['arduino-uno', 'esp32', 'raspberry-pi-pico', 'unihiker-m10']) {
+      expect(check(kind, [{ id: 'mpu', metadataId: 'mpu6050' }], [wire('a', 'mpu', 'SDA', 'pi', 'GPIO17')]), kind).toEqual([]);
+    }
+  });
+
+  it('a Pi wired to another board is the Interconnect, not a bus', () => {
+    expect(piBusPinWarnings({
+      boards: [board('pi', 'raspberry-pi-4'), board('uno', 'arduino-uno')],
+      components: [],
+      wires: [wire('a', 'uno', 'SDA', 'pi', 'GPIO17')],
+    })).toEqual([]);
+  });
+});

--- a/frontend/src/simulation/verify/circuitVerifier.ts
+++ b/frontend/src/simulation/verify/circuitVerifier.ts
@@ -48,7 +48,8 @@ export type WarningCode =
   | 'unsupported-sensor'
   | 'unpowered-net'
   | 'no-return-path'
-  | 'voltage-mismatch';
+  | 'voltage-mismatch'
+  | 'bus-off-pins';
 
 export interface CircuitWarning {
   severity: WarningSeverity;
@@ -139,6 +140,11 @@ export async function verifyCircuit(
           : `${gap.sensorType} on GPIO ${gap.pin} will not answer here: ${gap.why}`,
     });
   }
+
+  // ── Buses a Raspberry Pi has only on fixed pins (no solve) ────────────
+  // Same placement as the line gaps above, for the same reason: pure wiring,
+  // reported even when the netlist cannot be built.
+  warnings.push(...piBusPinWarnings(input));
 
   // Reported BEFORE the netlist is built, on purpose. This loop reads nothing
   // but input.components, and buildNetlist throws on a canvas the emitter
@@ -1153,6 +1159,119 @@ export function findSourceConflicts(
       componentId: parts.find((p) => p.componentId)?.componentId,
       message: `${names.join(', ')} and ${last} are both driving the same net, so the circuit has no solution: the simulator cannot solve any voltage on the canvas until one of them is removed. Typical cause: a regulator or battery output wired straight into a board supply pin.`,
     });
+  }
+  return out;
+}
+
+
+// ── Raspberry Pi header buses ─────────────────────────────────────────────
+
+/** Header boards of the Pi family; the Pico and the UNIHIKER are not. */
+const PI_HEADER_KIND = /^raspberry-pi-(zero|1|2|3|4|5)\b/;
+
+/** 40-pin header position -> BCM GPIO, for wires that name the pin by number. */
+const PI_HEADER_GPIO: Record<string, number> = {
+  '3': 2, '5': 3, '7': 4, '8': 14, '10': 15, '11': 17, '12': 18, '13': 27, '15': 22,
+  '16': 23, '18': 24, '19': 10, '21': 9, '22': 25, '23': 11, '24': 8, '26': 7, '27': 0,
+  '28': 1, '29': 5, '31': 6, '32': 12, '33': 13, '35': 19, '36': 16, '37': 26, '38': 20,
+  '40': 21,
+};
+const PI_ALIAS_GPIO: Record<string, number> = {
+  SDA: 2, SDA1: 2, SCL: 3, SCL1: 3, MOSI: 10, MISO: 9, SCLK: 11, SCK: 11, CE0: 8, CE1: 7,
+};
+
+/** The BCM number a Pi pin name refers to, or null for power / ground. */
+function piGpioOf(pinName: string): number | null {
+  const m = /^GPIO(\d+)$/i.exec(pinName);
+  if (m) return Number(m[1]);
+  return PI_HEADER_GPIO[pinName] ?? PI_ALIAS_GPIO[pinName.toUpperCase()] ?? null;
+}
+
+interface BusRole {
+  bus: 'I2C' | 'SPI';
+  signal: string;
+  gpio: number;
+  header: number;
+}
+
+const I2C_ROLES: Record<string, BusRole> = {
+  SDA: { bus: 'I2C', signal: 'SDA', gpio: 2, header: 3 },
+  SCL: { bus: 'I2C', signal: 'SCL', gpio: 3, header: 5 },
+};
+const SPI_CLOCK = new Set(['SCK', 'SCLK', 'CLK']);
+const SPI_MOSI = new Set(['MOSI', 'DIN', 'SDI']);
+const SPI_MISO = new Set(['MISO', 'DOUT', 'SDO', 'SO']);
+const SPI_ROLE: Record<'clock' | 'mosi' | 'miso', BusRole> = {
+  clock: { bus: 'SPI', signal: 'SCLK', gpio: 11, header: 23 },
+  mosi: { bus: 'SPI', signal: 'MOSI', gpio: 10, header: 19 },
+  miso: { bus: 'SPI', signal: 'MISO', gpio: 9, header: 21 },
+};
+
+/**
+ * A part on a Pi's I2C or SPI pins that is wired to the wrong GPIO looks
+ * connected and never answers: smbus2 opens /dev/i2c-1 and spidev
+ * /dev/spidev0.x, and those exist only on the header's hardware pins (I2C on
+ * GPIO2/GPIO3, SPI0 on GPIO11/GPIO10/GPIO9). This says which pin the part
+ * needs.
+ *
+ * Deliberately narrow, so it never cries wolf:
+ *   - only wires between a PART pin and a Pi header pin (a Pi wired to
+ *     another board goes through the Interconnect, not a bus);
+ *   - SPI only for a part that looks like SPI, a clock plus a data pin: an
+ *     HX711, a TM1637 or an encoder bit-banging CLK on any GPIO is legitimate;
+ *   - chip selects and the 1-Wire data line are never checked: any GPIO can
+ *     drive a CS by hand, and config.txt moves the w1 pin.
+ */
+export function piBusPinWarnings(input: Pick<BuildNetlistInput, 'boards' | 'components' | 'wires'>): CircuitWarning[] {
+  const piBoards = new Set(
+    input.boards.filter((b) => PI_HEADER_KIND.test(b.boardKind ?? '')).map((b) => b.id),
+  );
+  if (!piBoards.size) return [];
+  const partIds = new Set(input.components.map((c) => c.id));
+
+  // Every (part pin -> Pi GPIO) link, per part.
+  const links = new Map<string, Array<{ pin: string; gpio: number }>>();
+  for (const wire of input.wires) {
+    for (const [a, b] of [
+      [wire.start, wire.end],
+      [wire.end, wire.start],
+    ] as const) {
+      if (!piBoards.has(a.componentId) || !partIds.has(b.componentId)) continue;
+      const gpio = piGpioOf(a.pinName);
+      if (gpio === null) continue;
+      let list = links.get(b.componentId);
+      if (!list) links.set(b.componentId, (list = []));
+      list.push({ pin: b.pinName, gpio });
+    }
+  }
+
+  const out: CircuitWarning[] = [];
+  for (const [componentId, list] of links) {
+    const names = new Set(list.map((l) => l.pin.toUpperCase()));
+    const looksSpi =
+      [...names].some((n) => SPI_CLOCK.has(n)) &&
+      [...names].some((n) => SPI_MOSI.has(n) || SPI_MISO.has(n));
+    const seen = new Set<string>();
+    for (const { pin, gpio } of list) {
+      const n = pin.toUpperCase();
+      const role =
+        I2C_ROLES[n] ??
+        (looksSpi && SPI_CLOCK.has(n) ? SPI_ROLE.clock : undefined) ??
+        (looksSpi && SPI_MOSI.has(n) ? SPI_ROLE.mosi : undefined) ??
+        (looksSpi && SPI_MISO.has(n) ? SPI_ROLE.miso : undefined);
+      if (!role || gpio === role.gpio || seen.has(n)) continue;
+      seen.add(n);
+      const lib = role.bus === 'I2C' ? 'smbus2 on /dev/i2c-1' : 'spidev on /dev/spidev0.x';
+      out.push({
+        severity: 'warning',
+        code: 'bus-off-pins',
+        componentId,
+        message:
+          `${componentId} ${pin} is on GPIO${gpio}, but the Raspberry Pi's ${role.bus} ${role.signal} is ` +
+          `GPIO${role.gpio} (header pin ${role.header}). ${lib} only reaches that pin: move the wire there` +
+          (role.bus === 'SPI' ? ', unless your script bit-bangs the bus on its own pins.' : '.'),
+      });
+    }
   }
   return out;
 }


### PR DESCRIPTION
A part on a Raspberry Pi's I2C or SPI that is wired to the wrong GPIO looks connected and never answers. smbus2 opens `/dev/i2c-1` and spidev `/dev/spidev0.x`, and those exist only on the header's hardware pins: GPIO2/GPIO3 for I2C, GPIO11/GPIO10/GPIO9 for SPI0.

The pre-flight check now names the pin the part needs, as a warning: `bus-off-pins`, from the new `piBusPinWarnings()` in `circuitVerifier.ts`.

It is kept narrow so it never cries wolf:
- Pi header boards only: never the Pico, a UNIHIKER or another family.
- Part-to-Pi wires only. A Pi wired to another board goes through the Interconnect and is not checked.
- SPI only for a part that looks like SPI, meaning a clock plus a data pin. An HX711, a TM1637 or an encoder bit-banging `CLK` on any GPIO is legitimate and not flagged.
- Chip selects and the 1-Wire data line are never checked. Any GPIO can drive a CS by hand, and `config.txt` moves the w1 pin.

It runs before the netlist is built, next to the line gaps, so it reports even when the circuit cannot solve.

Tests: `circuit-verifier-pi-bus.test.ts` (6 cases), plus the existing verifier suites, which still pass: 41 tests in all.